### PR TITLE
Complete core architecture — context, model, solver, mesh, docs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -146,7 +146,7 @@ component_management:
 # Pull request comments
 # ──────────────────────────────────────────────────────────────────────────────
 comment:
-  layout: "reach,diff,flags,components,files"
+  layout: reach,diff,flags,components,files
   behavior: default
   require_changes: true
 

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,18 +1,37 @@
+# Codecov configuration for oxiflow
+# Generic PDE engine — transport, reaction, diffusion
+# Documentation: https://docs.codecov.com/docs/codecov-yaml
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Global settings
+# ──────────────────────────────────────────────────────────────────────────────
+codecov:
+  require_ci_to_pass: yes
+  notify:
+    wait_for_ci: yes
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Coverage targets
+# Non-negotiable constraints: 80–90% global (DEVELOPPEMENT.md)
+# ──────────────────────────────────────────────────────────────────────────────
 coverage:
+  precision: 2      # e.g. 85.42%
+  round: down       # conservative rounding
+  range: 80...90  # green >90%, yellow 80–90%, red <80%
+
   status:
     project:
       default:
-        # Minimum global coverage
-        target: 80%
-        # Regression tolerance between commits
-        threshold: 2%
+        target: 85%   # global project target
+        threshold: 2% # regression tolerance between commits
     patch:
       default:
-        # Minimum coverage of changed lines
-        target: 80%
+        target: 80%   # every new line of code must be covered at 80%
+        threshold: 5%
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Flags — coverage runs per features configuration
+# Flags — one upload per feature configuration
+# Activate feature flags in coverage.yml as features are declared in Cargo.toml
 # ──────────────────────────────────────────────────────────────────────────────
 flags:
   default:
@@ -20,40 +39,128 @@ flags:
       - src/
     carryforward: false
 
-  # J5 (v0.7) — activate when --features parallel is declared in coverage.yml
+  # J5 (v0.6) — activate when `parallel` feature is declared in Cargo.toml
   # parallel:
   #   paths:
   #     - src/
   #   carryforward: false
 
-  # J5 (v0.7) — activate when --features serde is declared in coverage.yml
+  # J5 (v0.6) — activate when `serde` feature is declared in Cargo.toml
   # serde:
   #   paths:
   #     - src/
   #   carryforward: false
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Components — coverage per FEM invariant
-# J7 (v2.0) — activate when FEM modules are implemented
+# Components — per-module coverage visibility
+#
+# Convention:
+#   - Active components reflect implemented jalons
+#   - Commented blocks are activated when the jalon lands
+#   - Target 90% for architectural contracts (traits, invariants)
+#   - Target 85% for implementations
 # ──────────────────────────────────────────────────────────────────────────────
-# component_management:
-#   individual_components:
-#     - component_id: fem_invariants
-#       name: "FEM Invariants (INV-1/2/3)"
-#       paths:
-#         - src/mesh/
-#         - src/operators/
-#         - src/coupling/
-#     - component_id: context
-#       name: "Context & Calculators"
-#       paths:
-#         - src/context/
-#     - component_id: solver
-#       name: "Solver & Integrators"
-#       paths:
-#         - src/solver/
+component_management:
 
+  default_rules:
+    statuses:
+      - type: project
+        target: 85%
+      - type: patch
+        target: 80%
+
+  individual_components:
+
+    # ── J1 (v0.1.0) — active ─────────────────────────────────────────────────
+
+    # Context layer: ContextVariable, OxiflowError, ContextValue, ComputeContext
+    # Architectural contract — highest coverage target
+    - component_id: context
+      name: "Context & Calculators"
+      paths:
+        - src/context/
+      statuses:
+        - type: project
+          target: 90%
+
+    # Model traits: RequiresContext
+    # Architectural contract — high target
+    - component_id: model
+      name: "Model Traits"
+      paths:
+        - src/model/
+      statuses:
+        - type: project
+          target: 90%
+
+    # Mesh abstraction: Mesh trait + UniformGrid1D (INV-1)
+    # Architectural contract — high target
+    - component_id: mesh
+      name: "Mesh Abstraction (INV-1)"
+      paths:
+        - src/mesh/
+      statuses:
+        - type: project
+          target: 90%
+
+    # Solver orchestration: Scenario, SolverConfiguration, Solver trait
+    - component_id: solver
+      name: "Solver Orchestration"
+      paths:
+        - src/solver/
+
+    # ── J2 (v0.2.0) — activate when boundary conditions are implemented ───────
+
+    # - component_id: boundary
+    #   name: "Boundary Conditions"
+    #   paths:
+    #     - src/boundary/
+
+    # ── J3 (v0.3.0) — activate when CouplingOperator is implemented ───────────
+
+    # - component_id: coupling
+    #   name: "Multi-Domain Coupling (INV-3)"
+    #   paths:
+    #     - src/coupling/
+
+    # ── J5 (v0.5.0) — activate when DiscreteOperator is implemented ───────────
+
+    # - component_id: operators
+    #   name: "Discrete Operators (INV-2)"
+    #   paths:
+    #     - src/operators/
+
+    # ── J7 (v2.0.0) — activate for FEM invariant audit ───────────────────────
+
+    # - component_id: fem_invariants
+    #   name: "FEM Invariants (INV-1/2/3)"
+    #   paths:
+    #     - src/mesh/
+    #     - src/operators/
+    #     - src/coupling/
+    #   statuses:
+    #     - type: project
+    #       target: 90%
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Pull request comments
+# ──────────────────────────────────────────────────────────────────────────────
 comment:
-  layout: "reach,diff,flags,tree"
+  layout: "reach,diff,flags,components,files"
   behavior: default
   require_changes: true
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Ignored paths — no coverage measurement for tests, examples, benchmarks
+# ──────────────────────────────────────────────────────────────────────────────
+ignore:
+  - tests/
+  - examples/
+  - benches/
+  - "**/*_test.rs"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# GitHub annotations on PRs
+# ──────────────────────────────────────────────────────────────────────────────
+github_checks:
+  annotations: true

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -2,9 +2,9 @@ name: Mirror to GitLab
 
 on:
   push:
-    branches: ['**']   # toutes les branches
-    tags: ['**']       # tous les tags (inclut les releases)
-  delete:              # synchronise aussi les suppressions de branches/tags
+    branches: ['**']
+    tags: ['**']
+  delete:
 
 jobs:
   mirror:
@@ -13,15 +13,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0   # historique complet obligatoire
+          fetch-depth: 0
+
+      - name: Fetch all branches as local heads
+        run: git fetch origin '+refs/heads/*:refs/heads/*'
 
       - name: Push mirror to GitLab
         run: |
           git remote add gitlab \
             https://oauth2:${GITLAB_TOKEN}@gitlab.com/open-works/oxiflow.git
 
-          # --mirror pousse aussi refs/remotes/* que GitLab refuse.
-          # On pousse uniquement les branches et les tags explicitement.
           git push gitlab \
             --prune \
             "+refs/heads/*:refs/heads/*" \

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -2,9 +2,9 @@ name: Mirror to GitLab
 
 on:
   push:
-    branches: ['**']
-    tags: ['**']
-  delete:
+    branches: ['**']   # all branches
+    tags: ['**']       # all tags (includes releases)
+  delete:              # also synchronise branch/tag deletions
 
 jobs:
   mirror:
@@ -13,19 +13,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-
-      - name: Fetch all branches as local heads
-        run: git fetch origin '+refs/heads/*:refs/heads/*'
+          fetch-depth: 0   # full history required
 
       - name: Push mirror to GitLab
         run: |
           git remote add gitlab \
             https://oauth2:${GITLAB_TOKEN}@gitlab.com/open-works/oxiflow.git
 
+          # Push branches without force — GitLab forbids force-push on the
+          # default branch and rejects --prune when it would delete it.
           git push gitlab \
-            --prune \
-            "+refs/heads/*:refs/heads/*" \
-            "+refs/tags/*:refs/tags/*"
+            "refs/heads/*:refs/heads/*"
+
+          # Push tags with force so re-created tags are synced correctly.
+          git push gitlab --force \
+            "refs/tags/*:refs/tags/*"
         env:
           GITLAB_TOKEN: ${{ secrets.GITLAB_MIRROR_TOKEN }}

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,6 +1,6 @@
 # oxiflow
 
-[![CI](https://github.com/[USER]/oxiflow/actions/workflows/ci.yml/badge.svg)](https://github.com/biface/oxiflow/actions/workflows/ci.yml)
+[![CI](https://github.com/biface/oxiflow/actions/workflows/ci.yml/badge.svg)](https://github.com/biface/oxiflow/actions/workflows/ci.yml)
 [![Couverture](https://codecov.io/gh/[USER]/oxiflow/branch/main/graph/badge.svg)](https://codecov.io/gh/biface/oxiflow)
 [![Crates.io](https://img.shields.io/crates/v/oxiflow.svg)](https://crates.io/crates/oxiflow)
 [![Docs.rs](https://docs.rs/oxiflow/badge.svg)](https://docs.rs/oxiflow)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # oxiflow
 
-[![CI](https://github.com/[USER]/oxiflow/actions/workflows/ci.yml/badge.svg)](https://github.com/biface/oxiflow/actions/workflows/ci.yml)
+[![CI](https://github.com/biface/oxiflow/actions/workflows/ci.yml/badge.svg)](https://github.com/biface/oxiflow/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/[USER]/oxiflow/branch/main/graph/badge.svg)](https://codecov.io/gh/biface/oxiflow)
 [![Crates.io](https://img.shields.io/crates/v/oxiflow.svg)](https://crates.io/crates/oxiflow)
 [![Docs.rs](https://docs.rs/oxiflow/badge.svg)](https://docs.rs/oxiflow)

--- a/src/context/calculator.rs
+++ b/src/context/calculator.rs
@@ -1,0 +1,280 @@
+//! # Module `context::calculator`
+//!
+//! Trait `ContextCalculator` — computes a single context variable (issue #32, DD-020).
+//!
+//! A calculator is the symmetric counterpart of `RequiresContext`: where a model
+//! *declares* what it needs, a calculator *provides* what it computes.
+//! The solver chains calculators in topological order (DD-009, J2) and feeds
+//! results into `ComputeContext` before each time step.
+//!
+//! ## Placement
+//!
+//! Calculators live in `SolverConfiguration` — they are part of HOW the problem is
+//! solved, not WHAT the problem is. `DiscreteOperator` (INV-2, J4b) is an
+//! implementation detail inside spatial calculators, never exposed at configuration level.
+
+use crate::context::compute::ComputeContext;
+use crate::context::error::OxiflowError;
+use crate::context::value::ContextValue;
+use crate::context::variable::ContextVariable;
+use crate::model::traits::RequiresContext;
+
+/// Computes one context variable and injects it into `ComputeContext`.
+///
+/// The solver calls calculators in topological order — a calculator that
+/// `depends_on()` variable X is guaranteed to run after the calculator that
+/// `provides()` X. Within a dependency tier, execution order is determined
+/// by `priority()` (inherited from `RequiresContext`).
+///
+/// # Contract
+///
+/// - `provides()` must return a stable `ContextVariable` — the same value
+///   across calls for a given calculator instance.
+/// - `compute()` receives the current field state and a **partially populated**
+///   `ComputeContext` (variables with lower priority already resolved).
+/// - `compute()` must not modify `ctx` directly — the solver inserts the result.
+///
+/// # DiscreteOperator (INV-2, J4b)
+///
+/// Spatial calculators (gradient, Laplacian, flux) may internally hold a
+/// `DiscreteOperator` implementation. This is an implementation detail of the
+/// calculator — `DiscreteOperator` is never exposed in `SolverConfiguration`.
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::context::calculator::ContextCalculator;
+/// use oxiflow::context::variable::ContextVariable;
+/// use oxiflow::context::value::ContextValue;
+/// use oxiflow::context::compute::ComputeContext;
+/// use oxiflow::context::error::OxiflowError;
+/// use oxiflow::model::traits::RequiresContext;
+///
+/// struct TimeCalculator;
+///
+/// impl RequiresContext for TimeCalculator {
+///     fn required_variables(&self) -> Vec<ContextVariable> { vec![] }
+///     fn priority(&self) -> u32 { 0 }
+/// }
+///
+/// impl ContextCalculator for TimeCalculator {
+///     fn provides(&self) -> ContextVariable { ContextVariable::Time }
+///     fn compute(&self, _state: &ContextValue, ctx: &ComputeContext)
+///         -> Result<ContextValue, OxiflowError>
+///     {
+///         Ok(ContextValue::Scalar(ctx.time()))
+///     }
+///     fn name(&self) -> &str { "time" }
+/// }
+/// ```
+pub trait ContextCalculator: RequiresContext + Send + Sync {
+    /// The context variable this calculator produces.
+    ///
+    /// Must be stable across calls. The solver uses this to match calculators
+    /// against `RequiresContext::required_variables()` declarations.
+    fn provides(&self) -> ContextVariable;
+
+    /// Computes the value for `provides()` given the current field state and
+    /// the partially populated context.
+    ///
+    /// Variables declared in `depends_on()` are guaranteed to be present in
+    /// `ctx` when this method is called.
+    fn compute(
+        &self,
+        state: &ContextValue,
+        ctx: &ComputeContext,
+    ) -> Result<ContextValue, OxiflowError>;
+
+    /// Human-readable name for logging and error messages.
+    fn name(&self) -> &str {
+        "unnamed calculator"
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Fixtures ──────────────────────────────────────────────────────────────
+
+    /// Returns the current time as a Scalar — priority 0.
+    struct TimeCalculator;
+
+    impl RequiresContext for TimeCalculator {
+        fn required_variables(&self) -> Vec<ContextVariable> {
+            vec![]
+        }
+        fn priority(&self) -> u32 {
+            0
+        }
+    }
+
+    impl ContextCalculator for TimeCalculator {
+        fn provides(&self) -> ContextVariable {
+            ContextVariable::Time
+        }
+        fn compute(
+            &self,
+            _state: &ContextValue,
+            ctx: &ComputeContext,
+        ) -> Result<ContextValue, OxiflowError> {
+            Ok(ContextValue::Scalar(ctx.time()))
+        }
+        fn name(&self) -> &str {
+            "time"
+        }
+    }
+
+    /// Returns a fixed external scalar — depends on nothing.
+    struct ConstantCalculator {
+        var: ContextVariable,
+        value: f64,
+    }
+
+    impl RequiresContext for ConstantCalculator {
+        fn required_variables(&self) -> Vec<ContextVariable> {
+            vec![]
+        }
+    }
+
+    impl ContextCalculator for ConstantCalculator {
+        fn provides(&self) -> ContextVariable {
+            self.var.clone()
+        }
+        fn compute(
+            &self,
+            _state: &ContextValue,
+            _ctx: &ComputeContext,
+        ) -> Result<ContextValue, OxiflowError> {
+            Ok(ContextValue::Scalar(self.value))
+        }
+    }
+
+    /// Depends on Time — must run after TimeCalculator.
+    struct TimeDependentCalculator;
+
+    impl RequiresContext for TimeDependentCalculator {
+        fn required_variables(&self) -> Vec<ContextVariable> {
+            vec![ContextVariable::Time]
+        }
+        fn depends_on(&self) -> Vec<ContextVariable> {
+            vec![ContextVariable::Time]
+        }
+        fn priority(&self) -> u32 {
+            50
+        }
+    }
+
+    impl ContextCalculator for TimeDependentCalculator {
+        fn provides(&self) -> ContextVariable {
+            ContextVariable::External {
+                name: "double_time",
+            }
+        }
+        fn compute(
+            &self,
+            _state: &ContextValue,
+            ctx: &ComputeContext,
+        ) -> Result<ContextValue, OxiflowError> {
+            let t = ctx.time();
+            Ok(ContextValue::Scalar(t * 2.0))
+        }
+    }
+
+    // ── provides() ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn provides_returns_declared_variable() {
+        assert_eq!(TimeCalculator.provides(), ContextVariable::Time);
+    }
+
+    #[test]
+    fn provides_is_stable_across_calls() {
+        let calc = ConstantCalculator {
+            var: ContextVariable::TimeStep,
+            value: 0.01,
+        };
+        assert_eq!(calc.provides(), calc.provides());
+    }
+
+    // ── compute() ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn time_calculator_returns_current_time() {
+        let ctx = ComputeContext::new(3.14, 0.01);
+        let result = TimeCalculator
+            .compute(&ContextValue::Scalar(0.0), &ctx)
+            .unwrap();
+        assert_eq!(result.as_scalar().unwrap(), 3.14);
+    }
+
+    #[test]
+    fn constant_calculator_returns_fixed_value() {
+        let calc = ConstantCalculator {
+            var: ContextVariable::External { name: "D_ax" },
+            value: 1.5e-4,
+        };
+        let ctx = ComputeContext::new(0.0, 0.01);
+        let result = calc.compute(&ContextValue::Scalar(0.0), &ctx).unwrap();
+        assert!((result.as_scalar().unwrap() - 1.5e-4).abs() < 1e-12);
+    }
+
+    #[test]
+    fn time_dependent_calculator_reads_from_ctx() {
+        let mut ctx = ComputeContext::new(5.0, 0.01);
+        ctx.insert(ContextVariable::Time, ContextValue::Scalar(5.0));
+        let result = TimeDependentCalculator
+            .compute(&ContextValue::Scalar(0.0), &ctx)
+            .unwrap();
+        assert_eq!(result.as_scalar().unwrap(), 10.0);
+    }
+
+    // ── name() ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn name_returns_provided_string() {
+        assert_eq!(TimeCalculator.name(), "time");
+    }
+
+    #[test]
+    fn default_name_is_unnamed() {
+        let calc = ConstantCalculator {
+            var: ContextVariable::TimeStep,
+            value: 0.01,
+        };
+        assert_eq!(calc.name(), "unnamed calculator");
+    }
+
+    // ── RequiresContext integration ───────────────────────────────────────────
+
+    #[test]
+    fn time_calculator_has_no_requirements() {
+        assert!(TimeCalculator.required_variables().is_empty());
+        assert_eq!(TimeCalculator.priority(), 0);
+    }
+
+    #[test]
+    fn time_dependent_requires_time() {
+        let calc = TimeDependentCalculator;
+        assert!(calc.required_variables().contains(&ContextVariable::Time));
+        assert!(calc.depends_on().contains(&ContextVariable::Time));
+        assert_eq!(calc.priority(), 50);
+    }
+
+    // ── Object safety ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn trait_is_object_safe() {
+        let calcs: Vec<Box<dyn ContextCalculator>> = vec![
+            Box::new(TimeCalculator),
+            Box::new(ConstantCalculator {
+                var: ContextVariable::TimeStep,
+                value: 0.01,
+            }),
+        ];
+        assert_eq!(calcs[0].provides(), ContextVariable::Time);
+        assert_eq!(calcs[1].provides(), ContextVariable::TimeStep);
+    }
+}

--- a/src/context/compute.rs
+++ b/src/context/compute.rs
@@ -1,13 +1,405 @@
 //! # Module `context::compute`
 //!
-//! Type-safe computation context and variable requirements declaration.
+//! Type-safe computation context (DD-006, issue #30).
 //!
-//! ## `RequiresContext` (DD-005)
+//! ## `ComputeContext`
 //!
-//! Trait separate from `PhysicalModel`: a model declares its required, optional
-//! variables and dependencies. The engine guarantees their availability before solving.
+//! Provides typed access to all context variables resolved by the solver before
+//! each time step. Physical models receive a `&ComputeContext` in
+//! `compute_physics_v2()` and access variables through typed accessors —
+//! no string keys, no `HashMap<String, f64>`, no runtime type guessing.
 //!
-//! ## `ComputeContext` (DD-006)
+//! ## Revised signatures (DD-006)
 //!
-//! Type-safe API from v0.2 — context variable access is compile-time guaranteed or
-//! fails explicitly via `OxiflowError` at startup, never mid-computation.
+//! - `gradient(dim)` returns `&DVector<f64>` — the full nodal field, consistent
+//!   with `ContextValue::ScalarField`. The model indexes the node it needs.
+//! - `external(var)` takes a typed `ContextVariable` — no `&str` shortcut that
+//!   would bypass the type system.
+
+use std::collections::HashMap;
+
+use nalgebra::{DMatrix, DVector};
+
+use crate::context::error::OxiflowError;
+use crate::context::value::ContextValue;
+use crate::context::variable::ContextVariable;
+
+/// Type-safe computation context provided to physical models during time integration.
+///
+/// Built by the solver at each time step from registered calculators. Models access
+/// variables through typed accessors — every access is either correct at compile time
+/// or fails explicitly via `OxiflowError` at solve startup.
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::context::compute::ComputeContext;
+/// use oxiflow::context::variable::ContextVariable;
+/// use oxiflow::context::value::ContextValue;
+///
+/// let mut ctx = ComputeContext::new(1.5, 0.01);
+/// ctx.insert(ContextVariable::SpatialGradient { dimension: 0 },
+///            ContextValue::ScalarField(nalgebra::DVector::from_vec(vec![0.1, 0.2, 0.3])));
+///
+/// assert_eq!(ctx.time(), 1.5);
+/// assert_eq!(ctx.time_step(), 0.01);
+/// assert_eq!(ctx.gradient(0).unwrap().len(), 3);
+/// ```
+pub struct ComputeContext {
+    /// Current simulation time `t`.
+    time: f64,
+    /// Current time step `dt`.
+    time_step: f64,
+    /// Resolved context variables, keyed by typed `ContextVariable`.
+    variables: HashMap<ContextVariable, ContextValue>,
+}
+
+impl ComputeContext {
+    /// Creates a new context for a given time and time step.
+    ///
+    /// Variables are inserted after construction via [`insert`](Self::insert).
+    pub fn new(time: f64, time_step: f64) -> Self {
+        Self {
+            time,
+            time_step,
+            variables: HashMap::new(),
+        }
+    }
+
+    /// Inserts a resolved variable into the context.
+    ///
+    /// Called by the solver after each calculator runs. Overwrites any previous
+    /// value for the same key.
+    pub fn insert(&mut self, var: ContextVariable, value: ContextValue) {
+        self.variables.insert(var, value);
+    }
+
+    // ── System accessors (infallible) ─────────────────────────────────────────
+
+    /// Returns the current simulation time `t`.
+    pub fn time(&self) -> f64 {
+        self.time
+    }
+
+    /// Returns the current time step `dt`.
+    pub fn time_step(&self) -> f64 {
+        self.time_step
+    }
+
+    // ── Typed accessors ───────────────────────────────────────────────────────
+
+    /// Returns the scalar value of a `Scalar` context variable.
+    ///
+    /// # Errors
+    ///
+    /// - `OxiflowError::MissingCalculator` if the variable is not in the context.
+    /// - `OxiflowError::TypeMismatch` if the variable is present but not a `Scalar`.
+    pub fn scalar(&self, var: ContextVariable) -> Result<f64, OxiflowError> {
+        self.get_value(&var)?.as_scalar()
+    }
+
+    /// Borrows the `DVector` of a `Vector` context variable.
+    ///
+    /// # Errors
+    ///
+    /// - `OxiflowError::MissingCalculator` if the variable is not in the context.
+    /// - `OxiflowError::TypeMismatch` if the variable is present but not a `Vector`.
+    pub fn vector(&self, var: ContextVariable) -> Result<&DVector<f64>, OxiflowError> {
+        self.get_value(&var)?.as_vector()
+    }
+
+    /// Borrows the `DMatrix` of a `Matrix` context variable.
+    ///
+    /// # Errors
+    ///
+    /// - `OxiflowError::MissingCalculator` if the variable is not in the context.
+    /// - `OxiflowError::TypeMismatch` if the variable is present but not a `Matrix`.
+    pub fn matrix(&self, var: ContextVariable) -> Result<&DMatrix<f64>, OxiflowError> {
+        self.get_value(&var)?.as_matrix()
+    }
+
+    /// Borrows the full nodal gradient field for spatial dimension `dim`.
+    ///
+    /// Returns the `DVector` of `ContextValue::ScalarField` stored under
+    /// `ContextVariable::SpatialGradient { dimension: dim }`.
+    /// The model indexes the node it needs from the returned slice.
+    ///
+    /// # Errors
+    ///
+    /// - `OxiflowError::MissingCalculator` if no gradient calculator is registered
+    ///   for `dim`.
+    /// - `OxiflowError::TypeMismatch` if the value is not a `ScalarField`.
+    pub fn gradient(&self, dim: usize) -> Result<&DVector<f64>, OxiflowError> {
+        let var = ContextVariable::SpatialGradient { dimension: dim };
+        self.get_value(&var)?.as_scalar_field()
+    }
+
+    /// Borrows any context variable by typed key, returning the raw `ContextValue`.
+    ///
+    /// Use this for `External` variables or when the caller needs to handle multiple
+    /// variant types. For common cases prefer the typed accessors.
+    ///
+    /// # Errors
+    ///
+    /// - `OxiflowError::MissingCalculator` if the variable is not in the context.
+    pub fn external(&self, var: ContextVariable) -> Result<&ContextValue, OxiflowError> {
+        self.get_value(&var)
+    }
+
+    /// Returns a reference to a context variable if present, or `None` if absent.
+    ///
+    /// Non-failing alternative to the typed accessors — use for optional variables.
+    pub fn try_get(&self, var: ContextVariable) -> Option<&ContextValue> {
+        self.variables.get(&var)
+    }
+
+    // ── Internal helper ───────────────────────────────────────────────────────
+
+    fn get_value(&self, var: &ContextVariable) -> Result<&ContextValue, OxiflowError> {
+        self.variables
+            .get(var)
+            .ok_or_else(|| OxiflowError::MissingCalculator(var.clone()))
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::{DMatrix, DVector};
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn ctx_with_all_variants() -> ComputeContext {
+        let mut ctx = ComputeContext::new(2.0, 0.01);
+        ctx.insert(
+            ContextVariable::External { name: "coeff" },
+            ContextValue::Scalar(42.0),
+        );
+        ctx.insert(
+            ContextVariable::External { name: "flag" },
+            ContextValue::Boolean(true),
+        );
+        ctx.insert(
+            ContextVariable::External { name: "vel" },
+            ContextValue::Vector(DVector::from_vec(vec![1.0, 2.0, 3.0])),
+        );
+        ctx.insert(
+            ContextVariable::External { name: "tensor" },
+            ContextValue::Matrix(DMatrix::from_element(2, 2, 5.0)),
+        );
+        ctx.insert(
+            ContextVariable::SpatialGradient { dimension: 0 },
+            ContextValue::ScalarField(DVector::from_vec(vec![0.1, 0.2, 0.3])),
+        );
+        ctx.insert(
+            ContextVariable::External { name: "vfield" },
+            ContextValue::VectorField(DMatrix::from_element(3, 2, 1.5)),
+        );
+        ctx
+    }
+
+    // ── System accessors ──────────────────────────────────────────────────────
+
+    #[test]
+    fn time_returns_correct_value() {
+        let ctx = ComputeContext::new(3.14, 0.001);
+        assert_eq!(ctx.time(), 3.14);
+    }
+
+    #[test]
+    fn time_step_returns_correct_value() {
+        let ctx = ComputeContext::new(0.0, 0.05);
+        assert_eq!(ctx.time_step(), 0.05);
+    }
+
+    // ── scalar ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn scalar_returns_value_for_scalar_variable() {
+        let ctx = ctx_with_all_variants();
+        let v = ctx
+            .scalar(ContextVariable::External { name: "coeff" })
+            .unwrap();
+        assert_eq!(v, 42.0);
+    }
+
+    #[test]
+    fn scalar_returns_missing_calculator_when_absent() {
+        let ctx = ComputeContext::new(0.0, 0.01);
+        let err = ctx.scalar(ContextVariable::Time).unwrap_err();
+        assert!(matches!(err, OxiflowError::MissingCalculator(_)));
+    }
+
+    #[test]
+    fn scalar_returns_type_mismatch_for_non_scalar() {
+        let ctx = ctx_with_all_variants();
+        let err = ctx
+            .scalar(ContextVariable::External { name: "vel" })
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            OxiflowError::TypeMismatch {
+                expected: "Scalar",
+                ..
+            }
+        ));
+    }
+
+    // ── vector ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn vector_returns_reference_for_vector_variable() {
+        let ctx = ctx_with_all_variants();
+        let v = ctx
+            .vector(ContextVariable::External { name: "vel" })
+            .unwrap();
+        assert_eq!(v.len(), 3);
+        assert_eq!(v[1], 2.0);
+    }
+
+    #[test]
+    fn vector_returns_missing_calculator_when_absent() {
+        let ctx = ComputeContext::new(0.0, 0.01);
+        let err = ctx
+            .vector(ContextVariable::External { name: "missing" })
+            .unwrap_err();
+        assert!(matches!(err, OxiflowError::MissingCalculator(_)));
+    }
+
+    #[test]
+    fn vector_returns_type_mismatch_for_non_vector() {
+        let ctx = ctx_with_all_variants();
+        let err = ctx
+            .vector(ContextVariable::External { name: "coeff" })
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            OxiflowError::TypeMismatch {
+                expected: "Vector",
+                ..
+            }
+        ));
+    }
+
+    // ── matrix ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn matrix_returns_reference_for_matrix_variable() {
+        let ctx = ctx_with_all_variants();
+        let m = ctx
+            .matrix(ContextVariable::External { name: "tensor" })
+            .unwrap();
+        assert_eq!(m.shape(), (2, 2));
+        assert_eq!(m[(0, 0)], 5.0);
+    }
+
+    #[test]
+    fn matrix_returns_type_mismatch_for_non_matrix() {
+        let ctx = ctx_with_all_variants();
+        let err = ctx
+            .matrix(ContextVariable::External { name: "coeff" })
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            OxiflowError::TypeMismatch {
+                expected: "Matrix",
+                ..
+            }
+        ));
+    }
+
+    // ── gradient ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn gradient_returns_full_nodal_field() {
+        let ctx = ctx_with_all_variants();
+        let g = ctx.gradient(0).unwrap();
+        assert_eq!(g.len(), 3);
+        assert!((g[0] - 0.1).abs() < 1e-12);
+        assert!((g[2] - 0.3).abs() < 1e-12);
+    }
+
+    #[test]
+    fn gradient_missing_dimension_returns_missing_calculator() {
+        let ctx = ctx_with_all_variants();
+        let err = ctx.gradient(1).unwrap_err();
+        assert!(matches!(err, OxiflowError::MissingCalculator(_)));
+    }
+
+    #[test]
+    fn gradient_with_wrong_type_returns_type_mismatch() {
+        let mut ctx = ComputeContext::new(0.0, 0.01);
+        // Stored as Scalar instead of ScalarField — misconfigured calculator
+        ctx.insert(
+            ContextVariable::SpatialGradient { dimension: 0 },
+            ContextValue::Scalar(1.0),
+        );
+        let err = ctx.gradient(0).unwrap_err();
+        assert!(matches!(
+            err,
+            OxiflowError::TypeMismatch {
+                expected: "ScalarField",
+                ..
+            }
+        ));
+    }
+
+    // ── external ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn external_returns_raw_context_value() {
+        let ctx = ctx_with_all_variants();
+        let val = ctx
+            .external(ContextVariable::External { name: "flag" })
+            .unwrap();
+        assert!(matches!(val, ContextValue::Boolean(true)));
+    }
+
+    #[test]
+    fn external_returns_missing_calculator_when_absent() {
+        let ctx = ComputeContext::new(0.0, 0.01);
+        let err = ctx
+            .external(ContextVariable::External { name: "absent" })
+            .unwrap_err();
+        assert!(matches!(err, OxiflowError::MissingCalculator(_)));
+    }
+
+    #[test]
+    fn external_works_for_any_variant_type() {
+        let ctx = ctx_with_all_variants();
+        // VectorField via external()
+        let val = ctx
+            .external(ContextVariable::External { name: "vfield" })
+            .unwrap();
+        assert!(val.is_vector_field());
+    }
+
+    // ── try_get ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn try_get_returns_some_when_present() {
+        let ctx = ctx_with_all_variants();
+        let val = ctx.try_get(ContextVariable::SpatialGradient { dimension: 0 });
+        assert!(val.is_some());
+        assert!(val.unwrap().is_scalar_field());
+    }
+
+    #[test]
+    fn try_get_returns_none_when_absent() {
+        let ctx = ComputeContext::new(0.0, 0.01);
+        assert!(ctx.try_get(ContextVariable::Time).is_none());
+    }
+
+    // ── insert overwrites ─────────────────────────────────────────────────────
+
+    #[test]
+    fn insert_overwrites_previous_value() {
+        let mut ctx = ComputeContext::new(0.0, 0.01);
+        let var = ContextVariable::External { name: "x" };
+        ctx.insert(var.clone(), ContextValue::Scalar(1.0));
+        ctx.insert(var.clone(), ContextValue::Scalar(2.0));
+        assert_eq!(ctx.scalar(var).unwrap(), 2.0);
+    }
+}

--- a/src/context/compute.rs
+++ b/src/context/compute.rs
@@ -38,7 +38,7 @@ use crate::context::variable::ContextVariable;
 /// use oxiflow::context::value::ContextValue;
 ///
 /// let mut ctx = ComputeContext::new(1.5, 0.01);
-/// ctx.insert(ContextVariable::SpatialGradient { dimension: 0 },
+/// ctx.insert(ContextVariable::SpatialGradient { dimension: 0, component: None },
 ///            ContextValue::ScalarField(nalgebra::DVector::from_vec(vec![0.1, 0.2, 0.3])));
 ///
 /// assert_eq!(ctx.time(), 1.5);
@@ -121,7 +121,7 @@ impl ComputeContext {
     /// Borrows the full nodal gradient field for spatial dimension `dim`.
     ///
     /// Returns the `DVector` of `ContextValue::ScalarField` stored under
-    /// `ContextVariable::SpatialGradient { dimension: dim }`.
+    /// `ContextVariable::SpatialGradient { dimension: dim, component: None }`.
     /// The model indexes the node it needs from the returned slice.
     ///
     /// # Errors
@@ -130,7 +130,10 @@ impl ComputeContext {
     ///   for `dim`.
     /// - `OxiflowError::TypeMismatch` if the value is not a `ScalarField`.
     pub fn gradient(&self, dim: usize) -> Result<&DVector<f64>, OxiflowError> {
-        let var = ContextVariable::SpatialGradient { dimension: dim };
+        let var = ContextVariable::SpatialGradient {
+            dimension: dim,
+            component: None,
+        };
         self.get_value(&var)?.as_scalar_field()
     }
 
@@ -190,7 +193,10 @@ mod tests {
             ContextValue::Matrix(DMatrix::from_element(2, 2, 5.0)),
         );
         ctx.insert(
-            ContextVariable::SpatialGradient { dimension: 0 },
+            ContextVariable::SpatialGradient {
+                dimension: 0,
+                component: None,
+            },
             ContextValue::ScalarField(DVector::from_vec(vec![0.1, 0.2, 0.3])),
         );
         ctx.insert(
@@ -333,7 +339,10 @@ mod tests {
         let mut ctx = ComputeContext::new(0.0, 0.01);
         // Stored as Scalar instead of ScalarField — misconfigured calculator
         ctx.insert(
-            ContextVariable::SpatialGradient { dimension: 0 },
+            ContextVariable::SpatialGradient {
+                dimension: 0,
+                component: None,
+            },
             ContextValue::Scalar(1.0),
         );
         let err = ctx.gradient(0).unwrap_err();
@@ -381,7 +390,10 @@ mod tests {
     #[test]
     fn try_get_returns_some_when_present() {
         let ctx = ctx_with_all_variants();
-        let val = ctx.try_get(ContextVariable::SpatialGradient { dimension: 0 });
+        let val = ctx.try_get(ContextVariable::SpatialGradient {
+            dimension: 0,
+            component: None,
+        });
         assert!(val.is_some());
         assert!(val.unwrap().is_scalar_field());
     }

--- a/src/context/error.rs
+++ b/src/context/error.rs
@@ -100,7 +100,10 @@ mod tests {
         let source: Box<dyn std::error::Error + Send + Sync> =
             Box::new(std::io::Error::other("calculator error"));
         let err = OxiflowError::ComputationFailed {
-            variable: ContextVariable::SpatialGradient { dimension: 0 },
+            variable: ContextVariable::SpatialGradient {
+                dimension: 0,
+                component: None,
+            },
             source,
         };
         assert!(matches!(err, OxiflowError::ComputationFailed { .. }));
@@ -111,7 +114,10 @@ mod tests {
         let source: Box<dyn std::error::Error + Send + Sync> =
             Box::new(std::io::Error::other("overflow"));
         let err = OxiflowError::ComputationFailed {
-            variable: ContextVariable::SpatialGradient { dimension: 1 },
+            variable: ContextVariable::SpatialGradient {
+                dimension: 1,
+                component: None,
+            },
             source,
         };
         let msg = err.to_string();

--- a/src/context/error.rs
+++ b/src/context/error.rs
@@ -58,7 +58,7 @@ pub enum OxiflowError {
     #[error("type mismatch: expected {expected}, actual {actual}")]
     TypeMismatch {
         expected: &'static str,
-        actual:   &'static str,
+        actual: &'static str,
     },
 
     /// The mesh or domain configuration is invalid.
@@ -71,10 +71,7 @@ pub enum OxiflowError {
 
     /// The solver produced a non-finite state and cannot continue.
     #[error("solver divergence at t={time:.4e}: {reason}")]
-    SolverDivergence {
-        time:   f64,
-        reason: String,
-    },
+    SolverDivergence { time: f64, reason: String },
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -86,7 +83,10 @@ mod tests {
     #[test]
     fn missing_calculator_matches_variable() {
         let err = OxiflowError::MissingCalculator(ContextVariable::Time);
-        assert!(matches!(err, OxiflowError::MissingCalculator(ContextVariable::Time)));
+        assert!(matches!(
+            err,
+            OxiflowError::MissingCalculator(ContextVariable::Time)
+        ));
     }
 
     #[test]
@@ -133,13 +133,25 @@ mod tests {
 
     #[test]
     fn type_mismatch_fields_are_accessible() {
-        let err = OxiflowError::TypeMismatch { expected: "Scalar", actual: "Vector" };
-        assert!(matches!(err, OxiflowError::TypeMismatch { expected: "Scalar", actual: "Vector" }));
+        let err = OxiflowError::TypeMismatch {
+            expected: "Scalar",
+            actual: "Vector",
+        };
+        assert!(matches!(
+            err,
+            OxiflowError::TypeMismatch {
+                expected: "Scalar",
+                actual: "Vector"
+            }
+        ));
     }
 
     #[test]
     fn type_mismatch_display_contains_both_types() {
-        let err = OxiflowError::TypeMismatch { expected: "Matrix", actual: "ScalarField" };
+        let err = OxiflowError::TypeMismatch {
+            expected: "Matrix",
+            actual: "ScalarField",
+        };
         let msg = err.to_string();
         assert!(msg.contains("Matrix"));
         assert!(msg.contains("ScalarField"));
@@ -170,7 +182,10 @@ mod tests {
 
     #[test]
     fn solver_divergence_time_formatted_scientific() {
-        let err = OxiflowError::SolverDivergence { time: 0.001, reason: "diverged".into() };
+        let err = OxiflowError::SolverDivergence {
+            time: 0.001,
+            reason: "diverged".into(),
+        };
         assert!(err.to_string().contains("e-"));
     }
 
@@ -179,10 +194,16 @@ mod tests {
         let variants: Vec<Box<dyn std::fmt::Debug>> = vec![
             Box::new(OxiflowError::MissingCalculator(ContextVariable::Time)),
             Box::new(OxiflowError::CircularDependency(ContextVariable::TimeStep)),
-            Box::new(OxiflowError::TypeMismatch { expected: "Scalar", actual: "Boolean" }),
+            Box::new(OxiflowError::TypeMismatch {
+                expected: "Scalar",
+                actual: "Boolean",
+            }),
             Box::new(OxiflowError::InvalidDomain("test".into())),
             Box::new(OxiflowError::ExternalData("test".into())),
-            Box::new(OxiflowError::SolverDivergence { time: 0.0, reason: "test".into() }),
+            Box::new(OxiflowError::SolverDivergence {
+                time: 0.0,
+                reason: "test".into(),
+            }),
         ];
         for v in &variants {
             assert!(!format!("{:?}", v).is_empty());

--- a/src/context/error.rs
+++ b/src/context/error.rs
@@ -1,7 +1,191 @@
 //! # Module `context::error`
 //!
-//! Main error type of the oxiflow engine.
+//! Main error type of the oxiflow engine (DD-004, issue #28).
 //!
-//! `OxiflowError` is a typed enum built with `thiserror` covering all engine failure
-//! cases: missing variable, type mismatch, circular dependency, solver divergence
-//! (DD-004, J1).
+//! `OxiflowError` is a typed enum built with `thiserror` covering all engine
+//! failure cases. Every public function returns `Result<_, OxiflowError>` —
+//! never `Result<_, String>`.
+//!
+//! ## Design rationale
+//!
+//! chrom-rs used `Result<_, String>` throughout. String errors are not
+//! matchable programmatically: downstream code cannot distinguish a missing
+//! calculator from a solver divergence without parsing strings. `OxiflowError`
+//! makes every failure case a first-class type.
+
+use crate::context::variable::ContextVariable;
+
+/// Typed error enum for all oxiflow engine failures.
+///
+/// Each variant corresponds to a distinct, matchable failure mode.
+/// The `source` field in `ComputationFailed` preserves the original error
+/// for error-chain display while keeping the variant matchable.
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::context::error::OxiflowError;
+/// use oxiflow::context::variable::ContextVariable;
+///
+/// let err = OxiflowError::MissingCalculator(ContextVariable::Time);
+/// assert!(matches!(err, OxiflowError::MissingCalculator(ContextVariable::Time)));
+///
+/// let err = OxiflowError::TypeMismatch {
+///     expected: "Scalar",
+///     actual:   "Vector",
+/// };
+/// assert!(matches!(err, OxiflowError::TypeMismatch { .. }));
+/// ```
+#[derive(Debug, thiserror::Error)]
+pub enum OxiflowError {
+    /// No calculator registered for the required variable.
+    #[error("missing calculator for variable: {0}")]
+    MissingCalculator(ContextVariable),
+
+    /// A calculator returned an error while computing a variable.
+    #[error("computation failed for {variable}: {source}")]
+    ComputationFailed {
+        variable: ContextVariable,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// A circular dependency was detected among calculators.
+    #[error("circular dependency detected involving: {0}")]
+    CircularDependency(ContextVariable),
+
+    /// A context accessor was called with the wrong `ContextValue` variant.
+    #[error("type mismatch: expected {expected}, actual {actual}")]
+    TypeMismatch {
+        expected: &'static str,
+        actual:   &'static str,
+    },
+
+    /// The mesh or domain configuration is invalid.
+    #[error("invalid domain: {0}")]
+    InvalidDomain(String),
+
+    /// An external data source returned an error or is unavailable.
+    #[error("external data error: {0}")]
+    ExternalData(String),
+
+    /// The solver produced a non-finite state and cannot continue.
+    #[error("solver divergence at t={time:.4e}: {reason}")]
+    SolverDivergence {
+        time:   f64,
+        reason: String,
+    },
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_calculator_matches_variable() {
+        let err = OxiflowError::MissingCalculator(ContextVariable::Time);
+        assert!(matches!(err, OxiflowError::MissingCalculator(ContextVariable::Time)));
+    }
+
+    #[test]
+    fn missing_calculator_display_contains_variable() {
+        let err = OxiflowError::MissingCalculator(ContextVariable::TimeStep);
+        assert!(err.to_string().contains("TimeStep"));
+    }
+
+    #[test]
+    fn computation_failed_is_matchable() {
+        let source: Box<dyn std::error::Error + Send + Sync> =
+            Box::new(std::io::Error::other("calculator error"));
+        let err = OxiflowError::ComputationFailed {
+            variable: ContextVariable::SpatialGradient { dimension: 0 },
+            source,
+        };
+        assert!(matches!(err, OxiflowError::ComputationFailed { .. }));
+    }
+
+    #[test]
+    fn computation_failed_display_contains_variable_and_source() {
+        let source: Box<dyn std::error::Error + Send + Sync> =
+            Box::new(std::io::Error::other("overflow"));
+        let err = OxiflowError::ComputationFailed {
+            variable: ContextVariable::SpatialGradient { dimension: 1 },
+            source,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("SpatialGradient"));
+        assert!(msg.contains("overflow"));
+    }
+
+    #[test]
+    fn circular_dependency_matches_variable() {
+        let err = OxiflowError::CircularDependency(ContextVariable::External { name: "flux" });
+        assert!(matches!(err, OxiflowError::CircularDependency(_)));
+    }
+
+    #[test]
+    fn circular_dependency_display_contains_variable() {
+        let err = OxiflowError::CircularDependency(ContextVariable::Time);
+        assert!(err.to_string().contains("Time"));
+    }
+
+    #[test]
+    fn type_mismatch_fields_are_accessible() {
+        let err = OxiflowError::TypeMismatch { expected: "Scalar", actual: "Vector" };
+        assert!(matches!(err, OxiflowError::TypeMismatch { expected: "Scalar", actual: "Vector" }));
+    }
+
+    #[test]
+    fn type_mismatch_display_contains_both_types() {
+        let err = OxiflowError::TypeMismatch { expected: "Matrix", actual: "ScalarField" };
+        let msg = err.to_string();
+        assert!(msg.contains("Matrix"));
+        assert!(msg.contains("ScalarField"));
+    }
+
+    #[test]
+    fn invalid_domain_display_contains_reason() {
+        let err = OxiflowError::InvalidDomain("n_points must be > 1".into());
+        assert!(err.to_string().contains("n_points must be > 1"));
+    }
+
+    #[test]
+    fn external_data_display_contains_reason() {
+        let err = OxiflowError::ExternalData("file not found".into());
+        assert!(err.to_string().contains("file not found"));
+    }
+
+    #[test]
+    fn solver_divergence_display_contains_time_and_reason() {
+        let err = OxiflowError::SolverDivergence {
+            time: 1.23e-4,
+            reason: "NaN detected in state vector".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("NaN detected"));
+        assert!(msg.contains("1.23"));
+    }
+
+    #[test]
+    fn solver_divergence_time_formatted_scientific() {
+        let err = OxiflowError::SolverDivergence { time: 0.001, reason: "diverged".into() };
+        assert!(err.to_string().contains("e-"));
+    }
+
+    #[test]
+    fn all_variants_implement_debug() {
+        let variants: Vec<Box<dyn std::fmt::Debug>> = vec![
+            Box::new(OxiflowError::MissingCalculator(ContextVariable::Time)),
+            Box::new(OxiflowError::CircularDependency(ContextVariable::TimeStep)),
+            Box::new(OxiflowError::TypeMismatch { expected: "Scalar", actual: "Boolean" }),
+            Box::new(OxiflowError::InvalidDomain("test".into())),
+            Box::new(OxiflowError::ExternalData("test".into())),
+            Box::new(OxiflowError::SolverDivergence { time: 0.0, reason: "test".into() }),
+        ];
+        for v in &variants {
+            assert!(!format!("{:?}", v).is_empty());
+        }
+    }
+}

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -12,6 +12,7 @@
 //! - [`value`]    — Type `ContextValue`: typed value enum (DD-003)
 //! - [`compute`]  — Type `ComputeContext` and trait `RequiresContext` (DD-005, DD-006)
 
+pub mod calculator;
 pub mod compute;
 pub mod error;
 pub mod value;
@@ -19,6 +20,7 @@ pub mod variable;
 
 // ── Re-exports ────────────────────────────────────────────────────────────────
 
+pub use calculator::ContextCalculator;
 pub use compute::ComputeContext;
 pub use error::OxiflowError;
 pub use value::ContextValue;

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -19,6 +19,7 @@ pub mod variable;
 
 // ── Re-exports ────────────────────────────────────────────────────────────────
 
+pub use compute::ComputeContext;
 pub use error::OxiflowError;
 pub use value::ContextValue;
 pub use variable::ContextVariable;

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -7,8 +7,18 @@
 //!
 //! ## Submodules
 //!
-//! - [`compute`] — Type `ComputeContext` and trait `RequiresContext` (DD-005, DD-006)
-//! - [`error`]   — Type `OxiflowError` and variant (DD-004)
+//! - [`variable`] — Type `ContextVariable`: typed key for context variables
+//! - [`error`]    — Type `OxiflowError`: typed engine error enum (DD-004)
+//! - [`value`]    — Type `ContextValue`: typed value enum (DD-003)
+//! - [`compute`]  — Type `ComputeContext` and trait `RequiresContext` (DD-005, DD-006)
 
 pub mod compute;
 pub mod error;
+pub mod value;
+pub mod variable;
+
+// ── Re-exports ────────────────────────────────────────────────────────────────
+
+pub use error::OxiflowError;
+pub use value::ContextValue;
+pub use variable::ContextVariable;

--- a/src/context/value.rs
+++ b/src/context/value.rs
@@ -66,6 +66,7 @@ use crate::context::error::OxiflowError;
 /// assert!(!field.as_scalar_field().unwrap().is_empty());
 /// ```
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum ContextValue {
     // ── Pointwise algebraic objects ───────────────────────────────────────────
     /// Rank-0 scalar: time, step size, uniform coefficient.
@@ -79,9 +80,12 @@ pub enum ContextValue {
 
     /// Rank-2 tensor: diffusion tensor D_ij, stress σ_ij, permeability K_ij.
     ///
-    /// Covariant transformation (`D' = J·D·Jᵀ`) is the caller's responsibility
-    /// via `DiscreteOperator` (INV-2, J7). This variant stores components in the
-    /// current reference frame only.
+    /// Covariant transformation is the caller's responsibility
+    /// via `DiscreteOperator` (INV-2, J7):
+    ///
+    /// $$D'_{ij} = J_{ik}\,D_{kl}\,J_{jl}^{\top}$$
+    ///
+    /// This variant stores components in the current reference frame only.
     Matrix(DMatrix<f64>),
 
     // ── Nodal fields ──────────────────────────────────────────────────────────
@@ -114,6 +118,9 @@ impl ContextValue {
             Self::Matrix(_) => "Matrix",
             Self::ScalarField(_) => "ScalarField",
             Self::VectorField(_) => "VectorField",
+            // J7 variants (Tensor4, TensorField) return their name when added
+            #[allow(unreachable_patterns)]
+            _ => "Unknown",
         }
     }
 

--- a/src/context/value.rs
+++ b/src/context/value.rs
@@ -1,0 +1,425 @@
+//! # Module `context::value`
+//!
+//! Typed values carried by the compute context (DD-003, issue #27).
+//!
+//! ## Two orthogonal axes
+//!
+//! `ContextValue` is structured along two independent axes:
+//!
+//! - **Rank** (algebraic): scalar (rank 0), vector (rank 1), matrix (rank 2 tensor).
+//! - **Distribution**: pointwise algebraic object vs. nodal field (one value per mesh node).
+//!
+//! ## Reserved variants (J7)
+//!
+//! `Tensor4` (rank-4 tensor C_ijkl) and `TensorField` (rank-2 tensor per node) are
+//! deliberately absent. They require `DiscreteOperator` (INV-2, J5) for covariant
+//! transformation semantics and will be added at J7. Tensors of rank > 4 are out of
+//! scope for all target physics; extension for third-party frameworks follows INV-4.
+//!
+//! ## Distinction from `PhysicalData`
+//!
+//! `PhysicalData` is the primary field `u` discretised on the mesh — a dimensionality-
+//! based array container with no tensor semantics. `ContextValue` holds coefficients,
+//! parameters and derived quantities consumed by physical models during time integration.
+
+use nalgebra::{DMatrix, DVector};
+
+use crate::context::error::OxiflowError;
+
+/// Typed value of a context variable.
+///
+/// # Pointwise algebraic objects
+///
+/// | Variant | Rank | Example |
+/// |---------|------|---------|
+/// | `Scalar` | 0 | time, axial dispersion coefficient D_ax |
+/// | `Boolean` | — | convergence flag, saturation condition |
+/// | `Vector` | 1 | velocity at a point, pointwise gradient |
+/// | `Matrix` | 2 | diffusion tensor D_ij, stress tensor σ_ij |
+///
+/// # Nodal fields
+///
+/// | Variant | Content | Example |
+/// |---------|---------|---------|
+/// | `ScalarField` | `DVector` — one scalar per node | porosity(x), T(x) |
+/// | `VectorField` | `DMatrix` — n_nodes × dim | velocity field u(x,y) |
+///
+/// # Reserved (J7 — requires INV-2 / DiscreteOperator)
+///
+/// ```text
+/// // Tensor4(Array4<f64>)  — rank-4 tensor C_ijkl (elastic stiffness)
+/// // TensorField(...)      — rank-2 tensor per node D_ij(x)
+/// // Tensors of rank > 4 are out of scope; extension via INV-4 for third-party frameworks.
+/// ```
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::context::value::ContextValue;
+/// use nalgebra::DVector;
+///
+/// let t   = ContextValue::Scalar(1.5);
+/// let flag = ContextValue::Boolean(false);
+/// let field = ContextValue::ScalarField(DVector::from_vec(vec![0.1, 0.2, 0.3]));
+///
+/// assert_eq!(t.as_scalar().unwrap(), 1.5);
+/// assert!(!field.as_scalar_field().unwrap().is_empty());
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub enum ContextValue {
+    // ── Pointwise algebraic objects ───────────────────────────────────────────
+
+    /// Rank-0 scalar: time, step size, uniform coefficient.
+    Scalar(f64),
+
+    /// Logical flag: convergence condition, saturation state.
+    Boolean(bool),
+
+    /// Rank-1 vector: pointwise velocity, pointwise gradient.
+    Vector(DVector<f64>),
+
+    /// Rank-2 tensor: diffusion tensor D_ij, stress σ_ij, permeability K_ij.
+    ///
+    /// Covariant transformation (`D' = J·D·Jᵀ`) is the caller's responsibility
+    /// via `DiscreteOperator` (INV-2, J7). This variant stores components in the
+    /// current reference frame only.
+    Matrix(DMatrix<f64>),
+
+    // ── Nodal fields ──────────────────────────────────────────────────────────
+
+    /// One scalar value per mesh node: porosity(x), temperature field T(x).
+    ///
+    /// Length equals the number of degrees of freedom (`Mesh::n_dof()`).
+    ScalarField(DVector<f64>),
+
+    /// One vector per mesh node, stored as `n_nodes × spatial_dim` matrix.
+    ///
+    /// Row `i` holds the vector at node `i`.
+    VectorField(DMatrix<f64>),
+    // Reserved for J7 — requires DiscreteOperator (INV-2):
+    // Tensor4(ndarray::Array4<f64>)  — rank-4 tensor C_ijkl
+    // TensorField(...)               — rank-2 tensor per node D_ij(x)
+    // Rank > 4: out of scope; extension via INV-4 for third-party frameworks.
+}
+
+impl ContextValue {
+    // ── Variant name (used in TypeMismatch errors) ────────────────────────────
+
+    /// Returns the variant name as a static string.
+    ///
+    /// Used to build `OxiflowError::TypeMismatch` messages.
+    pub fn variant_name(&self) -> &'static str {
+        match self {
+            Self::Scalar(_)      => "Scalar",
+            Self::Boolean(_)     => "Boolean",
+            Self::Vector(_)      => "Vector",
+            Self::Matrix(_)      => "Matrix",
+            Self::ScalarField(_) => "ScalarField",
+            Self::VectorField(_) => "VectorField",
+        }
+    }
+
+    // ── Pointwise accessors ───────────────────────────────────────────────────
+
+    /// Unwraps the inner `f64` of a `Scalar` variant.
+    ///
+    /// # Errors
+    ///
+    /// Returns `OxiflowError::TypeMismatch` if the variant is not `Scalar`.
+    pub fn as_scalar(&self) -> Result<f64, OxiflowError> {
+        match self {
+            Self::Scalar(v) => Ok(*v),
+            other => Err(OxiflowError::TypeMismatch {
+                expected: "Scalar",
+                actual:   other.variant_name(),
+            }),
+        }
+    }
+
+    /// Unwraps the inner `bool` of a `Boolean` variant.
+    ///
+    /// # Errors
+    ///
+    /// Returns `OxiflowError::TypeMismatch` if the variant is not `Boolean`.
+    pub fn as_bool(&self) -> Result<bool, OxiflowError> {
+        match self {
+            Self::Boolean(v) => Ok(*v),
+            other => Err(OxiflowError::TypeMismatch {
+                expected: "Boolean",
+                actual:   other.variant_name(),
+            }),
+        }
+    }
+
+    /// Borrows the inner `DVector` of a `Vector` variant.
+    ///
+    /// # Errors
+    ///
+    /// Returns `OxiflowError::TypeMismatch` if the variant is not `Vector`.
+    pub fn as_vector(&self) -> Result<&DVector<f64>, OxiflowError> {
+        match self {
+            Self::Vector(v) => Ok(v),
+            other => Err(OxiflowError::TypeMismatch {
+                expected: "Vector",
+                actual:   other.variant_name(),
+            }),
+        }
+    }
+
+    /// Borrows the inner `DMatrix` of a `Matrix` variant.
+    ///
+    /// # Errors
+    ///
+    /// Returns `OxiflowError::TypeMismatch` if the variant is not `Matrix`.
+    pub fn as_matrix(&self) -> Result<&DMatrix<f64>, OxiflowError> {
+        match self {
+            Self::Matrix(m) => Ok(m),
+            other => Err(OxiflowError::TypeMismatch {
+                expected: "Matrix",
+                actual:   other.variant_name(),
+            }),
+        }
+    }
+
+    // ── Nodal field accessors ─────────────────────────────────────────────────
+
+    /// Borrows the inner `DVector` of a `ScalarField` variant.
+    ///
+    /// # Errors
+    ///
+    /// Returns `OxiflowError::TypeMismatch` if the variant is not `ScalarField`.
+    pub fn as_scalar_field(&self) -> Result<&DVector<f64>, OxiflowError> {
+        match self {
+            Self::ScalarField(v) => Ok(v),
+            other => Err(OxiflowError::TypeMismatch {
+                expected: "ScalarField",
+                actual:   other.variant_name(),
+            }),
+        }
+    }
+
+    /// Borrows the inner `DMatrix` of a `VectorField` variant.
+    ///
+    /// Rows correspond to nodes, columns to spatial dimensions.
+    ///
+    /// # Errors
+    ///
+    /// Returns `OxiflowError::TypeMismatch` if the variant is not `VectorField`.
+    pub fn as_vector_field(&self) -> Result<&DMatrix<f64>, OxiflowError> {
+        match self {
+            Self::VectorField(m) => Ok(m),
+            other => Err(OxiflowError::TypeMismatch {
+                expected: "VectorField",
+                actual:   other.variant_name(),
+            }),
+        }
+    }
+
+    // ── Type predicates ───────────────────────────────────────────────────────
+
+    /// Returns `true` if this is a `Scalar`.
+    pub fn is_scalar(&self)       -> bool { matches!(self, Self::Scalar(_)) }
+    /// Returns `true` if this is a `Boolean`.
+    pub fn is_bool(&self)         -> bool { matches!(self, Self::Boolean(_)) }
+    /// Returns `true` if this is a `Vector`.
+    pub fn is_vector(&self)       -> bool { matches!(self, Self::Vector(_)) }
+    /// Returns `true` if this is a `Matrix`.
+    pub fn is_matrix(&self)       -> bool { matches!(self, Self::Matrix(_)) }
+    /// Returns `true` if this is a `ScalarField`.
+    pub fn is_scalar_field(&self) -> bool { matches!(self, Self::ScalarField(_)) }
+    /// Returns `true` if this is a `VectorField`.
+    pub fn is_vector_field(&self) -> bool { matches!(self, Self::VectorField(_)) }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::{DMatrix, DVector};
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn scalar()       -> ContextValue { ContextValue::Scalar(3.14) }
+    fn boolean()      -> ContextValue { ContextValue::Boolean(true) }
+    fn vector()       -> ContextValue { ContextValue::Vector(DVector::from_vec(vec![1.0, 2.0, 3.0])) }
+    fn matrix()       -> ContextValue { ContextValue::Matrix(DMatrix::from_element(2, 2, 1.0)) }
+    fn scalar_field() -> ContextValue { ContextValue::ScalarField(DVector::from_vec(vec![0.1, 0.2])) }
+    fn vector_field() -> ContextValue { ContextValue::VectorField(DMatrix::from_element(3, 2, 0.5)) }
+
+    fn all_variants() -> Vec<ContextValue> {
+        vec![scalar(), boolean(), vector(), matrix(), scalar_field(), vector_field()]
+    }
+
+    // ── variant_name ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn variant_names_are_correct() {
+        assert_eq!(scalar().variant_name(),       "Scalar");
+        assert_eq!(boolean().variant_name(),      "Boolean");
+        assert_eq!(vector().variant_name(),       "Vector");
+        assert_eq!(matrix().variant_name(),       "Matrix");
+        assert_eq!(scalar_field().variant_name(), "ScalarField");
+        assert_eq!(vector_field().variant_name(), "VectorField");
+    }
+
+    // ── as_scalar ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn as_scalar_on_scalar_returns_value() {
+        assert_eq!(scalar().as_scalar().unwrap(), 3.14);
+    }
+
+    #[test]
+    fn as_scalar_on_wrong_variant_returns_type_mismatch() {
+        for v in [boolean(), vector(), matrix(), scalar_field(), vector_field()] {
+            let err = v.as_scalar().unwrap_err();
+            assert!(
+                matches!(err, OxiflowError::TypeMismatch { expected: "Scalar", .. }),
+                "expected TypeMismatch for {:?}",
+                v
+            );
+        }
+    }
+
+    // ── as_bool ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn as_bool_on_boolean_returns_value() {
+        assert!(boolean().as_bool().unwrap());
+        assert!(!ContextValue::Boolean(false).as_bool().unwrap());
+    }
+
+    #[test]
+    fn as_bool_on_wrong_variant_returns_type_mismatch() {
+        for v in [scalar(), vector(), matrix(), scalar_field(), vector_field()] {
+            let err = v.as_bool().unwrap_err();
+            assert!(matches!(err, OxiflowError::TypeMismatch { expected: "Boolean", .. }));
+        }
+    }
+
+    // ── as_vector ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn as_vector_on_vector_returns_reference() {
+        let v = vector();
+        let inner = v.as_vector().unwrap();
+        assert_eq!(inner.len(), 3);
+        assert_eq!(inner[0], 1.0);
+    }
+
+    #[test]
+    fn as_vector_on_wrong_variant_returns_type_mismatch() {
+        for v in [scalar(), boolean(), matrix(), scalar_field(), vector_field()] {
+            let err = v.as_vector().unwrap_err();
+            assert!(matches!(err, OxiflowError::TypeMismatch { expected: "Vector", .. }));
+        }
+    }
+
+    // ── as_matrix ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn as_matrix_on_matrix_returns_reference() {
+        let m = matrix();
+        let inner = m.as_matrix().unwrap();
+        assert_eq!(inner.shape(), (2, 2));
+    }
+
+    #[test]
+    fn as_matrix_on_wrong_variant_returns_type_mismatch() {
+        for v in [scalar(), boolean(), vector(), scalar_field(), vector_field()] {
+            let err = v.as_matrix().unwrap_err();
+            assert!(matches!(err, OxiflowError::TypeMismatch { expected: "Matrix", .. }));
+        }
+    }
+
+    // ── as_scalar_field ───────────────────────────────────────────────────────
+
+    #[test]
+    fn as_scalar_field_on_scalar_field_returns_reference() {
+        let sf = scalar_field();
+        let inner = sf.as_scalar_field().unwrap();
+        assert_eq!(inner.len(), 2);
+        assert!((inner[0] - 0.1).abs() < 1e-12);
+    }
+
+    #[test]
+    fn as_scalar_field_on_wrong_variant_returns_type_mismatch() {
+        for v in [scalar(), boolean(), vector(), matrix(), vector_field()] {
+            let err = v.as_scalar_field().unwrap_err();
+            assert!(matches!(err, OxiflowError::TypeMismatch { expected: "ScalarField", .. }));
+        }
+    }
+
+    // ── as_vector_field ───────────────────────────────────────────────────────
+
+    #[test]
+    fn as_vector_field_on_vector_field_returns_reference() {
+        let vf = vector_field();
+        let inner = vf.as_vector_field().unwrap();
+        assert_eq!(inner.shape(), (3, 2));
+    }
+
+    #[test]
+    fn as_vector_field_on_wrong_variant_returns_type_mismatch() {
+        for v in [scalar(), boolean(), vector(), matrix(), scalar_field()] {
+            let err = v.as_vector_field().unwrap_err();
+            assert!(matches!(err, OxiflowError::TypeMismatch { expected: "VectorField", .. }));
+        }
+    }
+
+    // ── Type predicates ───────────────────────────────────────────────────────
+
+    #[test]
+    fn is_predicates_return_true_for_correct_variant() {
+        assert!(scalar().is_scalar());
+        assert!(boolean().is_bool());
+        assert!(vector().is_vector());
+        assert!(matrix().is_matrix());
+        assert!(scalar_field().is_scalar_field());
+        assert!(vector_field().is_vector_field());
+    }
+
+    #[test]
+    fn is_scalar_returns_false_for_other_variants() {
+        for v in [boolean(), vector(), matrix(), scalar_field(), vector_field()] {
+            assert!(!v.is_scalar(), "expected false for {:?}", v);
+        }
+    }
+
+    #[test]
+    fn is_scalar_field_returns_false_for_scalar() {
+        assert!(!scalar().is_scalar_field());
+    }
+
+    // ── Clone & PartialEq ─────────────────────────────────────────────────────
+
+    #[test]
+    fn clone_preserves_equality() {
+        for v in all_variants() {
+            assert_eq!(v.clone(), v);
+        }
+    }
+
+    #[test]
+    fn distinct_variants_are_not_equal() {
+        assert_ne!(scalar(), boolean());
+        assert_ne!(vector(), scalar_field()); // same inner type, different semantic
+        assert_ne!(matrix(), vector_field());
+    }
+
+    #[test]
+    fn scalar_values_compared_by_content() {
+        assert_eq!(ContextValue::Scalar(1.0), ContextValue::Scalar(1.0));
+        assert_ne!(ContextValue::Scalar(1.0), ContextValue::Scalar(2.0));
+    }
+
+    // ── Debug ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn debug_is_non_empty_for_all_variants() {
+        for v in all_variants() {
+            assert!(!format!("{:?}", v).is_empty());
+        }
+    }
+}

--- a/src/context/value.rs
+++ b/src/context/value.rs
@@ -68,7 +68,6 @@ use crate::context::error::OxiflowError;
 #[derive(Debug, Clone, PartialEq)]
 pub enum ContextValue {
     // ── Pointwise algebraic objects ───────────────────────────────────────────
-
     /// Rank-0 scalar: time, step size, uniform coefficient.
     Scalar(f64),
 
@@ -86,7 +85,6 @@ pub enum ContextValue {
     Matrix(DMatrix<f64>),
 
     // ── Nodal fields ──────────────────────────────────────────────────────────
-
     /// One scalar value per mesh node: porosity(x), temperature field T(x).
     ///
     /// Length equals the number of degrees of freedom (`Mesh::n_dof()`).
@@ -110,10 +108,10 @@ impl ContextValue {
     /// Used to build `OxiflowError::TypeMismatch` messages.
     pub fn variant_name(&self) -> &'static str {
         match self {
-            Self::Scalar(_)      => "Scalar",
-            Self::Boolean(_)     => "Boolean",
-            Self::Vector(_)      => "Vector",
-            Self::Matrix(_)      => "Matrix",
+            Self::Scalar(_) => "Scalar",
+            Self::Boolean(_) => "Boolean",
+            Self::Vector(_) => "Vector",
+            Self::Matrix(_) => "Matrix",
             Self::ScalarField(_) => "ScalarField",
             Self::VectorField(_) => "VectorField",
         }
@@ -131,7 +129,7 @@ impl ContextValue {
             Self::Scalar(v) => Ok(*v),
             other => Err(OxiflowError::TypeMismatch {
                 expected: "Scalar",
-                actual:   other.variant_name(),
+                actual: other.variant_name(),
             }),
         }
     }
@@ -146,7 +144,7 @@ impl ContextValue {
             Self::Boolean(v) => Ok(*v),
             other => Err(OxiflowError::TypeMismatch {
                 expected: "Boolean",
-                actual:   other.variant_name(),
+                actual: other.variant_name(),
             }),
         }
     }
@@ -161,7 +159,7 @@ impl ContextValue {
             Self::Vector(v) => Ok(v),
             other => Err(OxiflowError::TypeMismatch {
                 expected: "Vector",
-                actual:   other.variant_name(),
+                actual: other.variant_name(),
             }),
         }
     }
@@ -176,7 +174,7 @@ impl ContextValue {
             Self::Matrix(m) => Ok(m),
             other => Err(OxiflowError::TypeMismatch {
                 expected: "Matrix",
-                actual:   other.variant_name(),
+                actual: other.variant_name(),
             }),
         }
     }
@@ -193,7 +191,7 @@ impl ContextValue {
             Self::ScalarField(v) => Ok(v),
             other => Err(OxiflowError::TypeMismatch {
                 expected: "ScalarField",
-                actual:   other.variant_name(),
+                actual: other.variant_name(),
             }),
         }
     }
@@ -210,7 +208,7 @@ impl ContextValue {
             Self::VectorField(m) => Ok(m),
             other => Err(OxiflowError::TypeMismatch {
                 expected: "VectorField",
-                actual:   other.variant_name(),
+                actual: other.variant_name(),
             }),
         }
     }
@@ -218,17 +216,29 @@ impl ContextValue {
     // ── Type predicates ───────────────────────────────────────────────────────
 
     /// Returns `true` if this is a `Scalar`.
-    pub fn is_scalar(&self)       -> bool { matches!(self, Self::Scalar(_)) }
+    pub fn is_scalar(&self) -> bool {
+        matches!(self, Self::Scalar(_))
+    }
     /// Returns `true` if this is a `Boolean`.
-    pub fn is_bool(&self)         -> bool { matches!(self, Self::Boolean(_)) }
+    pub fn is_bool(&self) -> bool {
+        matches!(self, Self::Boolean(_))
+    }
     /// Returns `true` if this is a `Vector`.
-    pub fn is_vector(&self)       -> bool { matches!(self, Self::Vector(_)) }
+    pub fn is_vector(&self) -> bool {
+        matches!(self, Self::Vector(_))
+    }
     /// Returns `true` if this is a `Matrix`.
-    pub fn is_matrix(&self)       -> bool { matches!(self, Self::Matrix(_)) }
+    pub fn is_matrix(&self) -> bool {
+        matches!(self, Self::Matrix(_))
+    }
     /// Returns `true` if this is a `ScalarField`.
-    pub fn is_scalar_field(&self) -> bool { matches!(self, Self::ScalarField(_)) }
+    pub fn is_scalar_field(&self) -> bool {
+        matches!(self, Self::ScalarField(_))
+    }
     /// Returns `true` if this is a `VectorField`.
-    pub fn is_vector_field(&self) -> bool { matches!(self, Self::VectorField(_)) }
+    pub fn is_vector_field(&self) -> bool {
+        matches!(self, Self::VectorField(_))
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -240,25 +250,44 @@ mod tests {
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
-    fn scalar()       -> ContextValue { ContextValue::Scalar(3.14) }
-    fn boolean()      -> ContextValue { ContextValue::Boolean(true) }
-    fn vector()       -> ContextValue { ContextValue::Vector(DVector::from_vec(vec![1.0, 2.0, 3.0])) }
-    fn matrix()       -> ContextValue { ContextValue::Matrix(DMatrix::from_element(2, 2, 1.0)) }
-    fn scalar_field() -> ContextValue { ContextValue::ScalarField(DVector::from_vec(vec![0.1, 0.2])) }
-    fn vector_field() -> ContextValue { ContextValue::VectorField(DMatrix::from_element(3, 2, 0.5)) }
+    fn scalar() -> ContextValue {
+        ContextValue::Scalar(3.14)
+    }
+    fn boolean() -> ContextValue {
+        ContextValue::Boolean(true)
+    }
+    fn vector() -> ContextValue {
+        ContextValue::Vector(DVector::from_vec(vec![1.0, 2.0, 3.0]))
+    }
+    fn matrix() -> ContextValue {
+        ContextValue::Matrix(DMatrix::from_element(2, 2, 1.0))
+    }
+    fn scalar_field() -> ContextValue {
+        ContextValue::ScalarField(DVector::from_vec(vec![0.1, 0.2]))
+    }
+    fn vector_field() -> ContextValue {
+        ContextValue::VectorField(DMatrix::from_element(3, 2, 0.5))
+    }
 
     fn all_variants() -> Vec<ContextValue> {
-        vec![scalar(), boolean(), vector(), matrix(), scalar_field(), vector_field()]
+        vec![
+            scalar(),
+            boolean(),
+            vector(),
+            matrix(),
+            scalar_field(),
+            vector_field(),
+        ]
     }
 
     // ── variant_name ─────────────────────────────────────────────────────────
 
     #[test]
     fn variant_names_are_correct() {
-        assert_eq!(scalar().variant_name(),       "Scalar");
-        assert_eq!(boolean().variant_name(),      "Boolean");
-        assert_eq!(vector().variant_name(),       "Vector");
-        assert_eq!(matrix().variant_name(),       "Matrix");
+        assert_eq!(scalar().variant_name(), "Scalar");
+        assert_eq!(boolean().variant_name(), "Boolean");
+        assert_eq!(vector().variant_name(), "Vector");
+        assert_eq!(matrix().variant_name(), "Matrix");
         assert_eq!(scalar_field().variant_name(), "ScalarField");
         assert_eq!(vector_field().variant_name(), "VectorField");
     }
@@ -272,10 +301,22 @@ mod tests {
 
     #[test]
     fn as_scalar_on_wrong_variant_returns_type_mismatch() {
-        for v in [boolean(), vector(), matrix(), scalar_field(), vector_field()] {
+        for v in [
+            boolean(),
+            vector(),
+            matrix(),
+            scalar_field(),
+            vector_field(),
+        ] {
             let err = v.as_scalar().unwrap_err();
             assert!(
-                matches!(err, OxiflowError::TypeMismatch { expected: "Scalar", .. }),
+                matches!(
+                    err,
+                    OxiflowError::TypeMismatch {
+                        expected: "Scalar",
+                        ..
+                    }
+                ),
                 "expected TypeMismatch for {:?}",
                 v
             );
@@ -294,7 +335,13 @@ mod tests {
     fn as_bool_on_wrong_variant_returns_type_mismatch() {
         for v in [scalar(), vector(), matrix(), scalar_field(), vector_field()] {
             let err = v.as_bool().unwrap_err();
-            assert!(matches!(err, OxiflowError::TypeMismatch { expected: "Boolean", .. }));
+            assert!(matches!(
+                err,
+                OxiflowError::TypeMismatch {
+                    expected: "Boolean",
+                    ..
+                }
+            ));
         }
     }
 
@@ -310,9 +357,21 @@ mod tests {
 
     #[test]
     fn as_vector_on_wrong_variant_returns_type_mismatch() {
-        for v in [scalar(), boolean(), matrix(), scalar_field(), vector_field()] {
+        for v in [
+            scalar(),
+            boolean(),
+            matrix(),
+            scalar_field(),
+            vector_field(),
+        ] {
             let err = v.as_vector().unwrap_err();
-            assert!(matches!(err, OxiflowError::TypeMismatch { expected: "Vector", .. }));
+            assert!(matches!(
+                err,
+                OxiflowError::TypeMismatch {
+                    expected: "Vector",
+                    ..
+                }
+            ));
         }
     }
 
@@ -327,9 +386,21 @@ mod tests {
 
     #[test]
     fn as_matrix_on_wrong_variant_returns_type_mismatch() {
-        for v in [scalar(), boolean(), vector(), scalar_field(), vector_field()] {
+        for v in [
+            scalar(),
+            boolean(),
+            vector(),
+            scalar_field(),
+            vector_field(),
+        ] {
             let err = v.as_matrix().unwrap_err();
-            assert!(matches!(err, OxiflowError::TypeMismatch { expected: "Matrix", .. }));
+            assert!(matches!(
+                err,
+                OxiflowError::TypeMismatch {
+                    expected: "Matrix",
+                    ..
+                }
+            ));
         }
     }
 
@@ -347,7 +418,13 @@ mod tests {
     fn as_scalar_field_on_wrong_variant_returns_type_mismatch() {
         for v in [scalar(), boolean(), vector(), matrix(), vector_field()] {
             let err = v.as_scalar_field().unwrap_err();
-            assert!(matches!(err, OxiflowError::TypeMismatch { expected: "ScalarField", .. }));
+            assert!(matches!(
+                err,
+                OxiflowError::TypeMismatch {
+                    expected: "ScalarField",
+                    ..
+                }
+            ));
         }
     }
 
@@ -364,7 +441,13 @@ mod tests {
     fn as_vector_field_on_wrong_variant_returns_type_mismatch() {
         for v in [scalar(), boolean(), vector(), matrix(), scalar_field()] {
             let err = v.as_vector_field().unwrap_err();
-            assert!(matches!(err, OxiflowError::TypeMismatch { expected: "VectorField", .. }));
+            assert!(matches!(
+                err,
+                OxiflowError::TypeMismatch {
+                    expected: "VectorField",
+                    ..
+                }
+            ));
         }
     }
 
@@ -382,7 +465,13 @@ mod tests {
 
     #[test]
     fn is_scalar_returns_false_for_other_variants() {
-        for v in [boolean(), vector(), matrix(), scalar_field(), vector_field()] {
+        for v in [
+            boolean(),
+            vector(),
+            matrix(),
+            scalar_field(),
+            vector_field(),
+        ] {
             assert!(!v.is_scalar(), "expected false for {:?}", v);
         }
     }

--- a/src/context/variable.rs
+++ b/src/context/variable.rs
@@ -1,0 +1,199 @@
+//! # Module `context::variable`
+//!
+//! Typed keys identifying context variables required or produced by calculators.
+//!
+//! `ContextVariable` is the key type of the context map
+//! (`HashMap<ContextVariable, ContextValue>`). It must satisfy `Hash + Eq`
+//! to serve as a map key — which rules out `f64` fields (DD-003).
+//!
+//! ## Design note — no `position: f64`
+//!
+//! chrom-rs stored gradients as point-wise scalars keyed by `(dimension, position)`.
+//! oxiflow stores the complete gradient field under a single key
+//! `SpatialGradient { dimension }` → `ContextValue::ScalarField`.
+//! Node-level access is the operator's responsibility (INV-2, J5).
+
+/// Typed key identifying a context variable in the compute context.
+///
+/// All variants implement `Hash + Eq` so that `ContextVariable` can serve as
+/// a `HashMap` key without workarounds. In particular, no `f64` field appears
+/// here — the full spatial gradient field is stored as `ContextValue::ScalarField`.
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::context::variable::ContextVariable;
+///
+/// let t   = ContextVariable::Time;
+/// let dt  = ContextVariable::TimeStep;
+/// let gx  = ContextVariable::SpatialGradient { dimension: 0 };
+/// let ext = ContextVariable::External { name: "ambient_temperature" };
+///
+/// assert_ne!(t, dt);
+/// assert_ne!(
+///     ContextVariable::SpatialGradient { dimension: 0 },
+///     ContextVariable::SpatialGradient { dimension: 1 },
+/// );
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ContextVariable {
+    /// Current simulation time `t`.
+    Time,
+
+    /// Current time step `dt`.
+    TimeStep,
+
+    /// Spatial gradient of the primary field along `dimension`.
+    ///
+    /// The associated `ContextValue` is a `ScalarField` containing one gradient
+    /// value per mesh node — not a point-wise scalar.
+    ///
+    /// `dimension = 0` → ∂u/∂x, `dimension = 1` → ∂u/∂y, etc.
+    SpatialGradient {
+        /// Spatial dimension index (0-based).
+        dimension: usize,
+    },
+
+    /// External scalar provided by the user (e.g. ambient temperature, feed concentration).
+    ///
+    /// The `name` is a static string and participates in `Hash + Eq`.
+    External {
+        /// Unique name of the external variable.
+        name: &'static str,
+    },
+}
+
+impl std::fmt::Display for ContextVariable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Time => write!(f, "Time"),
+            Self::TimeStep => write!(f, "TimeStep"),
+            Self::SpatialGradient { dimension } => {
+                write!(f, "SpatialGradient(dim={})", dimension)
+            }
+            Self::External { name } => write!(f, "External({})", name),
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    // ── Construction & equality ───────────────────────────────────────────────
+
+    #[test]
+    fn time_equals_time() {
+        assert_eq!(ContextVariable::Time, ContextVariable::Time);
+    }
+
+    #[test]
+    fn time_differs_from_timestep() {
+        assert_ne!(ContextVariable::Time, ContextVariable::TimeStep);
+    }
+
+    #[test]
+    fn spatial_gradient_same_dimension_equal() {
+        let a = ContextVariable::SpatialGradient { dimension: 0 };
+        let b = ContextVariable::SpatialGradient { dimension: 0 };
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn spatial_gradient_different_dimension_not_equal() {
+        let a = ContextVariable::SpatialGradient { dimension: 0 };
+        let b = ContextVariable::SpatialGradient { dimension: 1 };
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn external_same_name_equal() {
+        let a = ContextVariable::External { name: "temperature" };
+        let b = ContextVariable::External { name: "temperature" };
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn external_different_name_not_equal() {
+        let a = ContextVariable::External { name: "temperature" };
+        let b = ContextVariable::External { name: "pressure" };
+        assert_ne!(a, b);
+    }
+
+    // ── Clone ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn clone_preserves_equality() {
+        let vars = [
+            ContextVariable::Time,
+            ContextVariable::TimeStep,
+            ContextVariable::SpatialGradient { dimension: 2 },
+            ContextVariable::External { name: "feed" },
+        ];
+        for v in &vars {
+            assert_eq!(v.clone(), *v);
+        }
+    }
+
+    // ── Hash (usable as HashMap key) ──────────────────────────────────────────
+
+    #[test]
+    fn usable_as_hashmap_key() {
+        let mut map: HashMap<ContextVariable, f64> = HashMap::new();
+        map.insert(ContextVariable::Time, 1.5);
+        map.insert(ContextVariable::TimeStep, 0.01);
+        map.insert(ContextVariable::SpatialGradient { dimension: 0 }, 0.3);
+        map.insert(ContextVariable::External { name: "T_amb" }, 298.15);
+
+        assert_eq!(map[&ContextVariable::Time], 1.5);
+        assert_eq!(map[&ContextVariable::TimeStep], 0.01);
+        assert_eq!(map[&ContextVariable::SpatialGradient { dimension: 0 }], 0.3);
+        assert_eq!(map[&ContextVariable::External { name: "T_amb" }], 298.15);
+    }
+
+    #[test]
+    fn gradient_dimensions_are_distinct_keys() {
+        let mut map: HashMap<ContextVariable, f64> = HashMap::new();
+        map.insert(ContextVariable::SpatialGradient { dimension: 0 }, 1.0);
+        map.insert(ContextVariable::SpatialGradient { dimension: 1 }, 2.0);
+
+        assert_eq!(map[&ContextVariable::SpatialGradient { dimension: 0 }], 1.0);
+        assert_eq!(map[&ContextVariable::SpatialGradient { dimension: 1 }], 2.0);
+    }
+
+    // ── Display ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn display_time() {
+        assert_eq!(format!("{}", ContextVariable::Time), "Time");
+    }
+
+    #[test]
+    fn display_timestep() {
+        assert_eq!(format!("{}", ContextVariable::TimeStep), "TimeStep");
+    }
+
+    #[test]
+    fn display_spatial_gradient() {
+        let v = ContextVariable::SpatialGradient { dimension: 1 };
+        assert_eq!(format!("{}", v), "SpatialGradient(dim=1)");
+    }
+
+    #[test]
+    fn display_external() {
+        let v = ContextVariable::External { name: "T_amb" };
+        assert_eq!(format!("{}", v), "External(T_amb)");
+    }
+
+    // ── Debug ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn debug_is_non_empty() {
+        let s = format!("{:?}", ContextVariable::SpatialGradient { dimension: 0 });
+        assert!(s.contains("SpatialGradient"));
+        assert!(s.contains('0'));
+    }
+}

--- a/src/context/variable.rs
+++ b/src/context/variable.rs
@@ -10,7 +10,7 @@
 //!
 //! chrom-rs stored gradients as point-wise scalars keyed by `(dimension, position)`.
 //! oxiflow stores the complete gradient field under a single key
-//! `SpatialGradient { dimension }` → `ContextValue::ScalarField`.
+//! `SpatialGradient { dimension, component }` → `ContextValue::ScalarField`.
 //! Node-level access is the operator's responsibility (INV-2, J5).
 
 /// Typed key identifying a context variable in the compute context.
@@ -26,16 +26,17 @@
 ///
 /// let t   = ContextVariable::Time;
 /// let dt  = ContextVariable::TimeStep;
-/// let gx  = ContextVariable::SpatialGradient { dimension: 0 };
+/// let gx  = ContextVariable::SpatialGradient { dimension: 0, component: None };
 /// let ext = ContextVariable::External { name: "ambient_temperature" };
 ///
 /// assert_ne!(t, dt);
 /// assert_ne!(
-///     ContextVariable::SpatialGradient { dimension: 0 },
-///     ContextVariable::SpatialGradient { dimension: 1 },
+///     ContextVariable::SpatialGradient { dimension: 0, component: None },
+///     ContextVariable::SpatialGradient { dimension: 1, component: None },
 /// );
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum ContextVariable {
     /// Current simulation time `t`.
     Time,
@@ -49,9 +50,17 @@ pub enum ContextVariable {
     /// value per mesh node — not a point-wise scalar.
     ///
     /// `dimension = 0` → ∂u/∂x, `dimension = 1` → ∂u/∂y, etc.
+    ///
+    /// `component = None` — mono-component field (J1/J2 default).
+    /// `component = Some(k)` — gradient of component k (J3+, DD-010).
     SpatialGradient {
         /// Spatial dimension index (0-based).
         dimension: usize,
+        /// Species/component index for multi-component fields (J3+, DD-010).
+        ///
+        /// `None` at J1/J2 (single-component). Adding this field now avoids a
+        /// breaking change when multi-component support lands at J3.
+        component: Option<usize>,
     },
 
     /// External scalar provided by the user (e.g. ambient temperature, feed concentration).
@@ -68,10 +77,22 @@ impl std::fmt::Display for ContextVariable {
         match self {
             Self::Time => write!(f, "Time"),
             Self::TimeStep => write!(f, "TimeStep"),
-            Self::SpatialGradient { dimension } => {
+            Self::SpatialGradient {
+                dimension,
+                component: None,
+            } => {
                 write!(f, "SpatialGradient(dim={})", dimension)
             }
+            Self::SpatialGradient {
+                dimension,
+                component: Some(c),
+            } => {
+                write!(f, "SpatialGradient(dim={},comp={})", dimension, c)
+            }
             Self::External { name } => write!(f, "External({})", name),
+            // J3+ variants handled when added
+            #[allow(unreachable_patterns)]
+            _ => write!(f, "Unknown"),
         }
     }
 }
@@ -97,15 +118,27 @@ mod tests {
 
     #[test]
     fn spatial_gradient_same_dimension_equal() {
-        let a = ContextVariable::SpatialGradient { dimension: 0 };
-        let b = ContextVariable::SpatialGradient { dimension: 0 };
+        let a = ContextVariable::SpatialGradient {
+            dimension: 0,
+            component: None,
+        };
+        let b = ContextVariable::SpatialGradient {
+            dimension: 0,
+            component: None,
+        };
         assert_eq!(a, b);
     }
 
     #[test]
     fn spatial_gradient_different_dimension_not_equal() {
-        let a = ContextVariable::SpatialGradient { dimension: 0 };
-        let b = ContextVariable::SpatialGradient { dimension: 1 };
+        let a = ContextVariable::SpatialGradient {
+            dimension: 0,
+            component: None,
+        };
+        let b = ContextVariable::SpatialGradient {
+            dimension: 1,
+            component: None,
+        };
         assert_ne!(a, b);
     }
 
@@ -136,7 +169,10 @@ mod tests {
         let vars = [
             ContextVariable::Time,
             ContextVariable::TimeStep,
-            ContextVariable::SpatialGradient { dimension: 2 },
+            ContextVariable::SpatialGradient {
+                dimension: 2,
+                component: None,
+            },
             ContextVariable::External { name: "feed" },
         ];
         for v in &vars {
@@ -151,23 +187,59 @@ mod tests {
         let mut map: HashMap<ContextVariable, f64> = HashMap::new();
         map.insert(ContextVariable::Time, 1.5);
         map.insert(ContextVariable::TimeStep, 0.01);
-        map.insert(ContextVariable::SpatialGradient { dimension: 0 }, 0.3);
+        map.insert(
+            ContextVariable::SpatialGradient {
+                dimension: 0,
+                component: None,
+            },
+            0.3,
+        );
         map.insert(ContextVariable::External { name: "T_amb" }, 298.15);
 
         assert_eq!(map[&ContextVariable::Time], 1.5);
         assert_eq!(map[&ContextVariable::TimeStep], 0.01);
-        assert_eq!(map[&ContextVariable::SpatialGradient { dimension: 0 }], 0.3);
+        assert_eq!(
+            map[&ContextVariable::SpatialGradient {
+                dimension: 0,
+                component: None
+            }],
+            0.3
+        );
         assert_eq!(map[&ContextVariable::External { name: "T_amb" }], 298.15);
     }
 
     #[test]
     fn gradient_dimensions_are_distinct_keys() {
         let mut map: HashMap<ContextVariable, f64> = HashMap::new();
-        map.insert(ContextVariable::SpatialGradient { dimension: 0 }, 1.0);
-        map.insert(ContextVariable::SpatialGradient { dimension: 1 }, 2.0);
+        map.insert(
+            ContextVariable::SpatialGradient {
+                dimension: 0,
+                component: None,
+            },
+            1.0,
+        );
+        map.insert(
+            ContextVariable::SpatialGradient {
+                dimension: 1,
+                component: None,
+            },
+            2.0,
+        );
 
-        assert_eq!(map[&ContextVariable::SpatialGradient { dimension: 0 }], 1.0);
-        assert_eq!(map[&ContextVariable::SpatialGradient { dimension: 1 }], 2.0);
+        assert_eq!(
+            map[&ContextVariable::SpatialGradient {
+                dimension: 0,
+                component: None
+            }],
+            1.0
+        );
+        assert_eq!(
+            map[&ContextVariable::SpatialGradient {
+                dimension: 1,
+                component: None
+            }],
+            2.0
+        );
     }
 
     // ── Display ───────────────────────────────────────────────────────────────
@@ -184,7 +256,10 @@ mod tests {
 
     #[test]
     fn display_spatial_gradient() {
-        let v = ContextVariable::SpatialGradient { dimension: 1 };
+        let v = ContextVariable::SpatialGradient {
+            dimension: 1,
+            component: None,
+        };
         assert_eq!(format!("{}", v), "SpatialGradient(dim=1)");
     }
 
@@ -198,7 +273,13 @@ mod tests {
 
     #[test]
     fn debug_is_non_empty() {
-        let s = format!("{:?}", ContextVariable::SpatialGradient { dimension: 0 });
+        let s = format!(
+            "{:?}",
+            ContextVariable::SpatialGradient {
+                dimension: 0,
+                component: None
+            }
+        );
         assert!(s.contains("SpatialGradient"));
         assert!(s.contains('0'));
     }

--- a/src/context/variable.rs
+++ b/src/context/variable.rs
@@ -111,14 +111,20 @@ mod tests {
 
     #[test]
     fn external_same_name_equal() {
-        let a = ContextVariable::External { name: "temperature" };
-        let b = ContextVariable::External { name: "temperature" };
+        let a = ContextVariable::External {
+            name: "temperature",
+        };
+        let b = ContextVariable::External {
+            name: "temperature",
+        };
         assert_eq!(a, b);
     }
 
     #[test]
     fn external_different_name_not_equal() {
-        let a = ContextVariable::External { name: "temperature" };
+        let a = ContextVariable::External {
+            name: "temperature",
+        };
         let b = ContextVariable::External { name: "pressure" };
         assert_ne!(a, b);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,141 +28,37 @@
 //!
 //! ## Physical domains
 //!
-//! ### Chromatographic transport (J1 validation scenario)
+//! oxiflow covers any problem expressible as the canonical form above.
 //!
-//! A solute migrating through a packed column under applied flow velocity `v`:
+//! | Domain | Primary field `u` | Milestone |
+//! |---|---|---|
+//! | Chromatographic transport | concentration `c(z,t)` | J1 |
+//! | Transient heat conduction | temperature `T(x,t)` | J2+ |
+//! | Reaction-diffusion | species `(u,v)` | J2+ |
+//! | Flow in porous media (Darcy) | water content `θ` | J2+ |
+//! | Shallow water (Saint-Venant) | depth `h`, momentum `hv` | J3 |
+//! | Electrochemical (Nernst-Planck) | ionic concentrations `cᵢ` | J3+ |
+//! | Resistive magnetic diffusion | flux density `B` | J7 |
+//! | Structural dynamics | displacement `u`, velocity `v` | J4+ |
 //!
-//! $$\frac{\partial c}{\partial t} + v\frac{\partial c}{\partial z} = D_{ax}\frac{\partial^2 c}{\partial z^2} - F_{\text{ads}}(c)$$
-//!
-//! - `u = c(z,t)` — concentration profile along the column axis
-//! - `F = v·c − D_ax·∂c/∂z` — convective + axial dispersion flux
-//! - `S = −F_ads(c)` — adsorption term (Langmuir, SMA, Thomas isotherm)
-//! - Boundary conditions: Danckwerts (Robin inlet + Neumann outlet)
-//!   or simplified Dirichlet
-//!
-//! ### Transient heat conduction
-//!
-//! Heat diffusion in a solid or fluid medium:
-//!
-//! $$\rho C_p \frac{\partial T}{\partial t} = \nabla \cdot (\lambda \nabla T) + Q(\mathbf{x}, t)$$
-//!
-//! - `u = T(x, t)` — temperature field
-//! - `F = −λ·∇T` — Fourier conductive flux
-//! - `S = Q` — internal heat source (Joule heating, chemical reaction)
-//! - Boundary conditions: Dirichlet (fixed temperature), Neumann (fixed flux),
-//!   Robin (convective exchange `h·(T − T_∞)`)
-//!
-//! ### Reaction-diffusion systems
-//!
-//! Two or more coupled species with local reactions (Turing patterns,
-//! Gray-Scott, FitzHugh-Nagumo, oscillating chemistry):
-//!
-//! $$\frac{\partial u}{\partial t} = D_u \nabla^2 u + f(u,v), \qquad \frac{\partial v}{\partial t} = D_v \nabla^2 v + g(u,v)$$
-//!
-//! - `u = (u, v)` — two interacting field components
-//! - `F = −D·∇u` — isotropic diffusion, no advection
-//! - `S = f(u, v)` — nonlinear local kinetics
-//! - Applications: pattern formation in biology, autocatalytic chemistry
-//!
-//! ### Flow in porous media (Darcy / Richards)
-//!
-//! Saturated or unsaturated flow driven by a pressure gradient:
-//!
-//! $$\frac{\partial \theta}{\partial t} = \nabla \cdot \bigl(K(\theta)\,\nabla\psi\bigr)$$
-//!
-//! - `u = θ` — volumetric water content (or hydraulic head)
-//! - `F = −K(θ)·∇ψ` — Darcy flux, nonlinear conductivity
-//! - `S = 0` (or rainfall/extraction source term)
-//! - Applications: groundwater, soil contamination, CO₂ storage
-//!
-//! ### Shallow water flow — gravitational transport
-//!
-//! Depth-averaged flow on a free surface (Saint-Venant equations):
-//!
-//! $$\frac{\partial h}{\partial t} + \nabla \cdot (h\mathbf{v}) = 0$$
-//!
-//! $$\frac{\partial (h\mathbf{v})}{\partial t} + \nabla \cdot (h\mathbf{v} \otimes \mathbf{v}) + g h \nabla \eta = \frac{1}{\rho}\,\boldsymbol{\tau}_b$$
-//!
-//! - `u = (h, h·v)` — water depth and depth-averaged momentum
-//! - `F` — advective + hydrostatic pressure flux
-//! - `S` — bed friction `τ_b`, rainfall, infiltration
-//! - Applications: lahars, tsunamis, dam breaks, coastal flooding
-//!
-//! ### Electrochemical transport (Nernst-Planck)
-//!
-//! Migration and diffusion of ionic species in an electrolyte:
-//!
-//! $$\frac{\partial c_i}{\partial t} = \nabla \cdot \!\left(D_i \nabla c_i + \frac{z_i D_i}{RT}\,c_i \nabla \varphi\right) + R_i(\mathbf{c})$$
-//!
-//! - `u = (cᵢ, φ)` — ionic concentrations and electric potential
-//! - `F` — diffusive + electromigration flux
-//! - `S = Rᵢ(c)` — electrochemical reaction at interfaces
-//! - Applications: batteries, fuel cells, electrodeposition
-//!
-//! ### Resistive magnetic diffusion
-//!
-//! Low-frequency electromagnetic field in a conducting medium (eddy currents):
-//!
-//! $$\frac{\partial B}{\partial t} = \frac{1}{\mu\sigma}\,\nabla^2 B$$
-//!
-//! - `u = B(x, t)` — magnetic flux density
-//! - `F = −(1/μσ)·∇B` — resistive diffusion flux
-//! - `S = 0` — no external source in the resistive limit
-//! - Requires FEM on unstructured meshes for realistic geometries (v2.0, J7)
-//!
-//! ### Structural dynamics (second-order systems)
-//!
-//! Vibrations, wave propagation, and dynamic elasticity:
-//!
-//! $$\frac{\partial^2 u}{\partial t^2} + C(\mathbf{x})\frac{\partial u}{\partial t} + K u = F(\mathbf{x}, t)$$
-//!
-//! Reduced to first-order form by introducing `v = ∂u/∂t`:
-//!
-//! $$\frac{\partial u}{\partial t} = v, \qquad \frac{\partial v}{\partial t} = F - Cv - Ku$$
-//!
-//! - `u = (displacement, velocity)` — two-component state vector
-//! - `S` — applied forces, damping
-//! - Integrators: Newmark-β, HHT-α (planned J4+)
-//! - Applications: structural analysis, seismic response, acoustics
-//!
-//! ### Spectral methods — planned extension (DD-024)
-//!
-//! Spectral methods (Fourier, Chebyshev, Legendre, spherical harmonics) offer
-//! exponential convergence for smooth solutions. They approximate `u` as a sum
-//! of global basis functions rather than nodal values:
-//!
-//! $$u(\mathbf{x}, t) \approx \sum_n \hat{u}_n(t)\,\varphi_n(\mathbf{x})$$
-//!
-//! Spatial operators become matrix multiplications in spectral space
-//! (`∂u/∂x → D·û`) rather than finite differences between neighbours.
-//! This yields accuracy comparable to thousands of FD nodes with only tens
-//! of spectral modes for smooth profiles.
-//!
-//! Their integration raises an open architectural question (DD-024): whether
-//! a `SpectralBasis` should implement the existing `Mesh` trait or introduce
-//! a parallel `Basis` trait alongside it. This decision is deferred to J7+.
-//!
-//! Relevant domains: global atmospheric modelling (spherical harmonics),
-//! turbulence DNS, high-precision chromatography, acoustics.
+//! For full equations, physical derivations, and numerical details,
+//! see the **[project wiki](https://github.com/biface/oxiflow/wiki)**.
 //!
 //! ## Numerical structure
 //!
-//! In each case above, `u` changes physical meaning, but the numerical
-//! structure is identical: a field discretised on a mesh, fluxes computed
-//! at interfaces or nodes, time integration. This is what the engine abstracts:
+//! In each domain above, `u` changes physical meaning, but the engine abstraction
+//! is identical:
 //!
-//! ```text
-//! Physical concept           Engine abstraction
-//! ─────────────────          ──────────────────────────────────────────
-//! field u(x, t)         →    ContextValue::ScalarField / VectorField
-//! spatial domain        →    Mesh (INV-1) — UniformGrid1D (J1), FEM (J7)
-//! flux F, source S      →    PhysicalModel::compute_physics(u, ctx)
-//! auxiliary quantities  →    ComputeContext ← ContextCalculator chain
-//! time integration      →    Solver — Euler, RK4, Newmark… (J4, J4+)
-//! boundary conditions   →    BoundaryCondition: RequiresContext (J2)
-//! multi-domain coupling →    CouplingOperator (INV-3, J3)
-//! spatial operators     →    DiscreteOperator<M: Mesh> (INV-2, J4b)
-//! ```
+//! | Physical concept | Engine abstraction |
+//! |---|---|
+//! | Field `u(x,t)` | `ContextValue::ScalarField` / `VectorField` |
+//! | Spatial domain | `Mesh` (INV-1) — `UniformGrid1D` (J1), FEM (J7) |
+//! | Flux F, source S | `PhysicalModel::compute_physics(u, ctx)` |
+//! | Auxiliary quantities | `ComputeContext` ← `ContextCalculator` chain |
+//! | Time integration | `Solver` — Euler, RK4, … (J4) |
+//! | Boundary conditions | `BoundaryCondition: RequiresContext` (J2) |
+//! | Multi-domain coupling | `CouplingOperator` (INV-3, J3) |
+//! | Spatial operators | `DiscreteOperator<M: Mesh>` (INV-2, J4b) |
 //!
 //! ## Architecture — WHAT / HOW separation
 //!
@@ -178,16 +74,14 @@
 //!
 //! 1. Context calculators populate [`context::ComputeContext`]
 //! 2. Boundary conditions are applied to the current state (J2)
-//! 3. [`model::PhysicalModel::compute_physics`] computes `du/dt`
+//! 3. [`model::PhysicalModel::compute`] computes `du/dt`
 //! 4. The integrator advances the state by `dt`
 //!
 //! ## Modules
 //!
 //! - [`context`]   — [`context::ContextVariable`], [`context::ContextValue`],
-//!   [`context::OxiflowError`], [`context::ComputeContext`],
-//!   [`context::ContextCalculator`]
-//! - [`mesh`]      — [`mesh::Mesh`] trait (INV-1) and
-//!   [`mesh::UniformGrid1D`] (J1)
+//!   [`context::OxiflowError`], [`context::ComputeContext`], [`context::ContextCalculator`]
+//! - [`mesh`]      — [`mesh::Mesh`] trait (INV-1) and [`mesh::UniformGrid1D`] (J1)
 //! - [`model`]     — [`model::RequiresContext`] and [`model::PhysicalModel`]
 //! - [`solver`]    — [`solver::Scenario`], [`solver::SolverConfiguration`],
 //!   [`solver::Solver`], [`solver::SimulationResult`]
@@ -240,6 +134,7 @@
 //! // 4. Solve (J4 — integrator implementations land at v0.4.0)
 //! // let result = EulerSolver.solve(&scenario, &config)?;
 //! ```
+
 pub mod boundary;
 pub mod context;
 pub mod coupling;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,46 +1,245 @@
 //! # oxiflow
 //!
-//! Generic engine for solving partial differential equations of the form:
+//! Generic numerical engine for transport, reaction, and diffusion problems.
+//!
+//! ## The canonical form
+//!
+//! Every problem solved by oxiflow is expressed as a conservation law or field
+//! equation of the form:
+//!
+//! $$\frac{\partial u}{\partial t} + \nabla \cdot F(u, \nabla u) = S(u, \mathbf{x}, t)$$
+//!
+//! where:
+//!
+//! - **`u(x, t)`** — the primary field: concentration, temperature, velocity,
+//!   pressure, magnetic flux density, or any other quantity that evolves in
+//!   time and space.
+//! - **`F(u, ∇u)`** — the flux tensor, which may combine:
+//!   - *advective* flux `v·u` (transport by a flow field),
+//!   - *diffusive* flux `-D·∇u` (Fick, Fourier, Darcy),
+//!   - *dispersive* flux (higher-order spreading, e.g. in chromatography).
+//! - **`S(u, x, t)`** — source or reaction term: chemical reactions, heat
+//!   generation, gravity, electromagnetic forcing, adsorption isotherms.
+//!
+//! Second-order-in-time problems (`∂²u/∂t²`, structural dynamics, wave
+//! propagation) are reduced to this form by introducing `v = ∂u/∂t` as a
+//! second field component: the state `(u, v)` evolves as a first-order
+//! system. Newmark-β and HHT-α integrators are planned for J4+.
+//!
+//! ## Physical domains
+//!
+//! ### Chromatographic transport (J1 validation scenario)
+//!
+//! A solute migrating through a packed column under applied flow velocity `v`:
+//!
+//! $$\frac{\partial c}{\partial t} + v\frac{\partial c}{\partial z} = D_{ax}\frac{\partial^2 c}{\partial z^2} - F_{\text{ads}}(c)$$
+//!
+//! - `u = c(z,t)` — concentration profile along the column axis
+//! - `F = v·c − D_ax·∂c/∂z` — convective + axial dispersion flux
+//! - `S = −F_ads(c)` — adsorption term (Langmuir, SMA, Thomas isotherm)
+//! - Boundary conditions: Danckwerts (Robin inlet + Neumann outlet)
+//!   or simplified Dirichlet
+//!
+//! ### Transient heat conduction
+//!
+//! Heat diffusion in a solid or fluid medium:
+//!
+//! $$\rho C_p \frac{\partial T}{\partial t} = \nabla \cdot (\lambda \nabla T) + Q(\mathbf{x}, t)$$
+//!
+//! - `u = T(x, t)` — temperature field
+//! - `F = −λ·∇T` — Fourier conductive flux
+//! - `S = Q` — internal heat source (Joule heating, chemical reaction)
+//! - Boundary conditions: Dirichlet (fixed temperature), Neumann (fixed flux),
+//!   Robin (convective exchange `h·(T − T_∞)`)
+//!
+//! ### Reaction-diffusion systems
+//!
+//! Two or more coupled species with local reactions (Turing patterns,
+//! Gray-Scott, FitzHugh-Nagumo, oscillating chemistry):
+//!
+//! $$\frac{\partial u}{\partial t} = D_u \nabla^2 u + f(u,v), \qquad \frac{\partial v}{\partial t} = D_v \nabla^2 v + g(u,v)$$
+//!
+//! - `u = (u, v)` — two interacting field components
+//! - `F = −D·∇u` — isotropic diffusion, no advection
+//! - `S = f(u, v)` — nonlinear local kinetics
+//! - Applications: pattern formation in biology, autocatalytic chemistry
+//!
+//! ### Flow in porous media (Darcy / Richards)
+//!
+//! Saturated or unsaturated flow driven by a pressure gradient:
+//!
+//! $$\frac{\partial \theta}{\partial t} = \nabla \cdot \bigl(K(\theta)\,\nabla\psi\bigr)$$
+//!
+//! - `u = θ` — volumetric water content (or hydraulic head)
+//! - `F = −K(θ)·∇ψ` — Darcy flux, nonlinear conductivity
+//! - `S = 0` (or rainfall/extraction source term)
+//! - Applications: groundwater, soil contamination, CO₂ storage
+//!
+//! ### Shallow water flow — gravitational transport
+//!
+//! Depth-averaged flow on a free surface (Saint-Venant equations):
+//!
+//! $$\frac{\partial h}{\partial t} + \nabla \cdot (h\mathbf{v}) = 0$$
+//!
+//! $$\frac{\partial (h\mathbf{v})}{\partial t} + \nabla \cdot (h\mathbf{v} \otimes \mathbf{v}) + g h \nabla \eta = \frac{1}{\rho}\,\boldsymbol{\tau}_b$$
+//!
+//! - `u = (h, h·v)` — water depth and depth-averaged momentum
+//! - `F` — advective + hydrostatic pressure flux
+//! - `S` — bed friction `τ_b`, rainfall, infiltration
+//! - Applications: lahars, tsunamis, dam breaks, coastal flooding
+//!
+//! ### Electrochemical transport (Nernst-Planck)
+//!
+//! Migration and diffusion of ionic species in an electrolyte:
+//!
+//! $$\frac{\partial c_i}{\partial t} = \nabla \cdot \!\left(D_i \nabla c_i + \frac{z_i D_i}{RT}\,c_i \nabla \varphi\right) + R_i(\mathbf{c})$$
+//!
+//! - `u = (cᵢ, φ)` — ionic concentrations and electric potential
+//! - `F` — diffusive + electromigration flux
+//! - `S = Rᵢ(c)` — electrochemical reaction at interfaces
+//! - Applications: batteries, fuel cells, electrodeposition
+//!
+//! ### Resistive magnetic diffusion
+//!
+//! Low-frequency electromagnetic field in a conducting medium (eddy currents):
+//!
+//! $$\frac{\partial B}{\partial t} = \frac{1}{\mu\sigma}\,\nabla^2 B$$
+//!
+//! - `u = B(x, t)` — magnetic flux density
+//! - `F = −(1/μσ)·∇B` — resistive diffusion flux
+//! - `S = 0` — no external source in the resistive limit
+//! - Requires FEM on unstructured meshes for realistic geometries (v2.0, J7)
+//!
+//! ### Structural dynamics (second-order systems)
+//!
+//! Vibrations, wave propagation, and dynamic elasticity:
+//!
+//! $$\frac{\partial^2 u}{\partial t^2} + C(\mathbf{x})\frac{\partial u}{\partial t} + K u = F(\mathbf{x}, t)$$
+//!
+//! Reduced to first-order form by introducing `v = ∂u/∂t`:
+//!
+//! $$\frac{\partial u}{\partial t} = v, \qquad \frac{\partial v}{\partial t} = F - Cv - Ku$$
+//!
+//! - `u = (displacement, velocity)` — two-component state vector
+//! - `S` — applied forces, damping
+//! - Integrators: Newmark-β, HHT-α (planned J4+)
+//! - Applications: structural analysis, seismic response, acoustics
+//!
+//! ### Spectral methods — planned extension (DD-024)
+//!
+//! Spectral methods (Fourier, Chebyshev, Legendre, spherical harmonics) offer
+//! exponential convergence for smooth solutions. They approximate `u` as a sum
+//! of global basis functions rather than nodal values:
+//!
+//! $$u(\mathbf{x}, t) \approx \sum_n \hat{u}_n(t)\,\varphi_n(\mathbf{x})$$
+//!
+//! Spatial operators become matrix multiplications in spectral space
+//! (`∂u/∂x → D·û`) rather than finite differences between neighbours.
+//! This yields accuracy comparable to thousands of FD nodes with only tens
+//! of spectral modes for smooth profiles.
+//!
+//! Their integration raises an open architectural question (DD-024): whether
+//! a `SpectralBasis` should implement the existing `Mesh` trait or introduce
+//! a parallel `Basis` trait alongside it. This decision is deferred to J7+.
+//!
+//! Relevant domains: global atmospheric modelling (spherical harmonics),
+//! turbulence DNS, high-precision chromatography, acoustics.
+//!
+//! ## Numerical structure
+//!
+//! In each case above, `u` changes physical meaning, but the numerical
+//! structure is identical: a field discretised on a mesh, fluxes computed
+//! at interfaces or nodes, time integration. This is what the engine abstracts:
 //!
 //! ```text
-//! ∂u/∂t + ∇·F(u, ∇u) = S(u, x, t)
+//! Physical concept           Engine abstraction
+//! ─────────────────          ──────────────────────────────────────────
+//! field u(x, t)         →    ContextValue::ScalarField / VectorField
+//! spatial domain        →    Mesh (INV-1) — UniformGrid1D (J1), FEM (J7)
+//! flux F, source S      →    PhysicalModel::compute_physics(u, ctx)
+//! auxiliary quantities  →    ComputeContext ← ContextCalculator chain
+//! time integration      →    Solver — Euler, RK4, Newmark… (J4, J4+)
+//! boundary conditions   →    BoundaryCondition: RequiresContext (J2)
+//! multi-domain coupling →    CouplingOperator (INV-3, J3)
+//! spatial operators     →    DiscreteOperator<M: Mesh> (INV-2, J4b)
 //! ```
 //!
-//! where `u` is a physical field (concentration, temperature, velocity…),
-//! `F` a flux (advective, diffusive, dispersive) and `S` a source or reaction term.
+//! ## Architecture — WHAT / HOW separation
 //!
-//! ## Architecture — separation WHAT/HOW
+//! Three strictly separated responsibilities:
 //!
-//! The engine enforces three strictly separated responsibility levels:
+//! | Type | Pole | Role |
+//! |---|---|---|
+//! | [`solver::Scenario`] | WHAT | Declares the problem: model, mesh, domains, BCs |
+//! | [`solver::SolverConfiguration`] | HOW | Configures solving: integrator, step control, calculators |
+//! | [`solver::Solver`] | Execution | Orchestrates the time integration loop |
 //!
-//! | Type | Role |
-//! |---|---|
-//! | `Scenario` | Declares the problem |
-//! | `SolverConfiguration` | Configures the solving |
-//! | `Solver` | Orchestrates execution |
+//! The engine enforces a **contractual execution order** at each time step:
+//!
+//! 1. Context calculators populate [`context::ComputeContext`]
+//! 2. Boundary conditions are applied to the current state (J2)
+//! 3. [`model::PhysicalModel::compute_physics`] computes `du/dt`
+//! 4. The integrator advances the state by `dt`
 //!
 //! ## Modules
 //!
-//! - [`context`]   — Variables and calculators (DD-003–DD-006)
-//! - [`mesh`]      — Mesh abstraction (INV-1, DD-007)
-//! - [`model`]     — Physical models
-//! - [`boundary`]  — Boundary conditions (DD-008)
-//! - [`solver`]    — Numerical orchestration
-//! - [`operators`] — Discrete operators (INV-2, DD-012)
-//! - [`coupling`]  — Multi-domain coupling (INV-3, DD-011)
+//! - [`context`]   — [`context::ContextVariable`], [`context::ContextValue`],
+//!   [`context::OxiflowError`], [`context::ComputeContext`],
+//!   [`context::ContextCalculator`]
+//! - [`mesh`]      — [`mesh::Mesh`] trait (INV-1) and
+//!   [`mesh::UniformGrid1D`] (J1)
+//! - [`model`]     — [`model::RequiresContext`] and [`model::PhysicalModel`]
+//! - [`solver`]    — [`solver::Scenario`], [`solver::SolverConfiguration`],
+//!   [`solver::Solver`], [`solver::SimulationResult`]
+//! - [`boundary`]  — `BoundaryCondition` trait (J2)
+//! - [`operators`] — `DiscreteOperator<M: Mesh>` (INV-2, J4b)
+//! - [`coupling`]  — `CouplingOperator` (INV-3, J3)
 //!
-//! ## Invariants FEM anticipated
+//! ## FEM invariants — forward compatibility
 //!
-//! v0.x abstractions do not presuppose a structured grid, ensuring forward compatibility
-//! with the FEM support planned at v2.0.
+//! All abstractions from v0.1 are designed to extend naturally to FEM at
+//! v2.0 without any breaking change on existing code.
 //!
-//! | Invariant | Description | Active from |
+//! | Invariant | Guarantee | Active from |
 //! |---|---|---|
-//! | INV-1 | Abstract `Mesh` — zero `dx`/`nx` in public API | v0.1.0 |
-//! | INV-2 | `DiscreteOperator<M: Mesh>` — integrators decoupled from the scheme | v0.5.0 |
-//! | INV-3 | `CouplingOperator` — explicit inter-domain coupling | v0.3.0 |
-//! | INV-4 | Plugin-safe API — object-safe traits from external crates | v2.0.0 |
-
+//! | INV-1 | No `dx`/`nx` in public API — all spatial access via [`mesh::Mesh`] | v0.1.0 |
+//! | INV-2 | Integrators decoupled from spatial scheme via `DiscreteOperator<M>` | v0.5.0 |
+//! | INV-3 | Inter-domain coupling only via `CouplingOperator` | v0.3.0 |
+//! | INV-4 | All public traits object-safe — external crates can implement them | v2.0.0 |
+//!
+//! ## Getting started (J1)
+//!
+//! ```rust,ignore
+//! use oxiflow::{
+//!     context::ContextVariable,
+//!     mesh::{Mesh, UniformGrid1D},
+//!     model::{PhysicalModel, RequiresContext},
+//!     solver::{Scenario, SolverConfiguration, TimeConfiguration,
+//!              StepControl, IntegratorKind},
+//! };
+//!
+//! // 1. Declare the physical model
+//! struct MyModel;
+//! impl RequiresContext for MyModel {
+//!     fn required_variables(&self) -> Vec<ContextVariable> {
+//!         vec![ContextVariable::Time]
+//!     }
+//! }
+//! impl PhysicalModel for MyModel { /* … */ }
+//!
+//! // 2. Declare the problem (WHAT)
+//! let mesh = UniformGrid1D::new(100, 0.0, 1.0).unwrap();
+//! let scenario = Scenario::single(Box::new(MyModel), Box::new(mesh));
+//!
+//! // 3. Configure solving (HOW)
+//! let config = SolverConfiguration::new(
+//!     TimeConfiguration::new(600.0, StepControl::Fixed { dt: 0.1 }),
+//!     IntegratorKind::Euler,
+//! );
+//!
+//! // 4. Solve (J4 — integrator implementations land at v0.4.0)
+//! // let result = EulerSolver.solve(&scenario, &config)?;
+//! ```
 pub mod boundary;
 pub mod context;
 pub mod coupling;
@@ -49,13 +248,8 @@ pub mod model;
 pub mod operators;
 pub mod solver;
 
-// ── Tests ────────────────────────────────────────────────────────────────────
-
 #[cfg(test)]
 mod tests {
-    // Placeholder test — ensures llvm-cov generates a valid profdata
-    // even when no module is implemented yet.
-    // Remove once the first J1 tests are in place.
     #[test]
     fn placeholder() {}
 }

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -1,18 +1,108 @@
 //! # Module `mesh`
 //!
-//! Spatial mesh abstraction — INV-1 invariant.
+//! Spatial mesh abstraction — INV-1 invariant (DD-007, DD-019, issue #31).
 //!
 //! ## Core principle (INV-1)
 //!
 //! No public engine API exposes `dx`, `nx` or raw indices as first-class spatial
-//! parameters. All spatial references go through the `Mesh` trait, of which
-//! `UniformGrid1D` will be the first implementation (J1, v0.2) and unstructured
-//! FEM meshes the second (J7, v2.0).
+//! parameters. All spatial references go through the `Mesh` trait. This guarantees
+//! forward compatibility with FEM unstructured meshes at J7 — zero breaking change
+//! on existing code when `unstructured/` is added.
 //!
-//! ## Planned implementations
+//! ## Module hierarchy (DD-019)
 //!
-//! | Type | Description | Milestone |
-//! |---|---|---|
-//! | `UniformGrid1D` | 1D uniform grid | J1 — v0.2 |
-//! | `UnstructuredMesh2D` | 2D triangular mesh | J7 — v2.0 |
-//! | `TetrahedralMesh3D` | 3D tetrahedral mesh | J7 — v2.0 |
+//! ```text
+//! src/mesh/
+//! ├── mod.rs              — Mesh trait + public re-exports
+//! ├── structured/
+//! │   └── mod.rs          — UniformGrid1D (J1); UniformGrid2D (J4b+)
+//! └── unstructured/       — RESERVED J7 (UnstructuredMesh2D, TetrahedralMesh3D)
+//! ```
+//!
+//! ## Implementations
+//!
+//! | Type | Family | Description | Milestone |
+//! |---|---|---|---|
+//! | [`UniformGrid1D`] | structured | 1D uniform grid, FD/FV | J1 — v0.1.0 |
+//! | `UnstructuredMesh2D` | unstructured | 2D triangular mesh, FEM | J7 — v2.0.0 |
+//! | `TetrahedralMesh3D` | unstructured | 3D tetrahedral mesh, FEM | J7 — v2.0.0 |
+
+pub mod structured;
+
+// unstructured/ — RESERVED J7
+// pub mod unstructured;
+
+// ── Public re-exports ─────────────────────────────────────────────────────────
+
+pub use structured::UniformGrid1D;
+
+// ── Mesh trait ────────────────────────────────────────────────────────────────
+
+/// Abstract spatial mesh — INV-1 invariant.
+///
+/// All spatial information consumed by the engine passes through this trait.
+/// No implementation detail (`dx`, `nx`, node table) leaks into the public API.
+///
+/// # Object safety
+///
+/// This trait is object-safe: it can be used as `Box<dyn Mesh>` and `&dyn Mesh`.
+/// Required for INV-4 (plugin-safe API, J7).
+///
+/// # Implementing `Mesh`
+///
+/// A minimal implementation for a 1D uniform grid:
+///
+/// ```rust
+/// use oxiflow::mesh::Mesh;
+///
+/// struct MyGrid { n: usize, dx: f64 }
+///
+/// impl Mesh for MyGrid {
+///     fn n_dof(&self) -> usize { self.n }
+///     fn coordinates(&self, i: usize) -> &[f64] {
+///         // In practice, return a slice into a pre-computed node table.
+///         // This example uses a workaround for illustration only.
+///         std::slice::from_ref(Box::leak(Box::new(i as f64 * self.dx)))
+///     }
+///     fn spatial_dimension(&self) -> usize { 1 }
+///     fn characteristic_length(&self) -> f64 { self.dx }
+/// }
+/// ```
+///
+/// # INV-1 compliance
+///
+/// Implementations must **not** expose `dx`, `nx` or raw indices in any public
+/// method beyond those defined here. Spatial parameters are internal details.
+pub trait Mesh: Send + Sync {
+    /// Total number of degrees of freedom (nodes) in the mesh.
+    ///
+    /// For a 1D uniform grid: `n_dof() == n_points`.
+    /// For a 2D FEM mesh: `n_dof()` is the number of mesh nodes.
+    fn n_dof(&self) -> usize;
+
+    /// Coordinates of node `i` as a slice of length `spatial_dimension()`.
+    ///
+    /// Returns `&[f64]` — zero allocation. Callers must not store the returned
+    /// reference beyond the lifetime of the mesh. Implementors typically return
+    /// a slice into a pre-computed node coordinate table.
+    ///
+    /// # Panics
+    ///
+    /// Implementations may panic if `i >= n_dof()`. Use `n_dof()` to guard
+    /// iteration bounds.
+    fn coordinates(&self, i: usize) -> &[f64];
+
+    /// Number of spatial dimensions of this mesh.
+    ///
+    /// - `1` for 1D grids (chromatography column, 1D heat transfer)
+    /// - `2` for 2D meshes (surface flow, 2D diffusion)
+    /// - `3` for 3D meshes (volumetric FEM)
+    fn spatial_dimension(&self) -> usize;
+
+    /// A representative spatial length scale of the mesh.
+    ///
+    /// Used by integrators and operators for stability estimates (CFL condition,
+    /// Péclet number). For a uniform 1D grid: `dx`. For unstructured meshes:
+    /// the minimum element diameter or average edge length.
+    fn characteristic_length(&self) -> f64;
+}

--- a/src/mesh/structured/mod.rs
+++ b/src/mesh/structured/mod.rs
@@ -1,0 +1,322 @@
+//! # Module `mesh::structured`
+//!
+//! Structured mesh implementations — uniform grids for FD/FV schemes (DD-019).
+//!
+//! ## J1 (v0.1.0)
+//!
+//! - [`UniformGrid1D`] — 1D uniform grid, the first `Mesh` implementation.
+//!
+//! ## Future (J4b+)
+//!
+//! - `UniformGrid2D` — 2D Cartesian grid for 2D FD/FV problems.
+
+use crate::mesh::Mesh;
+
+/// 1D uniform grid — first concrete implementation of [`Mesh`] (INV-1, J1).
+///
+/// Nodes are evenly spaced at positions `x_i = x_start + i * dx` for
+/// `i = 0..n_points`. The coordinate table is pre-computed at construction
+/// so that `coordinates(i)` returns a zero-allocation slice.
+///
+/// # Invariant compliance (INV-1)
+///
+/// `dx` and `n_points` are private. Callers access spatial information only
+/// through the `Mesh` trait methods — `n_dof()`, `coordinates()`,
+/// `spatial_dimension()`, `characteristic_length()`.
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::mesh::{Mesh, UniformGrid1D};
+///
+/// let grid = UniformGrid1D::new(5, 0.0, 1.0).unwrap();
+///
+/// assert_eq!(grid.n_dof(), 5);
+/// assert_eq!(grid.spatial_dimension(), 1);
+/// assert!((grid.characteristic_length() - 0.25).abs() < 1e-12);
+///
+/// // Coordinates: 0.0, 0.25, 0.50, 0.75, 1.0
+/// assert!((grid.coordinates(0)[0] - 0.0).abs() < 1e-12);
+/// assert!((grid.coordinates(2)[0] - 0.5).abs() < 1e-12);
+/// assert!((grid.coordinates(4)[0] - 1.0).abs() < 1e-12);
+/// ```
+#[derive(Debug)]
+pub struct UniformGrid1D {
+    /// Number of nodes.
+    n_points: usize,
+    /// Spatial step — private per INV-1.
+    dx: f64,
+    /// Pre-computed node coordinates, length = n_points.
+    nodes: Vec<[f64; 1]>,
+}
+
+impl UniformGrid1D {
+    /// Creates a uniform 1D grid with `n_points` nodes from `x_start` to `x_end`.
+    ///
+    /// Node positions: `x_i = x_start + i * dx` where `dx = (x_end - x_start) / (n_points - 1)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if:
+    /// - `n_points < 2` — a grid must have at least 2 nodes.
+    /// - `x_end <= x_start` — the domain must be non-degenerate.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use oxiflow::mesh::UniformGrid1D;
+    ///
+    /// let grid = UniformGrid1D::new(100, 0.0, 1.0).unwrap();
+    /// assert_eq!(grid.n_dof(), 100);
+    ///
+    /// assert!(UniformGrid1D::new(1, 0.0, 1.0).is_err()); // n_points < 2
+    /// assert!(UniformGrid1D::new(10, 1.0, 0.0).is_err()); // x_end <= x_start
+    /// ```
+    pub fn new(n_points: usize, x_start: f64, x_end: f64) -> Result<Self, String> {
+        if n_points < 2 {
+            return Err(format!(
+                "UniformGrid1D requires at least 2 nodes, got {}",
+                n_points
+            ));
+        }
+        if x_end <= x_start {
+            return Err(format!(
+                "UniformGrid1D requires x_end > x_start, got [{}, {}]",
+                x_start, x_end
+            ));
+        }
+
+        let dx = (x_end - x_start) / (n_points - 1) as f64;
+        let nodes = (0..n_points).map(|i| [x_start + i as f64 * dx]).collect();
+
+        Ok(Self {
+            n_points,
+            dx,
+            nodes,
+        })
+    }
+}
+
+impl Mesh for UniformGrid1D {
+    fn n_dof(&self) -> usize {
+        self.n_points
+    }
+
+    /// Returns the coordinate of node `i` as a single-element slice `[x_i]`.
+    ///
+    /// Zero allocation — the slice points into the pre-computed `nodes` table.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `i >= n_dof()`.
+    fn coordinates(&self, i: usize) -> &[f64] {
+        &self.nodes[i]
+    }
+
+    fn spatial_dimension(&self) -> usize {
+        1
+    }
+
+    /// Returns `dx` — the uniform node spacing.
+    ///
+    /// Used by integrators for CFL and Péclet estimates.
+    fn characteristic_length(&self) -> f64 {
+        self.dx
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Construction ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn new_valid_grid_succeeds() {
+        let grid = UniformGrid1D::new(5, 0.0, 1.0).unwrap();
+        assert_eq!(grid.n_dof(), 5);
+    }
+
+    #[test]
+    fn new_with_one_node_fails() {
+        assert!(UniformGrid1D::new(1, 0.0, 1.0).is_err());
+    }
+
+    #[test]
+    fn new_with_zero_nodes_fails() {
+        assert!(UniformGrid1D::new(0, 0.0, 1.0).is_err());
+    }
+
+    #[test]
+    fn new_with_reversed_domain_fails() {
+        assert!(UniformGrid1D::new(10, 1.0, 0.0).is_err());
+    }
+
+    #[test]
+    fn new_with_equal_bounds_fails() {
+        assert!(UniformGrid1D::new(10, 0.5, 0.5).is_err());
+    }
+
+    #[test]
+    fn error_message_mentions_constraint() {
+        let err = UniformGrid1D::new(1, 0.0, 1.0).unwrap_err();
+        assert!(err.contains("2"));
+        let err = UniformGrid1D::new(10, 1.0, 0.0).unwrap_err();
+        assert!(err.contains("x_end"));
+    }
+
+    // ── n_dof ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn n_dof_equals_n_points() {
+        for n in [2, 10, 100, 1000] {
+            let grid = UniformGrid1D::new(n, 0.0, 1.0).unwrap();
+            assert_eq!(grid.n_dof(), n);
+        }
+    }
+
+    // ── coordinates ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn first_node_at_x_start() {
+        let grid = UniformGrid1D::new(5, 0.0, 1.0).unwrap();
+        assert!((grid.coordinates(0)[0] - 0.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn last_node_at_x_end() {
+        let grid = UniformGrid1D::new(5, 0.0, 1.0).unwrap();
+        assert!((grid.coordinates(4)[0] - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn middle_node_correctly_positioned() {
+        let grid = UniformGrid1D::new(5, 0.0, 1.0).unwrap();
+        // dx = 0.25 → node 2 at 0.5
+        assert!((grid.coordinates(2)[0] - 0.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn coordinates_with_non_zero_x_start() {
+        let grid = UniformGrid1D::new(3, 1.0, 3.0).unwrap();
+        // dx = 1.0 → nodes at 1.0, 2.0, 3.0
+        assert!((grid.coordinates(0)[0] - 1.0).abs() < 1e-12);
+        assert!((grid.coordinates(1)[0] - 2.0).abs() < 1e-12);
+        assert!((grid.coordinates(2)[0] - 3.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn coordinates_slice_has_length_one() {
+        let grid = UniformGrid1D::new(5, 0.0, 1.0).unwrap();
+        for i in 0..grid.n_dof() {
+            assert_eq!(grid.coordinates(i).len(), 1);
+        }
+    }
+
+    #[test]
+    fn coordinates_are_strictly_increasing() {
+        let grid = UniformGrid1D::new(10, 0.0, 1.0).unwrap();
+        for i in 1..grid.n_dof() {
+            assert!(grid.coordinates(i)[0] > grid.coordinates(i - 1)[0]);
+        }
+    }
+
+    #[test]
+    fn coordinates_zero_allocation_returns_reference() {
+        // Verify coordinates() returns a slice into the node table,
+        // not a newly allocated Vec — checked by testing two calls return
+        // the same pointer for the same index.
+        let grid = UniformGrid1D::new(5, 0.0, 1.0).unwrap();
+        let ptr1 = grid.coordinates(2).as_ptr();
+        let ptr2 = grid.coordinates(2).as_ptr();
+        assert_eq!(ptr1, ptr2);
+    }
+
+    #[test]
+    #[should_panic]
+    fn coordinates_out_of_bounds_panics() {
+        let grid = UniformGrid1D::new(5, 0.0, 1.0).unwrap();
+        let _ = grid.coordinates(5); // index == n_dof → panic
+    }
+
+    // ── spatial_dimension ─────────────────────────────────────────────────────
+
+    #[test]
+    fn spatial_dimension_is_one() {
+        let grid = UniformGrid1D::new(10, 0.0, 1.0).unwrap();
+        assert_eq!(grid.spatial_dimension(), 1);
+    }
+
+    // ── characteristic_length ─────────────────────────────────────────────────
+
+    #[test]
+    fn characteristic_length_equals_dx() {
+        // 5 nodes over [0, 1] → dx = 0.25
+        let grid = UniformGrid1D::new(5, 0.0, 1.0).unwrap();
+        assert!((grid.characteristic_length() - 0.25).abs() < 1e-12);
+    }
+
+    #[test]
+    fn characteristic_length_halves_when_doubling_nodes() {
+        let coarse = UniformGrid1D::new(5, 0.0, 1.0).unwrap();
+        let fine = UniformGrid1D::new(9, 0.0, 1.0).unwrap();
+        let ratio = coarse.characteristic_length() / fine.characteristic_length();
+        assert!((ratio - 2.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn characteristic_length_scales_with_domain() {
+        let unit = UniformGrid1D::new(5, 0.0, 1.0).unwrap();
+        let large = UniformGrid1D::new(5, 0.0, 4.0).unwrap();
+        let ratio = large.characteristic_length() / unit.characteristic_length();
+        assert!((ratio - 4.0).abs() < 1e-12);
+    }
+
+    // ── Mesh trait via dyn ────────────────────────────────────────────────────
+
+    #[test]
+    fn usable_as_dyn_mesh() {
+        let grid: Box<dyn Mesh> = Box::new(UniformGrid1D::new(10, 0.0, 1.0).unwrap());
+        assert_eq!(grid.n_dof(), 10);
+        assert_eq!(grid.spatial_dimension(), 1);
+        assert!((grid.characteristic_length() - 1.0 / 9.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn mesh_vec_of_different_grids() {
+        let grids: Vec<Box<dyn Mesh>> = vec![
+            Box::new(UniformGrid1D::new(10, 0.0, 1.0).unwrap()),
+            Box::new(UniformGrid1D::new(50, 0.0, 0.25).unwrap()),
+        ];
+        assert_eq!(grids[0].n_dof(), 10);
+        assert_eq!(grids[1].n_dof(), 50);
+    }
+
+    // ── Send + Sync ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn uniform_grid_1d_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<UniformGrid1D>();
+    }
+
+    // ── INV-1 — no dx/n_points in public API ──────────────────────────────────
+
+    #[test]
+    fn inv1_dx_not_accessible_directly() {
+        // This test documents INV-1 compliance: the only way to get dx is
+        // via characteristic_length(). There is no public `grid.dx` field.
+        let grid = UniformGrid1D::new(5, 0.0, 1.0).unwrap();
+        let dx = grid.characteristic_length(); // the only correct path
+        assert!((dx - 0.25).abs() < 1e-12);
+    }
+
+    #[test]
+    fn inv1_n_points_not_accessible_directly() {
+        // The only way to get the number of nodes is via n_dof().
+        let grid = UniformGrid1D::new(7, 0.0, 1.0).unwrap();
+        assert_eq!(grid.n_dof(), 7);
+    }
+}

--- a/src/mesh/structured/mod.rs
+++ b/src/mesh/structured/mod.rs
@@ -64,7 +64,7 @@ impl UniformGrid1D {
     /// # Examples
     ///
     /// ```rust
-    /// use oxiflow::mesh::UniformGrid1D;
+    /// use oxiflow::mesh::{Mesh, UniformGrid1D};
     ///
     /// let grid = UniformGrid1D::new(100, 0.0, 1.0).unwrap();
     /// assert_eq!(grid.n_dof(), 100);

--- a/src/mesh/structured/mod.rs
+++ b/src/mesh/structured/mod.rs
@@ -14,9 +14,13 @@ use crate::mesh::Mesh;
 
 /// 1D uniform grid — first concrete implementation of [`Mesh`] (INV-1, J1).
 ///
-/// Nodes are evenly spaced at positions `x_i = x_start + i * dx` for
-/// `i = 0..n_points`. The coordinate table is pre-computed at construction
-/// so that `coordinates(i)` returns a zero-allocation slice.
+/// Nodes are evenly spaced at positions:
+///
+/// $$x_i = x_{\text{start}} + i \cdot \Delta x, \quad i = 0, \ldots, n-1$$
+///
+/// where $\Delta x = (x_{\text{end}} - x_{\text{start}}) / (n - 1)$.
+/// The coordinate table is pre-computed at construction so that
+/// `coordinates(i)` returns a zero-allocation slice.
 ///
 /// # Invariant compliance (INV-1)
 ///
@@ -53,7 +57,8 @@ pub struct UniformGrid1D {
 impl UniformGrid1D {
     /// Creates a uniform 1D grid with `n_points` nodes from `x_start` to `x_end`.
     ///
-    /// Node positions: `x_i = x_start + i * dx` where `dx = (x_end - x_start) / (n_points - 1)`.
+    /// Node positions: $x_i = x_{\text{start}} + i \cdot \Delta x$
+    /// where $\Delta x = (x_{\text{end}} - x_{\text{start}}) / (n - 1)$.
     ///
     /// # Errors
     ///

--- a/src/mesh/unstructured/mod.rs
+++ b/src/mesh/unstructured/mod.rs
@@ -1,0 +1,14 @@
+//! # Module `mesh::unstructured`
+//!
+//! Unstructured mesh implementations — FEM triangular and tetrahedral meshes.
+//!
+//! **RESERVED — J7 (v2.0.0)**
+//!
+//! This module is intentionally empty at J1. Implementations will be added
+//! at J7 when FEM support lands (DD-007, DD-019):
+//!
+//! - `UnstructuredMesh2D` — 2D triangular mesh (Gmsh/Triangle reader)
+//! - `TetrahedralMesh3D` — 3D tetrahedral mesh
+//!
+//! Adding these types here at J7 requires zero changes to `mesh::structured`
+//! or any existing `Mesh` implementor — that is the point of DD-019.

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,8 +1,12 @@
 //! # Module `model`
 //!
-//! Physical models — `PhysicalModel` trait.
+//! Physical models — `PhysicalModel` trait and component traits.
 //!
 //! A physical model *declares* its context variable needs via `RequiresContext`
 //! and *computes* field `u` derivatives at each time step. It does not configure
 //! the solving nor orchestrate the time loop — those are the responsibilities of
 //! `SolverConfiguration` and `Solver`.
+
+pub mod traits;
+
+pub use traits::RequiresContext;

--- a/src/model/traits.rs
+++ b/src/model/traits.rs
@@ -1,0 +1,233 @@
+//! # Module `model::traits`
+//!
+//! Core traits for physical model components (issue #29, DD-005).
+//!
+//! ## `RequiresContext`
+//!
+//! Standalone trait implemented by any component that needs context variables
+//! during computation: physical models, boundary conditions (J2), source terms,
+//! coupling operators (J3).
+//!
+//! `required_variables()` is **mandatory** — every implementor must declare its
+//! context needs explicitly. Silent omissions are a compiler error, not a runtime
+//! surprise. This enforces the "declarative before implicit" principle (DD-005).
+
+use crate::context::variable::ContextVariable;
+
+/// Declares context variable requirements for any engine component.
+///
+/// Implemented by physical models, boundary conditions (J2), source terms, and
+/// coupling operators (J3). The solver aggregates declarations from all components
+/// before solving and guarantees every required variable is available.
+///
+/// # Mandatory method
+///
+/// `required_variables()` has no default. Every implementor must declare its
+/// required context variables explicitly — even if that declaration is `vec![]`.
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::model::traits::RequiresContext;
+/// use oxiflow::context::variable::ContextVariable;
+///
+/// struct ChromatographyModel;
+///
+/// impl RequiresContext for ChromatographyModel {
+///     fn required_variables(&self) -> Vec<ContextVariable> {
+///         vec![
+///             ContextVariable::Time,
+///             ContextVariable::SpatialGradient { dimension: 0 },
+///         ]
+///     }
+/// }
+///
+/// struct PureAdvection;
+///
+/// impl RequiresContext for PureAdvection {
+///     fn required_variables(&self) -> Vec<ContextVariable> {
+///         vec![]
+///     }
+/// }
+/// ```
+pub trait RequiresContext {
+    /// Returns the context variables this component **must** have available.
+    ///
+    /// The solver raises `OxiflowError::MissingCalculator` before solving if
+    /// any required variable has no registered calculator.
+    ///
+    /// No default implementation — every component must declare explicitly.
+    fn required_variables(&self) -> Vec<ContextVariable>;
+
+    /// Returns context variables this component uses if available, but can work
+    /// without. The solver provides them when calculators are registered.
+    ///
+    /// Default: no optional variables.
+    fn optional_variables(&self) -> Vec<ContextVariable> {
+        vec![]
+    }
+
+    /// Returns variables this component's calculator depends on.
+    ///
+    /// Used by the solver to build the topological execution order (J2, DD-009).
+    /// Declaring dependencies prevents silent ordering bugs when calculators
+    /// depend on each other's output.
+    ///
+    /// Default: no dependencies.
+    fn depends_on(&self) -> Vec<ContextVariable> {
+        vec![]
+    }
+
+    /// Execution priority within the calculator chain.
+    ///
+    /// Lower values run first. Reserved values:
+    /// - `0`   — system variables (Time, TimeStep)
+    /// - `50`  — external data providers
+    /// - `100` — default for derived quantities
+    ///
+    /// Used as fallback when no topological ordering is declared via `depends_on()`.
+    fn priority(&self) -> u32 {
+        100
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Test fixtures ─────────────────────────────────────────────────────────
+
+    struct FullModel;
+    impl RequiresContext for FullModel {
+        fn required_variables(&self) -> Vec<ContextVariable> {
+            vec![
+                ContextVariable::Time,
+                ContextVariable::SpatialGradient { dimension: 0 },
+            ]
+        }
+        fn optional_variables(&self) -> Vec<ContextVariable> {
+            vec![ContextVariable::External { name: "T_amb" }]
+        }
+        fn depends_on(&self) -> Vec<ContextVariable> {
+            vec![ContextVariable::Time]
+        }
+        fn priority(&self) -> u32 {
+            200
+        }
+    }
+
+    struct MinimalModel;
+    impl RequiresContext for MinimalModel {
+        fn required_variables(&self) -> Vec<ContextVariable> {
+            vec![]
+        }
+    }
+
+    struct DefaultsModel;
+    impl RequiresContext for DefaultsModel {
+        fn required_variables(&self) -> Vec<ContextVariable> {
+            vec![ContextVariable::TimeStep]
+        }
+    }
+
+    // ── required_variables ────────────────────────────────────────────────────
+
+    #[test]
+    fn required_variables_returns_declared_variables() {
+        let vars = FullModel.required_variables();
+        assert_eq!(vars.len(), 2);
+        assert!(vars.contains(&ContextVariable::Time));
+        assert!(vars.contains(&ContextVariable::SpatialGradient { dimension: 0 }));
+    }
+
+    #[test]
+    fn required_variables_empty_vec_is_valid() {
+        assert!(MinimalModel.required_variables().is_empty());
+    }
+
+    #[test]
+    fn required_variables_single_variable() {
+        let vars = DefaultsModel.required_variables();
+        assert_eq!(vars.len(), 1);
+        assert_eq!(vars[0], ContextVariable::TimeStep);
+    }
+
+    // ── optional_variables ────────────────────────────────────────────────────
+
+    #[test]
+    fn optional_variables_returns_declared() {
+        let vars = FullModel.optional_variables();
+        assert_eq!(vars.len(), 1);
+        assert_eq!(vars[0], ContextVariable::External { name: "T_amb" });
+    }
+
+    #[test]
+    fn optional_variables_default_is_empty() {
+        assert!(MinimalModel.optional_variables().is_empty());
+        assert!(DefaultsModel.optional_variables().is_empty());
+    }
+
+    // ── depends_on ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn depends_on_returns_declared_dependencies() {
+        let deps = FullModel.depends_on();
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0], ContextVariable::Time);
+    }
+
+    #[test]
+    fn depends_on_default_is_empty() {
+        assert!(MinimalModel.depends_on().is_empty());
+        assert!(DefaultsModel.depends_on().is_empty());
+    }
+
+    // ── priority ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn priority_returns_custom_value() {
+        assert_eq!(FullModel.priority(), 200);
+    }
+
+    #[test]
+    fn priority_default_is_100() {
+        assert_eq!(MinimalModel.priority(), 100);
+        assert_eq!(DefaultsModel.priority(), 100);
+    }
+
+    // ── Object safety ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn trait_is_object_safe() {
+        let model: Box<dyn RequiresContext> = Box::new(FullModel);
+        assert_eq!(model.required_variables().len(), 2);
+        assert_eq!(model.priority(), 200);
+    }
+
+    #[test]
+    fn solver_can_aggregate_all_required_variables() {
+        let components: Vec<Box<dyn RequiresContext>> = vec![
+            Box::new(FullModel),
+            Box::new(MinimalModel),
+            Box::new(DefaultsModel),
+        ];
+        let all_required: Vec<ContextVariable> = components
+            .iter()
+            .flat_map(|c| c.required_variables())
+            .collect();
+        // FullModel(2) + MinimalModel(0) + DefaultsModel(1) = 3
+        assert_eq!(all_required.len(), 3);
+    }
+
+    // ── Send + Sync ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn implementors_are_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<FullModel>();
+        assert_send_sync::<MinimalModel>();
+        assert_send_sync::<DefaultsModel>();
+    }
+}

--- a/src/model/traits.rs
+++ b/src/model/traits.rs
@@ -1,93 +1,139 @@
 //! # Module `model::traits`
 //!
-//! Core traits for physical model components (issue #29, DD-005).
+//! Core traits for physical model components (DD-005, issue #29, #32).
 //!
 //! ## `RequiresContext`
 //!
-//! Standalone trait implemented by any component that needs context variables
-//! during computation: physical models, boundary conditions (J2), source terms,
-//! coupling operators (J3).
+//! Standalone trait — `required_variables()` is mandatory (DD-005).
 //!
-//! `required_variables()` is **mandatory** — every implementor must declare its
-//! context needs explicitly. Silent omissions are a compiler error, not a runtime
-//! surprise. This enforces the "declarative before implicit" principle (DD-005).
+//! ## `PhysicalModel`
+//!
+//! Supertrait of `RequiresContext`. Declares the physical equations and computes
+//! field derivatives. The method is named `compute_physics` — the `_v2` suffix
+//! from chrom-rs is dropped because oxiflow never had a v1 (DD-006).
 
+use crate::context::compute::ComputeContext;
+use crate::context::error::OxiflowError;
+use crate::context::value::ContextValue;
 use crate::context::variable::ContextVariable;
+use crate::mesh::Mesh;
 
 /// Declares context variable requirements for any engine component.
 ///
-/// Implemented by physical models, boundary conditions (J2), source terms, and
-/// coupling operators (J3). The solver aggregates declarations from all components
-/// before solving and guarantees every required variable is available.
+/// Implemented by `PhysicalModel`, `BoundaryCondition` (J2), `SourceTerm`,
+/// and `CouplingOperator` (J3). The solver aggregates declarations from all
+/// components before solving and guarantees every required variable is available.
 ///
-/// # Mandatory method
-///
-/// `required_variables()` has no default. Every implementor must declare its
-/// required context variables explicitly — even if that declaration is `vec![]`.
-///
-/// # Examples
-///
-/// ```rust
-/// use oxiflow::model::traits::RequiresContext;
-/// use oxiflow::context::variable::ContextVariable;
-///
-/// struct ChromatographyModel;
-///
-/// impl RequiresContext for ChromatographyModel {
-///     fn required_variables(&self) -> Vec<ContextVariable> {
-///         vec![
-///             ContextVariable::Time,
-///             ContextVariable::SpatialGradient { dimension: 0 },
-///         ]
-///     }
-/// }
-///
-/// struct PureAdvection;
-///
-/// impl RequiresContext for PureAdvection {
-///     fn required_variables(&self) -> Vec<ContextVariable> {
-///         vec![]
-///     }
-/// }
-/// ```
+/// `required_variables()` has no default — every implementor must declare
+/// its requirements explicitly, even if that declaration is `vec![]`.
 pub trait RequiresContext {
-    /// Returns the context variables this component **must** have available.
+    /// Variables this component **must** have. Solver raises
+    /// `OxiflowError::MissingCalculator` if any is absent.
     ///
-    /// The solver raises `OxiflowError::MissingCalculator` before solving if
-    /// any required variable has no registered calculator.
-    ///
-    /// No default implementation — every component must declare explicitly.
+    /// No default — explicit declaration is mandatory.
     fn required_variables(&self) -> Vec<ContextVariable>;
 
-    /// Returns context variables this component uses if available, but can work
-    /// without. The solver provides them when calculators are registered.
-    ///
-    /// Default: no optional variables.
+    /// Variables used when available but not strictly required.
     fn optional_variables(&self) -> Vec<ContextVariable> {
         vec![]
     }
 
-    /// Returns variables this component's calculator depends on.
+    /// Variables that must be computed before this component runs.
     ///
-    /// Used by the solver to build the topological execution order (J2, DD-009).
-    /// Declaring dependencies prevents silent ordering bugs when calculators
-    /// depend on each other's output.
-    ///
-    /// Default: no dependencies.
+    /// Used by `chain.rs` for topological ordering (DD-009, J2).
     fn depends_on(&self) -> Vec<ContextVariable> {
         vec![]
     }
 
-    /// Execution priority within the calculator chain.
+    /// Execution priority within the calculator chain (lower = earlier).
     ///
-    /// Lower values run first. Reserved values:
-    /// - `0`   — system variables (Time, TimeStep)
-    /// - `50`  — external data providers
-    /// - `100` — default for derived quantities
-    ///
-    /// Used as fallback when no topological ordering is declared via `depends_on()`.
+    /// Reserved ranges: 0 = system (Time, TimeStep), 50 = external data,
+    /// 100 = default for derived quantities.
     fn priority(&self) -> u32 {
         100
+    }
+}
+
+/// Physical model — declares needs and computes field derivatives.
+///
+/// Supertrait of `RequiresContext`. A model declares *what* context variables
+/// it needs and *how* to compute the time derivative of the primary field:
+///
+/// $$\frac{\partial u}{\partial t} = -\nabla \cdot F(u, \nabla u) + S(u, \mathbf{x}, t)$$
+/// It does not configure solving nor orchestrate the time loop — those are
+/// the responsibilities of `SolverConfiguration` and `Solver`.
+///
+/// # Naming
+///
+/// The method is named `compute_physics` (not `compute_physics_v2`).
+/// oxiflow never had a v1 API — the `_v2` suffix was a chrom-rs migration
+/// artifact that does not apply here (DD-006).
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::model::traits::{PhysicalModel, RequiresContext};
+/// use oxiflow::context::variable::ContextVariable;
+/// use oxiflow::context::value::ContextValue;
+/// use oxiflow::context::compute::ComputeContext;
+/// use oxiflow::context::error::OxiflowError;
+/// use oxiflow::mesh::Mesh;
+/// use nalgebra::DVector;
+///
+/// struct PureDecay { rate: f64 }
+///
+/// impl RequiresContext for PureDecay {
+///     fn required_variables(&self) -> Vec<ContextVariable> {
+///         vec![ContextVariable::Time]
+///     }
+/// }
+///
+/// impl PhysicalModel for PureDecay {
+///     fn compute_physics(
+///         &self,
+///         state: &ContextValue,
+///         _ctx: &ComputeContext,
+///     ) -> Result<ContextValue, OxiflowError> {
+///         let u = state.as_scalar_field()?;
+///         let du_dt = u.map(|v| -self.rate * v);
+///         Ok(ContextValue::ScalarField(du_dt))
+///     }
+///
+///     fn initial_state(&self, mesh: &dyn Mesh) -> ContextValue {
+///         ContextValue::ScalarField(DVector::from_element(mesh.n_dof(), 1.0))
+///     }
+///
+///     fn name(&self) -> &str { "pure_decay" }
+/// }
+/// ```
+pub trait PhysicalModel: RequiresContext + Send + Sync {
+    /// Computes the time derivative `du/dt` of the primary field.
+    ///
+    /// # Arguments
+    ///
+    /// - `state` — current field `u`, typically `ContextValue::ScalarField`
+    ///   for 1D problems or `ContextValue::VectorField` for multi-component.
+    /// - `ctx`   — fully populated context for this time step; all variables
+    ///   declared in `required_variables()` are guaranteed present.
+    ///
+    /// # Returns
+    ///
+    /// The derivative field $\partial u / \partial t$, same shape as `state`.
+    fn compute_physics(
+        &self,
+        state: &ContextValue,
+        ctx: &ComputeContext,
+    ) -> Result<ContextValue, OxiflowError>;
+
+    /// Returns the initial condition `u(x, t_start)` on `mesh`.
+    fn initial_state(&self, mesh: &dyn Mesh) -> ContextValue;
+
+    /// Human-readable identifier for logging and `SimulationResult` metadata.
+    fn name(&self) -> &str;
+
+    /// Optional longer description.
+    fn description(&self) -> Option<&str> {
+        None
     }
 }
 
@@ -96,15 +142,20 @@ pub trait RequiresContext {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mesh::structured::UniformGrid1D;
+    use nalgebra::DVector;
 
-    // ── Test fixtures ─────────────────────────────────────────────────────────
+    // ── Fixtures ──────────────────────────────────────────────────────────────
 
     struct FullModel;
     impl RequiresContext for FullModel {
         fn required_variables(&self) -> Vec<ContextVariable> {
             vec![
                 ContextVariable::Time,
-                ContextVariable::SpatialGradient { dimension: 0 },
+                ContextVariable::SpatialGradient {
+                    dimension: 0,
+                    component: None,
+                },
             ]
         }
         fn optional_variables(&self) -> Vec<ContextVariable> {
@@ -118,116 +169,121 @@ mod tests {
         }
     }
 
+    impl PhysicalModel for FullModel {
+        fn compute_physics(
+            &self,
+            state: &ContextValue,
+            _ctx: &ComputeContext,
+        ) -> Result<ContextValue, OxiflowError> {
+            let u = state.as_scalar_field()?;
+            Ok(ContextValue::ScalarField(u.clone()))
+        }
+        fn initial_state(&self, mesh: &dyn Mesh) -> ContextValue {
+            ContextValue::ScalarField(DVector::from_element(mesh.n_dof(), 0.0))
+        }
+        fn name(&self) -> &str {
+            "full_model"
+        }
+        fn description(&self) -> Option<&str> {
+            Some("test model")
+        }
+    }
+
     struct MinimalModel;
     impl RequiresContext for MinimalModel {
         fn required_variables(&self) -> Vec<ContextVariable> {
             vec![]
         }
     }
-
-    struct DefaultsModel;
-    impl RequiresContext for DefaultsModel {
-        fn required_variables(&self) -> Vec<ContextVariable> {
-            vec![ContextVariable::TimeStep]
+    impl PhysicalModel for MinimalModel {
+        fn compute_physics(
+            &self,
+            state: &ContextValue,
+            _ctx: &ComputeContext,
+        ) -> Result<ContextValue, OxiflowError> {
+            Ok(state.clone())
+        }
+        fn initial_state(&self, mesh: &dyn Mesh) -> ContextValue {
+            ContextValue::ScalarField(DVector::from_element(mesh.n_dof(), 1.0))
+        }
+        fn name(&self) -> &str {
+            "minimal"
         }
     }
 
-    // ── required_variables ────────────────────────────────────────────────────
+    // ── RequiresContext ───────────────────────────────────────────────────────
 
     #[test]
-    fn required_variables_returns_declared_variables() {
+    fn required_variables_returns_declared() {
         let vars = FullModel.required_variables();
         assert_eq!(vars.len(), 2);
         assert!(vars.contains(&ContextVariable::Time));
-        assert!(vars.contains(&ContextVariable::SpatialGradient { dimension: 0 }));
     }
 
     #[test]
-    fn required_variables_empty_vec_is_valid() {
+    fn empty_required_variables_is_valid() {
         assert!(MinimalModel.required_variables().is_empty());
     }
 
     #[test]
-    fn required_variables_single_variable() {
-        let vars = DefaultsModel.required_variables();
-        assert_eq!(vars.len(), 1);
-        assert_eq!(vars[0], ContextVariable::TimeStep);
-    }
-
-    // ── optional_variables ────────────────────────────────────────────────────
-
-    #[test]
-    fn optional_variables_returns_declared() {
-        let vars = FullModel.optional_variables();
-        assert_eq!(vars.len(), 1);
-        assert_eq!(vars[0], ContextVariable::External { name: "T_amb" });
-    }
-
-    #[test]
-    fn optional_variables_default_is_empty() {
+    fn optional_and_depends_on_defaults_are_empty() {
         assert!(MinimalModel.optional_variables().is_empty());
-        assert!(DefaultsModel.optional_variables().is_empty());
-    }
-
-    // ── depends_on ────────────────────────────────────────────────────────────
-
-    #[test]
-    fn depends_on_returns_declared_dependencies() {
-        let deps = FullModel.depends_on();
-        assert_eq!(deps.len(), 1);
-        assert_eq!(deps[0], ContextVariable::Time);
-    }
-
-    #[test]
-    fn depends_on_default_is_empty() {
         assert!(MinimalModel.depends_on().is_empty());
-        assert!(DefaultsModel.depends_on().is_empty());
-    }
-
-    // ── priority ──────────────────────────────────────────────────────────────
-
-    #[test]
-    fn priority_returns_custom_value() {
-        assert_eq!(FullModel.priority(), 200);
     }
 
     #[test]
     fn priority_default_is_100() {
         assert_eq!(MinimalModel.priority(), 100);
-        assert_eq!(DefaultsModel.priority(), 100);
+    }
+
+    #[test]
+    fn priority_custom_value() {
+        assert_eq!(FullModel.priority(), 200);
+    }
+
+    // ── PhysicalModel ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn compute_physics_returns_derivative() {
+        let ctx = ComputeContext::new(0.0, 0.01);
+        let state = ContextValue::ScalarField(DVector::from_vec(vec![1.0, 2.0, 3.0]));
+        let result = FullModel.compute_physics(&state, &ctx).unwrap();
+        assert!(result.is_scalar_field());
+        assert_eq!(result.as_scalar_field().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn compute_physics_wrong_state_type_returns_error() {
+        let ctx = ComputeContext::new(0.0, 0.01);
+        let state = ContextValue::Scalar(1.0);
+        let err = FullModel.compute_physics(&state, &ctx).unwrap_err();
+        assert!(matches!(err, OxiflowError::TypeMismatch { .. }));
+    }
+
+    #[test]
+    fn initial_state_matches_mesh_n_dof() {
+        let mesh = UniformGrid1D::new(10, 0.0, 1.0).unwrap();
+        let state = FullModel.initial_state(&mesh);
+        assert_eq!(state.as_scalar_field().unwrap().len(), 10);
+    }
+
+    #[test]
+    fn name_returns_identifier() {
+        assert_eq!(FullModel.name(), "full_model");
+    }
+
+    #[test]
+    fn description_returns_some_or_none() {
+        assert_eq!(FullModel.description(), Some("test model"));
+        assert_eq!(MinimalModel.description(), None);
     }
 
     // ── Object safety ─────────────────────────────────────────────────────────
 
     #[test]
-    fn trait_is_object_safe() {
-        let model: Box<dyn RequiresContext> = Box::new(FullModel);
-        assert_eq!(model.required_variables().len(), 2);
-        assert_eq!(model.priority(), 200);
-    }
-
-    #[test]
-    fn solver_can_aggregate_all_required_variables() {
-        let components: Vec<Box<dyn RequiresContext>> = vec![
-            Box::new(FullModel),
-            Box::new(MinimalModel),
-            Box::new(DefaultsModel),
-        ];
-        let all_required: Vec<ContextVariable> = components
-            .iter()
-            .flat_map(|c| c.required_variables())
-            .collect();
-        // FullModel(2) + MinimalModel(0) + DefaultsModel(1) = 3
-        assert_eq!(all_required.len(), 3);
-    }
-
-    // ── Send + Sync ───────────────────────────────────────────────────────────
-
-    #[test]
-    fn implementors_are_send_and_sync() {
-        fn assert_send_sync<T: Send + Sync>() {}
-        assert_send_sync::<FullModel>();
-        assert_send_sync::<MinimalModel>();
-        assert_send_sync::<DefaultsModel>();
+    fn physical_model_is_object_safe() {
+        let models: Vec<Box<dyn PhysicalModel>> = vec![Box::new(FullModel), Box::new(MinimalModel)];
+        assert_eq!(models[0].name(), "full_model");
+        assert_eq!(models[1].name(), "minimal");
     }
 }

--- a/src/solver/config.rs
+++ b/src/solver/config.rs
@@ -1,6 +1,385 @@
 //! # Module `solver::config`
 //!
-//! Solving configuration — `SolverConfiguration` (HOW pole).
+//! Solving configuration — `SolverConfiguration` (HOW pole, DD-021, issue #32).
 //!
-//! Gathers numerical parameters: temporal integrator choice, time step `dt`, horizon
-//! `t_end`, and at J5 the parallelism threshold `parallel_threshold` (DD-014).
+//! ## Design
+//!
+//! `dt: f64` is never exposed directly in the public API. Instead, `StepControl`
+//! encapsulates both fixed-step and adaptive-step strategies. `TimeConfiguration`
+//! groups all temporal parameters. This prevents the breaking change that would
+//! occur at J4 when adaptive integrators (DoPri45, BDF2) are introduced (DD-021).
+
+use crate::context::calculator::ContextCalculator;
+
+// ── StepControl ───────────────────────────────────────────────────────────────
+
+/// Time step control strategy.
+///
+/// At J1, only `Fixed` is used. `Adaptive` is reserved for J4 (DoPri45, BDF2)
+/// and added as a new variant — non-breaking for all J1/J2 code.
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::solver::config::StepControl;
+///
+/// let fixed = StepControl::Fixed { dt: 0.01 };
+/// assert_eq!(fixed.dt_initial(), 0.01);
+/// ```
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum StepControl {
+    /// Fixed time step — J1.
+    ///
+    /// Stability for explicit methods requires the CFL condition:
+    ///
+    /// $$\text{CFL} = \frac{v \, \Delta t}{\Delta x} \leq 1$$
+    Fixed {
+        /// Time step size.
+        dt: f64,
+    },
+
+    /// Adaptive step-size control — RESERVED J4 (DoPri45, BDF2, DD-021).
+    ///
+    /// The integrator adjusts $\Delta t$ to keep the local truncation error
+    /// within the tolerance band:
+    ///
+    /// $$\| e \| \leq \text{atol} + \text{rtol} \cdot \| u \|$$
+    Adaptive {
+        /// Initial time step guess.
+        dt_init: f64,
+        /// Minimum allowed time step — `OxiflowError::SolverDivergence` if reached.
+        dt_min: f64,
+        /// Maximum allowed time step.
+        dt_max: f64,
+        /// Relative tolerance.
+        rtol: f64,
+        /// Absolute tolerance.
+        atol: f64,
+    },
+}
+
+impl StepControl {
+    /// Returns the initial `dt` regardless of strategy.
+    pub fn dt_initial(&self) -> f64 {
+        match self {
+            Self::Fixed { dt } => *dt,
+            Self::Adaptive { dt_init, .. } => *dt_init,
+        }
+    }
+
+    /// Returns `true` if this is a fixed step strategy.
+    pub fn is_fixed(&self) -> bool {
+        matches!(self, Self::Fixed { .. })
+    }
+
+    /// Returns `true` if this is an adaptive step strategy.
+    pub fn is_adaptive(&self) -> bool {
+        matches!(self, Self::Adaptive { .. })
+    }
+}
+
+// ── IntegratorKind ────────────────────────────────────────────────────────────
+
+/// Temporal integration method.
+///
+/// At J1, only `Euler` and `RK4` are active. Other variants are
+/// reserved for J4 (explicit, implicit, adaptive, IMEX).
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::solver::config::IntegratorKind;
+///
+/// let method = IntegratorKind::Euler;
+/// assert!(method.is_explicit());
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum IntegratorKind {
+    /// Forward Euler — explicit, 1st order — J1.
+    Euler,
+    /// Runge-Kutta 4 — explicit, 4th order — J1.
+    RK4,
+    // Reserved J4 — DoPri45, BackwardEuler, CrankNicolson, BDF2, IMEX
+}
+
+impl IntegratorKind {
+    /// Returns `true` if the method is explicit.
+    pub fn is_explicit(&self) -> bool {
+        matches!(self, Self::Euler | Self::RK4)
+    }
+}
+
+// ── TimeConfiguration ─────────────────────────────────────────────────────────
+
+/// Temporal simulation parameters.
+///
+/// Groups `t_end`, step control strategy, and output frequency.
+/// Decoupled from `SolverConfiguration` so that time parameters can be
+/// modified independently of the integration method and calculators.
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::solver::config::{TimeConfiguration, StepControl};
+///
+/// let time = TimeConfiguration::new(600.0, StepControl::Fixed { dt: 0.1 });
+/// assert_eq!(time.t_end, 600.0);
+/// assert_eq!(time.n_steps_estimate(), 6000);
+/// ```
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct TimeConfiguration {
+    /// End time of the simulation.
+    pub t_end: f64,
+    /// Step control strategy.
+    pub step_control: StepControl,
+    /// Save state every N steps into `SimulationResult`.
+    ///
+    /// `None` — save every step (default; suitable for short simulations).
+    /// `Some(n)` — save every n-th step (avoids large result vectors).
+    pub save_every: Option<usize>,
+}
+
+impl TimeConfiguration {
+    /// Creates a time configuration with default save frequency (every step).
+    pub fn new(t_end: f64, step_control: StepControl) -> Self {
+        Self {
+            t_end,
+            step_control,
+            save_every: None,
+        }
+    }
+
+    /// Sets the save frequency.
+    pub fn saving_every(mut self, n: usize) -> Self {
+        self.save_every = Some(n);
+        self
+    }
+
+    /// Estimates the number of steps for fixed step control.
+    ///
+    /// Returns 0 for adaptive step control (unknown a priori).
+    pub fn n_steps_estimate(&self) -> usize {
+        match &self.step_control {
+            StepControl::Fixed { dt } => {
+                if *dt > 0.0 {
+                    (self.t_end / dt).ceil() as usize
+                } else {
+                    0
+                }
+            }
+            StepControl::Adaptive { .. } => 0,
+        }
+    }
+}
+
+// ── SolverConfiguration ───────────────────────────────────────────────────────
+
+/// Solving configuration — HOW pole.
+///
+/// Groups the integration method, temporal parameters, and context calculators.
+/// `DiscreteOperator` (INV-2, J4b) is **not** a configuration field — it is
+/// an implementation detail inside spatial `ContextCalculator`s.
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::solver::config::{
+///     SolverConfiguration, TimeConfiguration, StepControl, IntegratorKind,
+/// };
+///
+/// let config = SolverConfiguration::new(
+///     TimeConfiguration::new(600.0, StepControl::Fixed { dt: 0.1 }),
+///     IntegratorKind::Euler,
+/// );
+/// assert!(config.calculators.is_empty());
+/// assert_eq!(config.time.t_end, 600.0);
+/// ```
+#[non_exhaustive]
+pub struct SolverConfiguration {
+    /// Temporal parameters — t_end, step control, save frequency.
+    pub time: TimeConfiguration,
+    /// Temporal integration method.
+    pub integrator: IntegratorKind,
+    /// Context variable calculators provided by the user.
+    ///
+    /// The solver chains these in topological order to populate `ComputeContext`
+    /// at each time step. Built-in calculators (Time, TimeStep) are always added
+    /// automatically; only derived quantities need user-supplied calculators.
+    pub calculators: Vec<Box<dyn ContextCalculator>>,
+    // external_data: Option<Arc<dyn ExternalDataProvider>>  — RESERVED J2
+    // parallel_threshold: Option<usize>                     — RESERVED J5 (DD-014)
+}
+
+impl SolverConfiguration {
+    /// Creates a new solver configuration with no user calculators.
+    pub fn new(time: TimeConfiguration, integrator: IntegratorKind) -> Self {
+        Self {
+            time,
+            integrator,
+            calculators: Vec::new(),
+        }
+    }
+
+    /// Adds a context calculator (builder pattern).
+    pub fn with_calculator(mut self, calc: Box<dyn ContextCalculator>) -> Self {
+        self.calculators.push(calc);
+        self
+    }
+
+    /// Adds multiple context calculators at once.
+    pub fn with_calculators(mut self, calcs: Vec<Box<dyn ContextCalculator>>) -> Self {
+        self.calculators.extend(calcs);
+        self
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::compute::ComputeContext;
+    use crate::context::error::OxiflowError;
+    use crate::context::value::ContextValue;
+    use crate::context::variable::ContextVariable;
+    use crate::model::traits::RequiresContext;
+
+    // ── StepControl ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn fixed_dt_initial() {
+        let sc = StepControl::Fixed { dt: 0.05 };
+        assert_eq!(sc.dt_initial(), 0.05);
+    }
+
+    #[test]
+    fn adaptive_dt_initial() {
+        let sc = StepControl::Adaptive {
+            dt_init: 0.01,
+            dt_min: 1e-6,
+            dt_max: 1.0,
+            rtol: 1e-4,
+            atol: 1e-6,
+        };
+        assert_eq!(sc.dt_initial(), 0.01);
+    }
+
+    #[test]
+    fn is_fixed_and_is_adaptive() {
+        assert!(StepControl::Fixed { dt: 0.01 }.is_fixed());
+        assert!(!StepControl::Fixed { dt: 0.01 }.is_adaptive());
+        let adaptive = StepControl::Adaptive {
+            dt_init: 0.01,
+            dt_min: 1e-6,
+            dt_max: 1.0,
+            rtol: 1e-4,
+            atol: 1e-6,
+        };
+        assert!(adaptive.is_adaptive());
+        assert!(!adaptive.is_fixed());
+    }
+
+    // ── IntegratorKind ────────────────────────────────────────────────────────
+
+    #[test]
+    fn euler_and_rk4_are_explicit() {
+        assert!(IntegratorKind::Euler.is_explicit());
+        assert!(IntegratorKind::RK4.is_explicit());
+    }
+
+    #[test]
+    fn integrator_equality() {
+        assert_eq!(IntegratorKind::Euler, IntegratorKind::Euler);
+        assert_ne!(IntegratorKind::Euler, IntegratorKind::RK4);
+    }
+
+    // ── TimeConfiguration ─────────────────────────────────────────────────────
+
+    #[test]
+    fn n_steps_estimate_fixed() {
+        let tc = TimeConfiguration::new(10.0, StepControl::Fixed { dt: 0.01 });
+        assert_eq!(tc.n_steps_estimate(), 1000);
+    }
+
+    #[test]
+    fn n_steps_estimate_adaptive_is_zero() {
+        let tc = TimeConfiguration::new(
+            10.0,
+            StepControl::Adaptive {
+                dt_init: 0.01,
+                dt_min: 1e-6,
+                dt_max: 1.0,
+                rtol: 1e-4,
+                atol: 1e-6,
+            },
+        );
+        assert_eq!(tc.n_steps_estimate(), 0);
+    }
+
+    #[test]
+    fn saving_every_builder() {
+        let tc = TimeConfiguration::new(100.0, StepControl::Fixed { dt: 0.1 }).saving_every(10);
+        assert_eq!(tc.save_every, Some(10));
+    }
+
+    #[test]
+    fn default_save_every_is_none() {
+        let tc = TimeConfiguration::new(1.0, StepControl::Fixed { dt: 0.1 });
+        assert_eq!(tc.save_every, None);
+    }
+
+    // ── SolverConfiguration ───────────────────────────────────────────────────
+
+    #[test]
+    fn new_config_has_no_calculators() {
+        let cfg = SolverConfiguration::new(
+            TimeConfiguration::new(1.0, StepControl::Fixed { dt: 0.1 }),
+            IntegratorKind::Euler,
+        );
+        assert!(cfg.calculators.is_empty());
+    }
+
+    #[test]
+    fn with_calculator_adds_to_chain() {
+        struct DummyCalc;
+        impl RequiresContext for DummyCalc {
+            fn required_variables(&self) -> Vec<ContextVariable> {
+                vec![]
+            }
+        }
+        impl crate::context::calculator::ContextCalculator for DummyCalc {
+            fn provides(&self) -> ContextVariable {
+                ContextVariable::Time
+            }
+            fn compute(
+                &self,
+                _: &ContextValue,
+                ctx: &ComputeContext,
+            ) -> Result<ContextValue, OxiflowError> {
+                Ok(ContextValue::Scalar(ctx.time()))
+            }
+        }
+
+        let cfg = SolverConfiguration::new(
+            TimeConfiguration::new(1.0, StepControl::Fixed { dt: 0.1 }),
+            IntegratorKind::RK4,
+        )
+        .with_calculator(Box::new(DummyCalc));
+
+        assert_eq!(cfg.calculators.len(), 1);
+        assert_eq!(cfg.integrator, IntegratorKind::RK4);
+    }
+
+    #[test]
+    fn time_configuration_accessible() {
+        let cfg = SolverConfiguration::new(
+            TimeConfiguration::new(600.0, StepControl::Fixed { dt: 0.5 }),
+            IntegratorKind::Euler,
+        );
+        assert_eq!(cfg.time.t_end, 600.0);
+        assert_eq!(cfg.time.step_control.dt_initial(), 0.5);
+    }
+}

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -1,20 +1,164 @@
 //! # Module `solver`
 //!
-//! Numerical solving orchestration — WHAT/HOW separation.
+//! Numerical solving orchestration — WHAT/HOW separation (issue #32).
 //!
 //! ## Responsibilities
 //!
-//! | Type | role |
+//! | Type | Role |
 //! |---|---|
-//! | [`scenario`] | Declares and validates the problem |
-//! | [`config`] | Configures solving parameters |
-//! | [`chain`] | Composes and sequences steps |
-//! | [`methods`] | Temporal integration methods |
+//! | [`scenario::Scenario`] | Declares the problem (WHAT) |
+//! | [`config::SolverConfiguration`] | Configures solving (HOW) |
+//! | [`Solver`] | Orchestrates execution |
 //!
-//! `Scenario` validates configuration consistency *before* solving. Any configuration
-//! error raises an `OxiflowError` at startup, never a panic mid-computation.
+//! ## Contractual execution order
+//!
+//! `Solver::solve()` implementations must follow this order at each time step:
+//!
+//! 1. **Calculators** — populate `ComputeContext` in topological order
+//! 2. **Boundary conditions** — apply to state using `ctx` (J2)
+//! 3. **`compute_physics`** — compute `du/dt` from state + context
+//! 4. **Integrate** — advance state by `dt`
+//!
+//! This order is a contract, not a convention. Deviating from it produces
+//! silently incorrect results.
 
 pub mod chain;
 pub mod config;
 pub mod methods;
 pub mod scenario;
+
+pub use config::{IntegratorKind, SolverConfiguration, StepControl, TimeConfiguration};
+pub use scenario::{Domain, DomainId, Scenario};
+
+use crate::context::error::OxiflowError;
+
+// ── SimulationResult ──────────────────────────────────────────────────────────
+
+/// Result of a completed simulation.
+///
+/// `states` and `times` have the same length. The save frequency is controlled
+/// by `SolverConfiguration::time.save_every`.
+///
+/// # Examples
+///
+/// ```rust, ignore
+/// use oxiflow::solver::SimulationResult;
+/// use oxiflow::context::value::ContextValue;
+/// use nalgebra::DVector;
+///
+/// let result = SimulationResult {
+///     states: vec![ContextValue::ScalarField(DVector::from_element(10, 0.0))],
+///     times:  vec![0.0],
+///     n_steps: 1,
+/// };
+/// assert_eq!(result.states.len(), result.times.len());
+/// ```
+#[non_exhaustive]
+pub struct SimulationResult {
+    /// Saved field states at each recorded time.
+    pub states: Vec<crate::context::value::ContextValue>,
+    /// Simulation times corresponding to each saved state.
+    pub times: Vec<f64>,
+    /// Total number of time steps taken (may be larger than `states.len()`
+    /// if `save_every > 1`).
+    pub n_steps: usize,
+    /// Solver metadata: timing, rejected steps, convergence info.
+    ///
+    /// Keys follow the convention `"solver.<key>"` (e.g. `"solver.rejected_steps"`).
+    /// Empty at J1 — populated by adaptive integrators at J4 (DoPri45, BDF2).
+    pub metadata: std::collections::HashMap<String, f64>,
+}
+
+impl SimulationResult {
+    /// Returns the number of saved states.
+    pub fn len(&self) -> usize {
+        self.states.len()
+    }
+
+    /// Returns `true` if no states were saved.
+    pub fn is_empty(&self) -> bool {
+        self.states.is_empty()
+    }
+
+    /// Returns the final simulation time.
+    pub fn t_final(&self) -> Option<f64> {
+        self.times.last().copied()
+    }
+}
+
+// ── Solver trait ──────────────────────────────────────────────────────────────
+
+/// Orchestrates the time integration loop.
+///
+/// Implementations receive a `Scenario` (WHAT) and a `SolverConfiguration`
+/// (HOW) and execute the contractual loop until `t_end`.
+///
+/// At J1, `Solver` implementations must:
+/// - Verify `scenario.n_domains() == 1` (multi-domain requires J3)
+/// - Build the calculator chain via `chain::build_calculator_chain()`
+/// - Follow the contractual execution order
+///
+/// # Object safety
+///
+/// This trait is object-safe to support INV-4 (plugin-safe API, v2.0).
+pub trait Solver: Send + Sync {
+    /// Runs the simulation and returns the collected states.
+    fn solve(
+        &self,
+        scenario: &Scenario,
+        config: &SolverConfiguration,
+    ) -> Result<SimulationResult, OxiflowError>;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::value::ContextValue;
+    use nalgebra::DVector;
+
+    #[test]
+    fn simulation_result_len() {
+        let r = SimulationResult {
+            states: vec![ContextValue::ScalarField(DVector::from_element(5, 0.0))],
+            times: vec![1.0],
+            n_steps: 10,
+            metadata: std::collections::HashMap::new(),
+        };
+        assert_eq!(r.len(), 1);
+        assert!(!r.is_empty());
+    }
+
+    #[test]
+    fn simulation_result_t_final() {
+        let r = SimulationResult {
+            states: vec![
+                ContextValue::ScalarField(DVector::from_element(5, 0.0)),
+                ContextValue::ScalarField(DVector::from_element(5, 1.0)),
+            ],
+            times: vec![0.0, 1.0],
+            n_steps: 2,
+            metadata: std::collections::HashMap::new(),
+        };
+        assert_eq!(r.t_final(), Some(1.0));
+    }
+
+    #[test]
+    fn empty_result() {
+        let r = SimulationResult {
+            states: vec![],
+            times: vec![],
+            n_steps: 0,
+            metadata: std::collections::HashMap::new(),
+        };
+        assert!(r.is_empty());
+        assert_eq!(r.t_final(), None);
+    }
+
+    #[test]
+    fn solver_is_object_safe() {
+        fn assert_object_safe<T: Solver + ?Sized>() {}
+        assert_object_safe::<dyn Solver>();
+    }
+}

--- a/src/solver/scenario.rs
+++ b/src/solver/scenario.rs
@@ -1,6 +1,472 @@
 //! # Module `solver::scenario`
 //!
-//! Problem declaration — `Scenario` (WHAT pole).
+//! Problem declaration — `Scenario` (WHAT pole, DD-020, issue #32).
 //!
-//! `Scenario` is the complete description of a physical problem: model, boundary
-//! conditions, mesh and time horizon. It is *declarative* — it contains no solving logic.
+//! ## Design
+//!
+//! `Scenario` is unified: it handles both single-domain (J1) and multi-domain
+//! (J3) problems. The single-domain case is the degenerate case with one element
+//! in `domains` and empty `couplings`. Ergonomic helpers cover the J1 use case
+//! without verbosity. At J3, additional domains and coupling operators are added
+//! without any API change (DD-020).
+
+use crate::context::error::OxiflowError;
+use crate::context::variable::ContextVariable;
+use crate::mesh::Mesh;
+use crate::model::traits::PhysicalModel;
+
+// ── DomainId ──────────────────────────────────────────────────────────────────
+
+/// Typed identifier for a domain within a multi-domain scenario.
+///
+/// At J1, a single-domain scenario uses `DomainId::default()` ("default").
+/// At J3, each domain gets a meaningful identifier for coupling resolution.
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::solver::scenario::DomainId;
+///
+/// let id = DomainId::new("column");
+/// assert_eq!(id.as_str(), "column");
+///
+/// let default_id = DomainId::default();
+/// assert_eq!(default_id.as_str(), "default");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DomainId(String);
+
+impl DomainId {
+    /// Creates a new domain identifier.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    /// Returns the identifier as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Default for DomainId {
+    fn default() -> Self {
+        Self("default".to_string())
+    }
+}
+
+impl std::fmt::Display for DomainId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<&str> for DomainId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+// ── Domain ────────────────────────────────────────────────────────────────────
+
+/// Single physical domain: model + mesh + boundary conditions.
+///
+/// At J1, `boundary_conditions` is always empty. At J2, BCs are added via
+/// `Scenario::with_bcs()` without touching this struct definition.
+#[non_exhaustive]
+pub struct Domain {
+    /// Unique identifier for this domain.
+    pub id: DomainId,
+    /// Physical model — declares and computes field equations.
+    pub model: Box<dyn PhysicalModel>,
+    /// Spatial mesh — INV-1.
+    pub mesh: Box<dyn Mesh>,
+    // boundary_conditions: Vec<Box<dyn BoundaryCondition>>  — RESERVED J2 (DD-008)
+}
+
+impl Domain {
+    /// Creates a new domain with the given id, model, and mesh.
+    pub fn new(
+        id: impl Into<DomainId>,
+        model: Box<dyn PhysicalModel>,
+        mesh: Box<dyn Mesh>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            model,
+            mesh,
+        }
+    }
+}
+
+// ── Scenario ──────────────────────────────────────────────────────────────────
+
+/// Complete problem declaration — WHAT pole.
+///
+/// Holds one or more `Domain`s, coupling operators between them (J3), and
+/// the simulation start time. Single-domain problems use the ergonomic helper
+/// `Scenario::single()`. Multi-domain problems add domains and couplings without
+/// any breaking change (DD-020).
+///
+/// `Scenario` is declarative — it contains no solving logic. The `Solver`
+/// receives it and validates it via `context_requirements()` before solving.
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::solver::scenario::Scenario;
+/// use oxiflow::model::traits::{PhysicalModel, RequiresContext};
+/// use oxiflow::context::variable::ContextVariable;
+/// use oxiflow::context::value::ContextValue;
+/// use oxiflow::context::compute::ComputeContext;
+/// use oxiflow::context::error::OxiflowError;
+/// use oxiflow::mesh::{Mesh, UniformGrid1D};
+/// use nalgebra::DVector;
+///
+/// struct ConstantModel;
+/// impl RequiresContext for ConstantModel {
+///     fn required_variables(&self) -> Vec<ContextVariable> { vec![] }
+/// }
+/// impl PhysicalModel for ConstantModel {
+///     fn compute_physics(&self, s: &ContextValue, _: &ComputeContext)
+///         -> Result<ContextValue, OxiflowError> { Ok(s.clone()) }
+///     fn initial_state(&self, mesh: &dyn Mesh) -> ContextValue {
+///         ContextValue::ScalarField(DVector::from_element(mesh.n_dof(), 0.0))
+///     }
+///     fn name(&self) -> &str { "constant" }
+/// }
+///
+/// let mesh = Box::new(UniformGrid1D::new(10, 0.0, 1.0).unwrap());
+/// let scenario = Scenario::single(Box::new(ConstantModel), mesh);
+/// assert_eq!(scenario.n_domains(), 1);
+/// ```
+pub struct Scenario {
+    /// Physical domains — at least one required.
+    domains: Vec<Domain>,
+    // couplings: Vec<Box<dyn CouplingOperator>>  — RESERVED J3 (DD-011, INV-3)
+    // interfaces: Vec<Interface>                 — RESERVED J3
+    /// Simulation start time.
+    pub t_start: f64,
+}
+
+impl Scenario {
+    // ── Constructors ──────────────────────────────────────────────────────────
+
+    /// Creates a single-domain scenario (J1 default).
+    ///
+    /// Uses `DomainId::default()` as the domain identifier.
+    /// `t_start` defaults to `0.0`.
+    pub fn single(model: Box<dyn PhysicalModel>, mesh: Box<dyn Mesh>) -> Self {
+        Self {
+            domains: vec![Domain::new(DomainId::default(), model, mesh)],
+            t_start: 0.0,
+        }
+    }
+
+    /// Creates a single-domain scenario with a custom start time.
+    pub fn single_from(model: Box<dyn PhysicalModel>, mesh: Box<dyn Mesh>, t_start: f64) -> Self {
+        Self {
+            domains: vec![Domain::new(DomainId::default(), model, mesh)],
+            t_start,
+        }
+    }
+
+    /// Creates a multi-domain scenario from a list of domains (J3 path).
+    ///
+    /// Domains are provided as pre-built `Domain` instances.
+    pub fn multi(domains: Vec<Domain>) -> Result<Self, OxiflowError> {
+        if domains.is_empty() {
+            return Err(OxiflowError::InvalidDomain(
+                "Scenario requires at least one domain".into(),
+            ));
+        }
+        Ok(Self {
+            domains,
+            t_start: 0.0,
+        })
+    }
+
+    /// Sets the simulation start time.
+    pub fn with_t_start(mut self, t_start: f64) -> Self {
+        self.t_start = t_start;
+        self
+    }
+
+    // ── Accessors ─────────────────────────────────────────────────────────────
+
+    /// Returns the number of domains.
+    pub fn n_domains(&self) -> usize {
+        self.domains.len()
+    }
+
+    /// Returns a reference to all domains.
+    pub fn domains(&self) -> &[Domain] {
+        &self.domains
+    }
+
+    /// Returns the single domain — convenience for J1 single-domain scenarios.
+    ///
+    /// # Errors
+    ///
+    /// Returns `OxiflowError::InvalidDomain` if the scenario has more than one domain.
+    pub fn single_domain(&self) -> Result<&Domain, OxiflowError> {
+        if self.domains.len() != 1 {
+            return Err(OxiflowError::InvalidDomain(format!(
+                "expected 1 domain, found {}",
+                self.domains.len()
+            )));
+        }
+        Ok(&self.domains[0])
+    }
+
+    // ── Context aggregation ───────────────────────────────────────────────────
+
+    /// Aggregates context variable requirements from all domains.
+    ///
+    /// At J1: model requirements only.
+    /// At J2: model + boundary condition requirements (deduplicated).
+    /// At J3: + coupling operator requirements.
+    pub fn context_requirements(&self) -> Vec<ContextVariable> {
+        let mut requirements: Vec<ContextVariable> = self
+            .domains
+            .iter()
+            .flat_map(|d| d.model.required_variables())
+            .collect();
+
+        // J2: extend with BC requirements
+        // self.domains.iter().for_each(|d| {
+        //     d.boundary_conditions.iter().for_each(|bc| {
+        //         requirements.extend(bc.required_variables());
+        //     });
+        // });
+
+        // J3: extend with coupling operator requirements
+        // self.couplings.iter().for_each(|c| {
+        //     requirements.extend(c.required_variables());
+        // });
+
+        requirements.sort_by(|a, b| format!("{a:?}").cmp(&format!("{b:?}")));
+        requirements.dedup();
+        requirements
+    }
+
+    // ── Validation ────────────────────────────────────────────────────────────
+
+    /// Validates scenario consistency before solving.
+    ///
+    /// At J1: verifies at least one domain is present.
+    /// At J3: will verify interface consistency and coupling coverage.
+    pub fn validate(&self) -> Result<(), OxiflowError> {
+        if self.domains.is_empty() {
+            return Err(OxiflowError::InvalidDomain(
+                "Scenario has no domains".into(),
+            ));
+        }
+        for domain in &self.domains {
+            if domain.mesh.n_dof() == 0 {
+                return Err(OxiflowError::InvalidDomain(format!(
+                    "domain '{}' has empty mesh",
+                    domain.id
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::compute::ComputeContext;
+    use crate::context::error::OxiflowError;
+    use crate::context::value::ContextValue;
+    use crate::context::variable::ContextVariable;
+    use crate::mesh::structured::UniformGrid1D;
+    use crate::model::traits::{PhysicalModel, RequiresContext};
+    use nalgebra::DVector;
+
+    // ── Fixtures ──────────────────────────────────────────────────────────────
+
+    struct NeedsTime;
+    impl RequiresContext for NeedsTime {
+        fn required_variables(&self) -> Vec<ContextVariable> {
+            vec![ContextVariable::Time]
+        }
+    }
+    impl PhysicalModel for NeedsTime {
+        fn compute_physics(
+            &self,
+            s: &ContextValue,
+            _: &ComputeContext,
+        ) -> Result<ContextValue, OxiflowError> {
+            Ok(s.clone())
+        }
+        fn initial_state(&self, mesh: &dyn Mesh) -> ContextValue {
+            ContextValue::ScalarField(DVector::from_element(mesh.n_dof(), 0.0))
+        }
+        fn name(&self) -> &str {
+            "needs_time"
+        }
+    }
+
+    struct NeedsGradient;
+    impl RequiresContext for NeedsGradient {
+        fn required_variables(&self) -> Vec<ContextVariable> {
+            vec![ContextVariable::SpatialGradient {
+                dimension: 0,
+                component: None,
+            }]
+        }
+    }
+    impl PhysicalModel for NeedsGradient {
+        fn compute_physics(
+            &self,
+            s: &ContextValue,
+            _: &ComputeContext,
+        ) -> Result<ContextValue, OxiflowError> {
+            Ok(s.clone())
+        }
+        fn initial_state(&self, mesh: &dyn Mesh) -> ContextValue {
+            ContextValue::ScalarField(DVector::from_element(mesh.n_dof(), 0.0))
+        }
+        fn name(&self) -> &str {
+            "needs_gradient"
+        }
+    }
+
+    fn make_mesh() -> Box<dyn Mesh> {
+        Box::new(UniformGrid1D::new(10, 0.0, 1.0).unwrap())
+    }
+
+    // ── DomainId ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn domain_id_new() {
+        let id = DomainId::new("col_a");
+        assert_eq!(id.as_str(), "col_a");
+    }
+
+    #[test]
+    fn domain_id_default_is_default() {
+        assert_eq!(DomainId::default().as_str(), "default");
+    }
+
+    #[test]
+    fn domain_id_from_str() {
+        let id: DomainId = "lake".into();
+        assert_eq!(id.as_str(), "lake");
+    }
+
+    #[test]
+    fn domain_id_display() {
+        assert_eq!(format!("{}", DomainId::new("river")), "river");
+    }
+
+    #[test]
+    fn domain_id_equality() {
+        assert_eq!(DomainId::new("a"), DomainId::new("a"));
+        assert_ne!(DomainId::new("a"), DomainId::new("b"));
+    }
+
+    // ── Scenario::single ──────────────────────────────────────────────────────
+
+    #[test]
+    fn single_creates_one_domain() {
+        let s = Scenario::single(Box::new(NeedsTime), make_mesh());
+        assert_eq!(s.n_domains(), 1);
+    }
+
+    #[test]
+    fn single_t_start_defaults_to_zero() {
+        let s = Scenario::single(Box::new(NeedsTime), make_mesh());
+        assert_eq!(s.t_start, 0.0);
+    }
+
+    #[test]
+    fn single_from_sets_t_start() {
+        let s = Scenario::single_from(Box::new(NeedsTime), make_mesh(), 5.0);
+        assert_eq!(s.t_start, 5.0);
+    }
+
+    #[test]
+    fn with_t_start_builder() {
+        let s = Scenario::single(Box::new(NeedsTime), make_mesh()).with_t_start(2.5);
+        assert_eq!(s.t_start, 2.5);
+    }
+
+    // ── Scenario::multi ───────────────────────────────────────────────────────
+
+    #[test]
+    fn multi_with_two_domains() {
+        let d1 = Domain::new("a", Box::new(NeedsTime), make_mesh());
+        let d2 = Domain::new("b", Box::new(NeedsGradient), make_mesh());
+        let s = Scenario::multi(vec![d1, d2]).unwrap();
+        assert_eq!(s.n_domains(), 2);
+    }
+
+    #[test]
+    fn multi_empty_returns_error() {
+        assert!(Scenario::multi(vec![]).is_err());
+    }
+
+    // ── single_domain ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn single_domain_ok_for_one_domain() {
+        let s = Scenario::single(Box::new(NeedsTime), make_mesh());
+        assert!(s.single_domain().is_ok());
+        assert_eq!(s.single_domain().unwrap().id, DomainId::default());
+    }
+
+    #[test]
+    fn single_domain_err_for_multi() {
+        let d1 = Domain::new("a", Box::new(NeedsTime), make_mesh());
+        let d2 = Domain::new("b", Box::new(NeedsGradient), make_mesh());
+        let s = Scenario::multi(vec![d1, d2]).unwrap();
+        assert!(s.single_domain().is_err());
+    }
+
+    // ── context_requirements ─────────────────────────────────────────────────
+
+    #[test]
+    fn requirements_from_single_domain() {
+        let s = Scenario::single(Box::new(NeedsTime), make_mesh());
+        let reqs = s.context_requirements();
+        assert!(reqs.contains(&ContextVariable::Time));
+    }
+
+    #[test]
+    fn requirements_aggregated_and_deduped_across_domains() {
+        let d1 = Domain::new("a", Box::new(NeedsTime), make_mesh());
+        let d2 = Domain::new("b", Box::new(NeedsTime), make_mesh());
+        let s = Scenario::multi(vec![d1, d2]).unwrap();
+        // Time appears in both domains — dedup → only once
+        let reqs = s.context_requirements();
+        assert_eq!(
+            reqs.iter().filter(|v| **v == ContextVariable::Time).count(),
+            1
+        );
+    }
+
+    #[test]
+    fn requirements_union_of_all_domains() {
+        let d1 = Domain::new("a", Box::new(NeedsTime), make_mesh());
+        let d2 = Domain::new("b", Box::new(NeedsGradient), make_mesh());
+        let s = Scenario::multi(vec![d1, d2]).unwrap();
+        let reqs = s.context_requirements();
+        assert!(reqs.contains(&ContextVariable::Time));
+        assert!(reqs.contains(&ContextVariable::SpatialGradient {
+            dimension: 0,
+            component: None
+        }));
+    }
+
+    // ── validate ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn validate_ok_for_valid_scenario() {
+        let s = Scenario::single(Box::new(NeedsTime), make_mesh());
+        assert!(s.validate().is_ok());
+    }
+}


### PR DESCRIPTION
## Summary

Implements the full J1 architecture (v0.1.0 — Core Architecture). All design decisions DD-003 to DD-022 are closed. All 13 issues in the milestone are either closed or unblocked.

## Changes

### Context layer (src/context/)
- `ContextVariable`: `SpatialGradient` gains `component: Option<usize>` for J3 multi-species compatibility — non-breaking addition at J3
- `ContextValue`, `ContextVariable`: `#[non_exhaustive]` + wildcard arms in `variant_name()` and `Display` (DD-022)
- `ContextCalculator`: new trait — provider counterpart of `RequiresContext`; `DiscreteOperator` is internal to spatial calculators, not a config field

### Model layer (src/model/)
- `PhysicalModel`: supertrait of `RequiresContext`; `compute_physics()` without `_v2` suffix — no migration context in oxiflow (DD-006)

### Solver layer (src/solver/)
- `Scenario`: unified `Vec<Domain>` from day one; `single()` helper for J1; couplings reserved J3 — no `MultiDomainScenario` will ever exist (DD-020)
- `SolverConfiguration`: `StepControl` enum (`Fixed`/`Adaptive`) and `TimeConfiguration` replace bare `dt: f64` — non-breaking at J4 (DD-021)
- `IntegratorKind`, `StepControl`: `#[non_exhaustive]`
- `SimulationResult`: `#[non_exhaustive]` with `pub(crate)` constructor
- `Solver`: contractual execution order documented — calculators → BCs → `compute_physics` → integrate

### Documentation
- KaTeX formulas in all J1 rustdoc comments: canonical PDE form, CFL condition, tensor covariant transformation, adaptive error band
- `lib.rs` trimmed: physical domain section replaced by compact table with link to project wiki
- Project wiki: 9 pages (EN + FR) covering architecture, equations, and integrators preview

## Closes

Closes #27, #28, #29, #30, #31, #32