### PR TITLE
feat(solver): ForwardEulerSolver, calculator chain, chromatography pipeline

### DIFF
--- a/src/context/calculator.rs
+++ b/src/context/calculator.rs
@@ -50,6 +50,7 @@ use crate::model::traits::RequiresContext;
 /// use oxiflow::context::error::OxiflowError;
 /// use oxiflow::model::traits::RequiresContext;
 ///
+/// #[derive(Debug)]
 /// struct TimeCalculator;
 ///
 /// impl RequiresContext for TimeCalculator {
@@ -67,7 +68,7 @@ use crate::model::traits::RequiresContext;
 ///     fn name(&self) -> &str { "time" }
 /// }
 /// ```
-pub trait ContextCalculator: RequiresContext + Send + Sync {
+pub trait ContextCalculator: RequiresContext + Send + Sync + std::fmt::Debug {
     /// The context variable this calculator produces.
     ///
     /// Must be stable across calls. The solver uses this to match calculators
@@ -100,6 +101,7 @@ mod tests {
     // ── Fixtures ──────────────────────────────────────────────────────────────
 
     /// Returns the current time as a Scalar — priority 0.
+    #[derive(Debug)]
     struct TimeCalculator;
 
     impl RequiresContext for TimeCalculator {
@@ -128,6 +130,7 @@ mod tests {
     }
 
     /// Returns a fixed external scalar — depends on nothing.
+    #[derive(Debug)]
     struct ConstantCalculator {
         var: ContextVariable,
         value: f64,
@@ -153,6 +156,7 @@ mod tests {
     }
 
     /// Depends on Time — must run after TimeCalculator.
+    #[derive(Debug)]
     struct TimeDependentCalculator;
 
     impl RequiresContext for TimeDependentCalculator {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -9,4 +9,5 @@
 
 pub mod traits;
 
+pub use traits::PhysicalModel;
 pub use traits::RequiresContext;

--- a/src/solver/chain.rs
+++ b/src/solver/chain.rs
@@ -1,6 +1,262 @@
 //! # Module `solver::chain`
 //!
-//! Solver chain — composition and scheduling of solving steps.
+//! Calculator chain — validation and priority-based ordering (issue #33).
 //!
-//! Allows composing multiple solving steps (context computation, temporal
-//! integration, boundary condition update) into a sequence executable by the `Solver`.
+//! ## Responsibility
+//!
+//! `build_calculator_chain` verifies that every context variable required by the
+//! scenario has a corresponding calculator in `SolverConfiguration`, then returns
+//! the calculators sorted by ascending priority for execution.
+//!
+//! ## Ordering strategy (J1)
+//!
+//! At J1, ordering is by `priority()` (ascending). Calculators with lower
+//! priority numbers run first — reserved ranges:
+//! - **0–49**: system variables (Time, TimeStep) — injected directly by the solver
+//! - **50–99**: external data providers
+//! - **100+**: derived quantities (default)
+//!
+//! Full topological ordering via Kahn's algorithm is reserved for J2 (DD-009),
+//! when calculators may declare `depends_on()` dependencies on each other.
+//!
+//! ## Built-in variables
+//!
+//! `Time` and `TimeStep` are always available in `ComputeContext` — the solver
+//! injects them directly via `ComputeContext::new(t, dt)` before running the
+//! chain. No calculator is needed for these variables.
+
+use crate::context::calculator::ContextCalculator;
+use crate::context::error::OxiflowError;
+use crate::context::variable::ContextVariable;
+
+/// Built-in variables provided directly by the solver — no calculator needed.
+///
+/// `Time` and `TimeStep` are injected via `ComputeContext::new(t, dt)` before
+/// the calculator chain runs. Declaring them as requirements is valid; checking
+/// them against the calculator list would be a false negative.
+const BUILTIN_VARIABLES: &[ContextVariable] = &[ContextVariable::Time, ContextVariable::TimeStep];
+
+/// Validates requirements against provided calculators and returns an
+/// execution-ordered chain.
+///
+/// # Validation
+///
+/// Every variable in `requirements` must be either:
+/// - a built-in variable (`Time`, `TimeStep`), or
+/// - covered by exactly one calculator via `provides()`.
+///
+/// A variable covered by multiple calculators is accepted — the last one
+/// in priority order wins (consistent with `ComputeContext::insert` overwrite).
+///
+/// # Ordering (J1)
+///
+/// Calculators are sorted by ascending `priority()`. Within the same priority,
+/// original registration order is preserved (stable sort).
+///
+/// # Errors
+///
+/// Returns `OxiflowError::MissingCalculator` for the first uncovered
+/// non-builtin required variable.
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::solver::chain::build_calculator_chain;
+/// use oxiflow::context::variable::ContextVariable;
+/// use oxiflow::context::value::ContextValue;
+/// use oxiflow::context::compute::ComputeContext;
+/// use oxiflow::context::error::OxiflowError;
+/// use oxiflow::context::calculator::ContextCalculator;
+/// use oxiflow::model::traits::RequiresContext;
+///
+/// #[derive(Debug)]
+/// struct TimeCalc;
+/// impl RequiresContext for TimeCalc {
+///     fn required_variables(&self) -> Vec<ContextVariable> { vec![] }
+///     fn priority(&self) -> u32 { 0 }
+/// }
+/// impl ContextCalculator for TimeCalc {
+///     fn provides(&self) -> ContextVariable { ContextVariable::Time }
+///     fn compute(&self, _: &ContextValue, ctx: &ComputeContext)
+///         -> Result<ContextValue, OxiflowError>
+///     { Ok(ContextValue::Scalar(ctx.time())) }
+/// }
+///
+/// let requirements = vec![ContextVariable::Time];
+/// let calculators: Vec<Box<dyn ContextCalculator>> = vec![Box::new(TimeCalc)];
+/// let chain = build_calculator_chain(&requirements, &calculators).unwrap();
+/// assert_eq!(chain.len(), 1);
+/// ```
+pub fn build_calculator_chain<'a>(
+    requirements: &[ContextVariable],
+    calculators: &'a [Box<dyn ContextCalculator>],
+) -> Result<Vec<&'a dyn ContextCalculator>, OxiflowError> {
+    // Check every requirement is covered
+    for req in requirements {
+        if is_builtin(req) {
+            continue;
+        }
+        let covered = calculators.iter().any(|c| &c.provides() == req);
+        if !covered {
+            return Err(OxiflowError::MissingCalculator(req.clone()));
+        }
+    }
+
+    // Sort by priority (stable — preserves registration order within same priority)
+    let mut chain: Vec<&dyn ContextCalculator> = calculators.iter().map(|c| c.as_ref()).collect();
+    chain.sort_by_key(|c| c.priority());
+
+    Ok(chain)
+}
+
+fn is_builtin(var: &ContextVariable) -> bool {
+    BUILTIN_VARIABLES.contains(var)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::compute::ComputeContext;
+    use crate::context::value::ContextValue;
+    use crate::model::traits::RequiresContext;
+
+    // ── Fixtures ──────────────────────────────────────────────────────────────
+
+    #[derive(Debug)]
+    struct NamedCalc {
+        provides: ContextVariable,
+        priority: u32,
+    }
+
+    impl RequiresContext for NamedCalc {
+        fn required_variables(&self) -> Vec<ContextVariable> {
+            vec![]
+        }
+        fn priority(&self) -> u32 {
+            self.priority
+        }
+    }
+
+    impl ContextCalculator for NamedCalc {
+        fn provides(&self) -> ContextVariable {
+            self.provides.clone()
+        }
+        fn compute(
+            &self,
+            _state: &ContextValue,
+            ctx: &ComputeContext,
+        ) -> Result<ContextValue, OxiflowError> {
+            Ok(ContextValue::Scalar(ctx.time()))
+        }
+    }
+
+    fn make_calc(provides: ContextVariable, priority: u32) -> Box<dyn ContextCalculator> {
+        Box::new(NamedCalc { provides, priority })
+    }
+
+    // ── Validation ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_requirements_with_no_calculators_succeeds() {
+        let chain = build_calculator_chain(&[], &[]).unwrap();
+        assert!(chain.is_empty());
+    }
+
+    #[test]
+    fn builtin_time_requires_no_calculator() {
+        let requirements = vec![ContextVariable::Time, ContextVariable::TimeStep];
+        let chain = build_calculator_chain(&requirements, &[]).unwrap();
+        assert!(chain.is_empty());
+    }
+
+    #[test]
+    fn satisfied_requirement_succeeds() {
+        let requirements = vec![ContextVariable::External { name: "D_ax" }];
+        let calcs = vec![make_calc(ContextVariable::External { name: "D_ax" }, 100)];
+        let chain = build_calculator_chain(&requirements, &calcs).unwrap();
+        assert_eq!(chain.len(), 1);
+    }
+
+    #[test]
+    fn missing_calculator_returns_error() {
+        let requirements = vec![ContextVariable::External { name: "missing" }];
+        let err = build_calculator_chain(&requirements, &[]).unwrap_err();
+        assert!(matches!(err, OxiflowError::MissingCalculator(_)));
+    }
+
+    #[test]
+    fn missing_calculator_error_names_the_variable() {
+        let var = ContextVariable::SpatialGradient {
+            dimension: 0,
+            component: None,
+        };
+        let requirements = vec![var.clone()];
+        let err = build_calculator_chain(&requirements, &[]).unwrap_err();
+        assert!(matches!(err, OxiflowError::MissingCalculator(v) if v == var));
+    }
+
+    #[test]
+    fn duplicate_calculator_for_same_variable_is_accepted() {
+        let var = ContextVariable::External { name: "v" };
+        let requirements = vec![var.clone()];
+        let calcs = vec![make_calc(var.clone(), 100), make_calc(var.clone(), 50)];
+        assert!(build_calculator_chain(&requirements, &calcs).is_ok());
+    }
+
+    #[test]
+    fn extra_calculators_beyond_requirements_are_included() {
+        // Calculators for unrequired variables are still executed
+        let requirements = vec![ContextVariable::External { name: "a" }];
+        let calcs = vec![
+            make_calc(ContextVariable::External { name: "a" }, 100),
+            make_calc(ContextVariable::External { name: "b" }, 100),
+        ];
+        let chain = build_calculator_chain(&requirements, &calcs).unwrap();
+        assert_eq!(chain.len(), 2);
+    }
+
+    // ── Ordering ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn chain_sorted_by_ascending_priority() {
+        let calcs = vec![
+            make_calc(ContextVariable::External { name: "c" }, 200),
+            make_calc(ContextVariable::External { name: "a" }, 50),
+            make_calc(ContextVariable::External { name: "b" }, 100),
+        ];
+        let chain = build_calculator_chain(&[], &calcs).unwrap();
+        assert_eq!(chain[0].priority(), 50);
+        assert_eq!(chain[1].priority(), 100);
+        assert_eq!(chain[2].priority(), 200);
+    }
+
+    #[test]
+    fn stable_sort_preserves_registration_order_within_same_priority() {
+        let calcs = vec![
+            make_calc(ContextVariable::External { name: "first" }, 100),
+            make_calc(ContextVariable::External { name: "second" }, 100),
+        ];
+        let chain = build_calculator_chain(&[], &calcs).unwrap();
+        assert_eq!(
+            chain[0].provides(),
+            ContextVariable::External { name: "first" }
+        );
+        assert_eq!(
+            chain[1].provides(),
+            ContextVariable::External { name: "second" }
+        );
+    }
+
+    #[test]
+    fn mixed_builtin_and_user_requirements() {
+        let requirements = vec![
+            ContextVariable::Time,
+            ContextVariable::External { name: "D_ax" },
+        ];
+        let calcs = vec![make_calc(ContextVariable::External { name: "D_ax" }, 100)];
+        let chain = build_calculator_chain(&requirements, &calcs).unwrap();
+        assert_eq!(chain.len(), 1);
+    }
+}

--- a/src/solver/config.rs
+++ b/src/solver/config.rs
@@ -344,6 +344,7 @@ mod tests {
 
     #[test]
     fn with_calculator_adds_to_chain() {
+        #[derive(Debug)]
         struct DummyCalc;
         impl RequiresContext for DummyCalc {
             fn required_variables(&self) -> Vec<ContextVariable> {

--- a/src/solver/methods/euler.rs
+++ b/src/solver/methods/euler.rs
@@ -1,0 +1,428 @@
+//! # Module `solver::methods::euler`
+//!
+//! Forward Euler integrator — explicit, 1st order (issue #33).
+//!
+//! ## Algorithm
+//!
+//! At each time step:
+//!
+//! $$u^{n+1} = u^n + \Delta t \cdot f(u^n, \text{ctx}^n)$$
+//!
+//! where $f = \text{compute\_physics}(u, \text{ctx})$ is the time derivative
+//! returned by the physical model.
+//!
+//! ## Scope at J1
+//!
+//! - Single-domain scenarios only (`n_domains() == 1`).
+//! - No `DiscreteOperator` (INV-2) — spatial schemes arrive at J4b.
+//!   The model computes `du/dt` internally from the field state and context.
+//! - No boundary conditions — `BoundaryCondition` arrives at J2.
+//! - `StepControl::Fixed { dt }` only — adaptive step at J4.
+//!
+//! ## Stability
+//!
+//! For explicit methods, stability requires the CFL condition:
+//!
+//! $$\text{CFL} = \frac{v \, \Delta t}{\Delta x} \leq 1$$
+//!
+//! The solver does not enforce this automatically — the caller is responsible
+//! for choosing a stable `dt`.
+
+use std::collections::HashMap;
+
+use crate::context::compute::ComputeContext;
+use crate::context::error::OxiflowError;
+use crate::context::value::ContextValue;
+use crate::solver::chain::build_calculator_chain;
+use crate::solver::config::StepControl;
+use crate::solver::scenario::Scenario;
+use crate::solver::{SimulationResult, Solver, SolverConfiguration};
+
+/// Forward Euler solver — explicit, 1st order.
+///
+/// Implements the `Solver` trait for single-domain problems with fixed step
+/// control. See [module documentation](self) for algorithm details.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use oxiflow::solver::methods::euler::ForwardEulerSolver;
+/// use oxiflow::solver::{Scenario, SolverConfiguration, TimeConfiguration, StepControl, IntegratorKind};
+/// use oxiflow::mesh::UniformGrid1D;
+///
+/// let scenario = Scenario::single(Box::new(my_model), Box::new(mesh));
+/// let config = SolverConfiguration::new(
+///     TimeConfiguration::new(100.0, StepControl::Fixed { dt: 0.1 }),
+///     IntegratorKind::Euler,
+/// );
+/// let solver = ForwardEulerSolver;
+/// let result = solver.solve(&scenario, &config).unwrap();
+/// ```
+pub struct ForwardEulerSolver;
+
+impl Solver for ForwardEulerSolver {
+    fn solve(
+        &self,
+        scenario: &Scenario,
+        config: &SolverConfiguration,
+    ) -> Result<SimulationResult, OxiflowError> {
+        // ── Pre-solve validation ───────────────────────────────────────────────
+        scenario.validate()?;
+
+        let domain = scenario.single_domain()?;
+
+        let dt = match &config.time.step_control {
+            StepControl::Fixed { dt } => *dt,
+            _ => {
+                return Err(OxiflowError::InvalidDomain(
+                    "ForwardEulerSolver only supports StepControl::Fixed at J1".into(),
+                ))
+            }
+        };
+
+        let t_end = config.time.t_end;
+        let t_start = scenario.t_start;
+
+        if dt <= 0.0 {
+            return Err(OxiflowError::InvalidDomain(
+                "dt must be strictly positive".into(),
+            ));
+        }
+        if t_end <= t_start {
+            return Err(OxiflowError::InvalidDomain(
+                "t_end must be greater than t_start".into(),
+            ));
+        }
+
+        // ── Build calculator chain ─────────────────────────────────────────────
+        let requirements = scenario.context_requirements();
+        let chain = build_calculator_chain(&requirements, &config.calculators)?;
+
+        // ── Initial state ──────────────────────────────────────────────────────
+        let mut u = domain.model.initial_state(domain.mesh.as_ref());
+
+        // ── Result buffers ─────────────────────────────────────────────────────
+        let save_every = config.time.save_every.unwrap_or(1);
+        let capacity = ((t_end - t_start) / dt).ceil() as usize / save_every + 1;
+        let mut states: Vec<ContextValue> = Vec::with_capacity(capacity);
+        let mut times: Vec<f64> = Vec::with_capacity(capacity);
+
+        // Save initial state
+        states.push(u.clone());
+        times.push(t_start);
+
+        // ── Time loop ──────────────────────────────────────────────────────────
+        let mut t = t_start;
+        let mut step = 0usize;
+
+        while t + dt <= t_end + dt * 1e-10 {
+            // 1. Build ComputeContext for this step
+            let mut ctx = ComputeContext::new(t, dt);
+
+            // 2. Run calculators in priority order
+            for calc in &chain {
+                let value =
+                    calc.compute(&u, &ctx)
+                        .map_err(|e| OxiflowError::ComputationFailed {
+                            variable: calc.provides(),
+                            source: Box::new(e),
+                        })?;
+                ctx.insert(calc.provides(), value);
+            }
+
+            // 3. BCs — RESERVED J2
+
+            // 4. Compute du/dt
+            let du_dt = domain.model.compute_physics(&u, &ctx)?;
+
+            // 5. Euler step: u_next = u + dt * du_dt
+            u = euler_step(&u, &du_dt, dt)?;
+
+            t += dt;
+            step += 1;
+
+            // Guard against NaN / Inf
+            check_finite(&u, t)?;
+
+            // Save according to frequency
+            if step % save_every == 0 {
+                states.push(u.clone());
+                times.push(t);
+            }
+        }
+
+        Ok(SimulationResult {
+            states,
+            times,
+            n_steps: step,
+            metadata: HashMap::new(),
+        })
+    }
+}
+
+/// Computes `u + dt * du_dt` for `ScalarField` states.
+///
+/// Returns `OxiflowError::TypeMismatch` if `u` and `du_dt` are not both
+/// `ScalarField`, or `InvalidDomain` if their lengths differ.
+fn euler_step(
+    u: &ContextValue,
+    du_dt: &ContextValue,
+    dt: f64,
+) -> Result<ContextValue, OxiflowError> {
+    let u_field = u.as_scalar_field()?;
+    let du_field = du_dt.as_scalar_field()?;
+
+    if u_field.len() != du_field.len() {
+        return Err(OxiflowError::InvalidDomain(format!(
+            "state length {} != derivative length {}",
+            u_field.len(),
+            du_field.len()
+        )));
+    }
+
+    Ok(ContextValue::ScalarField(u_field + du_field * dt))
+}
+
+/// Checks that all nodal values are finite.
+fn check_finite(u: &ContextValue, t: f64) -> Result<(), OxiflowError> {
+    if let Ok(field) = u.as_scalar_field() {
+        if field.iter().any(|v| !v.is_finite()) {
+            return Err(OxiflowError::SolverDivergence {
+                time: t,
+                reason: "non-finite value detected in state vector".into(),
+            });
+        }
+    }
+    Ok(())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::compute::ComputeContext;
+    use crate::context::error::OxiflowError;
+    use crate::context::value::ContextValue;
+    use crate::context::variable::ContextVariable;
+    use crate::mesh::{Mesh, UniformGrid1D};
+    use crate::model::traits::{PhysicalModel, RequiresContext};
+    use crate::solver::config::{
+        IntegratorKind, SolverConfiguration, StepControl, TimeConfiguration,
+    };
+    use nalgebra::DVector;
+
+    // ── Fixtures ──────────────────────────────────────────────────────────────
+
+    /// Pure exponential decay: du/dt = -lambda * u
+    /// Analytical solution: u(t) = u0 * exp(-lambda * t)
+    #[derive(Debug)]
+    struct ExponentialDecay {
+        lambda: f64,
+    }
+
+    impl RequiresContext for ExponentialDecay {
+        fn required_variables(&self) -> Vec<ContextVariable> {
+            vec![]
+        }
+    }
+
+    impl PhysicalModel for ExponentialDecay {
+        fn compute_physics(
+            &self,
+            state: &ContextValue,
+            _ctx: &ComputeContext,
+        ) -> Result<ContextValue, OxiflowError> {
+            let u = state.as_scalar_field()?;
+            Ok(ContextValue::ScalarField(u.map(|v| -self.lambda * v)))
+        }
+
+        fn initial_state(&self, mesh: &dyn Mesh) -> ContextValue {
+            ContextValue::ScalarField(DVector::from_element(mesh.n_dof(), 1.0))
+        }
+
+        fn name(&self) -> &str {
+            "exponential_decay"
+        }
+    }
+
+    /// Constant zero derivative — field stays unchanged.
+    #[derive(Debug)]
+    struct ZeroDerivative;
+
+    impl RequiresContext for ZeroDerivative {
+        fn required_variables(&self) -> Vec<ContextVariable> {
+            vec![]
+        }
+    }
+
+    impl PhysicalModel for ZeroDerivative {
+        fn compute_physics(
+            &self,
+            state: &ContextValue,
+            _ctx: &ComputeContext,
+        ) -> Result<ContextValue, OxiflowError> {
+            let u = state.as_scalar_field()?;
+            Ok(ContextValue::ScalarField(DVector::from_element(
+                u.len(),
+                0.0,
+            )))
+        }
+
+        fn initial_state(&self, mesh: &dyn Mesh) -> ContextValue {
+            ContextValue::ScalarField(DVector::from_element(mesh.n_dof(), 2.5))
+        }
+
+        fn name(&self) -> &str {
+            "zero_derivative"
+        }
+    }
+
+    fn make_config(t_end: f64, dt: f64) -> SolverConfiguration {
+        SolverConfiguration::new(
+            TimeConfiguration::new(t_end, StepControl::Fixed { dt }),
+            IntegratorKind::Euler,
+        )
+    }
+
+    fn make_mesh(n: usize) -> Box<dyn Mesh> {
+        Box::new(UniformGrid1D::new(n, 0.0, 1.0).unwrap())
+    }
+
+    // ── Basic correctness ─────────────────────────────────────────────────────
+
+    #[test]
+    fn zero_derivative_field_stays_constant() {
+        let scenario = Scenario::single(Box::new(ZeroDerivative), make_mesh(5));
+        let config = make_config(1.0, 0.1);
+        let result = ForwardEulerSolver.solve(&scenario, &config).unwrap();
+        // All saved states should be 2.5 everywhere
+        for state in &result.states {
+            let field = state.as_scalar_field().unwrap();
+            for v in field.iter() {
+                assert!((v - 2.5).abs() < 1e-12);
+            }
+        }
+    }
+
+    #[test]
+    fn exponential_decay_euler_error_is_first_order() {
+        // Euler approximation of du/dt = -u, u0=1 → u(t) = exp(-t)
+        // At t=1: analytical = exp(-1) ≈ 0.3679
+        // Euler with dt=0.1 should be close but not exact
+        // UniformGrid1D requires >= 2 nodes — we use 2 and check node 0.
+        let scenario = Scenario::single(Box::new(ExponentialDecay { lambda: 1.0 }), make_mesh(2));
+        let config = make_config(1.0, 0.1);
+        let result = ForwardEulerSolver.solve(&scenario, &config).unwrap();
+
+        let final_state = result.states.last().unwrap().as_scalar_field().unwrap();
+        let euler_val = final_state[0];
+        let analytical = (-1.0_f64).exp();
+
+        // Euler error should be small but non-zero
+        let error = (euler_val - analytical).abs();
+        assert!(error < 0.1, "error too large: {}", error);
+        assert!(error > 1e-10, "error suspiciously small: {}", error);
+    }
+
+    #[test]
+    fn result_times_match_expected_steps() {
+        let scenario = Scenario::single(Box::new(ZeroDerivative), make_mesh(3));
+        let config = make_config(0.5, 0.1);
+        let result = ForwardEulerSolver.solve(&scenario, &config).unwrap();
+
+        // t=0.0 (initial) + 5 steps = 6 saved states
+        assert_eq!(result.states.len(), result.times.len());
+        assert!((result.times[0] - 0.0).abs() < 1e-12);
+        assert!(result.t_final().unwrap() > 0.4);
+    }
+
+    #[test]
+    fn n_steps_is_correct() {
+        let scenario = Scenario::single(Box::new(ZeroDerivative), make_mesh(2));
+        let config = make_config(1.0, 0.25);
+        let result = ForwardEulerSolver.solve(&scenario, &config).unwrap();
+        assert_eq!(result.n_steps, 4);
+    }
+
+    #[test]
+    fn save_every_reduces_stored_states() {
+        let scenario = Scenario::single(Box::new(ZeroDerivative), make_mesh(2));
+        let config = SolverConfiguration::new(
+            TimeConfiguration::new(1.0, StepControl::Fixed { dt: 0.1 }).saving_every(5),
+            IntegratorKind::Euler,
+        );
+        let result = ForwardEulerSolver.solve(&scenario, &config).unwrap();
+        // 10 steps, save every 5 → 2 saves + initial = 3 states
+        assert_eq!(result.states.len(), 3);
+    }
+
+    // ── Validation errors ─────────────────────────────────────────────────────
+
+    #[test]
+    fn negative_dt_returns_error() {
+        let scenario = Scenario::single(Box::new(ZeroDerivative), make_mesh(2));
+        let config = make_config(1.0, -0.1);
+        assert!(ForwardEulerSolver.solve(&scenario, &config).is_err());
+    }
+
+    #[test]
+    fn t_end_before_t_start_returns_error() {
+        let scenario = Scenario::single(Box::new(ZeroDerivative), make_mesh(2)).with_t_start(5.0);
+        let config = make_config(1.0, 0.1);
+        assert!(ForwardEulerSolver.solve(&scenario, &config).is_err());
+    }
+
+    #[test]
+    fn missing_calculator_returns_error() {
+        use crate::context::variable::ContextVariable;
+
+        #[derive(Debug)]
+        struct NeedsExternal;
+        impl RequiresContext for NeedsExternal {
+            fn required_variables(&self) -> Vec<ContextVariable> {
+                vec![ContextVariable::External { name: "missing" }]
+            }
+        }
+        impl PhysicalModel for NeedsExternal {
+            fn compute_physics(
+                &self,
+                s: &ContextValue,
+                _: &ComputeContext,
+            ) -> Result<ContextValue, OxiflowError> {
+                Ok(s.clone())
+            }
+            fn initial_state(&self, mesh: &dyn Mesh) -> ContextValue {
+                ContextValue::ScalarField(DVector::from_element(mesh.n_dof(), 0.0))
+            }
+            fn name(&self) -> &str {
+                "needs_external"
+            }
+        }
+
+        let scenario = Scenario::single(Box::new(NeedsExternal), make_mesh(2));
+        let config = make_config(1.0, 0.1);
+        let err = ForwardEulerSolver.solve(&scenario, &config).unwrap_err();
+        assert!(matches!(err, OxiflowError::MissingCalculator(_)));
+    }
+
+    // ── euler_step ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn euler_step_computes_correctly() {
+        let u = ContextValue::ScalarField(DVector::from_vec(vec![1.0, 2.0, 3.0]));
+        let du = ContextValue::ScalarField(DVector::from_vec(vec![0.1, 0.2, 0.3]));
+        let result = euler_step(&u, &du, 0.5).unwrap();
+        let field = result.as_scalar_field().unwrap();
+        assert!((field[0] - 1.05).abs() < 1e-12);
+        assert!((field[1] - 2.10).abs() < 1e-12);
+        assert!((field[2] - 3.15).abs() < 1e-12);
+    }
+
+    #[test]
+    fn euler_step_mismatched_length_returns_error() {
+        let u = ContextValue::ScalarField(DVector::from_element(3, 1.0));
+        let du = ContextValue::ScalarField(DVector::from_element(2, 0.1));
+        assert!(euler_step(&u, &du, 0.1).is_err());
+    }
+}

--- a/src/solver/methods/mod.rs
+++ b/src/solver/methods/mod.rs
@@ -1,18 +1,28 @@
 //! # Module `solver::methods`
 //!
-//! *Temporal integration methods — J4a (v0.5).*
+//! Temporal integration methods.
 //!
-//! ## Planned methods
+//! ## Active at J1
 //!
-//! | Méthode | Type | Milestone |
+//! | Method | Type | Issue |
 //! |---|---|---|
-//! | Euler explicite | Explicit | J4a |
-//! | RK4 | Explicit | J4a |
-//! | DoPri45 | Adaptive | J4a |
-//! | Euler implicite | Implicit | J4a |
-//! | Crank–Nicolson | Semi-implicit | J4a |
-//! | BDF2/3 | Implicit multi-step | J4a |
-//! | IMEX (splitting de Strang) | Hybrid | J4a |
+//! | [`euler::ForwardEulerSolver`] | Explicit, 1st order | #33 |
 //!
-//! Integrators are generic over `DiscreteOperator<M: Mesh>` (INV-2) — no spatial
-//! scheme is called directly inside an integrator.
+//! ## Reserved — J4 (v0.4.0)
+//!
+//! | Method | Type | Note |
+//! |---|---|---|
+//! | `RK4Solver` | Explicit, 4th order | — |
+//! | `DoPri45Solver` | Adaptive explicit | `StepControl::Adaptive` |
+//! | `BackwardEulerSolver` | Implicit, 1st order | Linear solve via DD-013 |
+//! | `CrankNicolsonSolver` | Semi-implicit, 2nd order | — |
+//! | `BDF2Solver` | Implicit multi-step, 2nd order | — |
+//! | `IMEXSolver` | Strang splitting | Transport-reaction |
+//!
+//! All integrators are decoupled from the spatial scheme via
+//! `DiscreteOperator<M: Mesh>` (INV-2, J4b) — no FD/FV/FEM
+//! method is called directly inside an integrator.
+
+pub mod euler;
+
+pub use euler::ForwardEulerSolver;

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -54,6 +54,7 @@ use crate::context::error::OxiflowError;
 /// assert_eq!(result.states.len(), result.times.len());
 /// ```
 #[non_exhaustive]
+#[derive(Debug)]
 pub struct SimulationResult {
     /// Saved field states at each recorded time.
     pub states: Vec<crate::context::value::ContextValue>,

--- a/tests/solver_pipeline_chromatography.rs
+++ b/tests/solver_pipeline_chromatography.rs
@@ -1,0 +1,231 @@
+//! # Solver pipeline — chromatography end-to-end
+//!
+//! This integration test validates the full core architecture pipeline:
+//!
+//! ```text
+//! Scenario → build_calculator_chain → ComputeContext → compute_physics → ForwardEulerSolver
+//! ```
+//!
+//! ## Physical model
+//!
+//! `GaussianInjection` models the temporal evolution of a concentration field
+//! under a Gaussian injection at each node (simplified 0D per-node ODE):
+//!
+//! $$\frac{\partial c}{\partial t} = -\lambda \cdot c + A \cdot \exp\!\left(-\frac{(t - t_{\text{inj}})^2}{2\sigma^2}\right)$$
+//!
+//! At J1, spatial transport ($v \cdot \partial c / \partial z$, $D_{ax} \cdot \partial^2 c / \partial z^2$)
+//! is not modelled — `DiscreteOperator` (INV-2) arrives at J4b. The test validates
+//! that the engine pipeline runs correctly, not the spatial accuracy of the physics.
+//!
+//! ## Acceptance criteria
+//!
+//! - Solver runs without error from `t=0` to `t=t_end`
+//! - `SimulationResult` contains saved states and times
+//! - Peak concentration is reached and then decays
+//! - `context_requirements()` declares `[Time]`, calculator chain is built correctly
+
+use oxiflow::{
+    context::{
+        compute::ComputeContext,
+        error::OxiflowError,
+        value::ContextValue,
+        variable::ContextVariable,
+    },
+    mesh::{Mesh, UniformGrid1D},
+    model::traits::{PhysicalModel, RequiresContext},
+    solver::{
+        methods::euler::ForwardEulerSolver,
+        scenario::Scenario,
+        config::{IntegratorKind, SolverConfiguration, StepControl, TimeConfiguration},
+        Solver,
+    },
+};
+use nalgebra::DVector;
+
+// ── Model ─────────────────────────────────────────────────────────────────────
+
+/// Chromatographic injection model — J1 validation (simplified ODE per node).
+///
+/// Models concentration decay with a Gaussian injection source:
+///
+/// $$\frac{dc}{dt} = -\lambda \cdot c + c_{\max} \cdot \exp\!\left(-\frac{(t - t_{\text{inj}})^2}{2\sigma^2}\right)$$
+///
+/// Requires `Time` from the context. All other parameters are model-level constants.
+struct GaussianInjection {
+    /// First-order decay rate [1/s].
+    lambda: f64,
+    /// Peak injection time [s].
+    t_inj: f64,
+    /// Injection pulse width (std deviation) [s].
+    sigma: f64,
+    /// Peak concentration [mol/m³].
+    c_max: f64,
+}
+
+impl RequiresContext for GaussianInjection {
+    fn required_variables(&self) -> Vec<ContextVariable> {
+        vec![ContextVariable::Time]
+    }
+}
+
+impl PhysicalModel for GaussianInjection {
+    fn compute_physics(
+        &self,
+        state: &ContextValue,
+        ctx: &ComputeContext,
+    ) -> Result<ContextValue, OxiflowError> {
+        let t = ctx.time();
+        let c = state.as_scalar_field()?;
+
+        // Gaussian injection source term
+        let injection = self.c_max
+            * (-(t - self.t_inj).powi(2) / (2.0 * self.sigma.powi(2))).exp();
+
+        // dc/dt = -lambda * c + injection (same at every node — 0D per-node ODE)
+        let dc_dt = c.map(|ci| -self.lambda * ci + injection);
+
+        Ok(ContextValue::ScalarField(dc_dt))
+    }
+
+    fn initial_state(&self, mesh: &dyn Mesh) -> ContextValue {
+        // Start with near-zero concentration
+        ContextValue::ScalarField(DVector::from_element(mesh.n_dof(), 0.0))
+    }
+
+    fn name(&self) -> &str {
+        "gaussian_injection"
+    }
+
+    fn description(&self) -> Option<&str> {
+        Some("J1 exit criterion — Gaussian injection chromatography (0D per-node ODE)")
+    }
+}
+
+// ── Parameters ────────────────────────────────────────────────────────────────
+
+const N_NODES: usize = 50;
+const L_COLUMN: f64 = 0.25;  // [m]
+const T_END: f64 = 60.0;     // [s]
+const DT: f64 = 0.5;         // [s]
+const LAMBDA: f64 = 0.05;    // [1/s]
+const T_INJ: f64 = 10.0;     // [s]
+const SIGMA: f64 = 2.0;      // [s]
+const C_MAX: f64 = 1.0;      // [mol/m³]
+
+fn make_scenario() -> Scenario {
+    let model = Box::new(GaussianInjection {
+        lambda: LAMBDA,
+        t_inj: T_INJ,
+        sigma: SIGMA,
+        c_max: C_MAX,
+    });
+    let mesh = Box::new(UniformGrid1D::new(N_NODES, 0.0, L_COLUMN).unwrap());
+    Scenario::single(model, mesh)
+}
+
+fn make_config() -> SolverConfiguration {
+    SolverConfiguration::new(
+        TimeConfiguration::new(T_END, StepControl::Fixed { dt: DT }),
+        IntegratorKind::Euler,
+    )
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn core_architecture_solver_runs_to_completion() {
+    let result = ForwardEulerSolver.solve(&make_scenario(), &make_config());
+    assert!(result.is_ok(), "solver failed: {:?}", result.err());
+}
+
+#[test]
+fn core_architecture_result_has_correct_structure() {
+    let result = ForwardEulerSolver.solve(&make_scenario(), &make_config()).unwrap();
+
+    // states and times have the same length
+    assert_eq!(result.states.len(), result.times.len());
+    assert!(!result.is_empty());
+
+    // Initial state is saved at t=0
+    assert!((result.times[0] - 0.0).abs() < 1e-10);
+
+    // Final time is close to t_end
+    let t_final = result.t_final().unwrap();
+    assert!(t_final > T_END - DT, "t_final={} < t_end-dt={}", t_final, T_END - DT);
+}
+
+#[test]
+fn core_architecture_initial_concentration_is_zero() {
+    let result = ForwardEulerSolver.solve(&make_scenario(), &make_config()).unwrap();
+    let initial = result.states[0].as_scalar_field().unwrap();
+    assert_eq!(initial.len(), N_NODES);
+    for v in initial.iter() {
+        assert!(v.abs() < 1e-12, "initial concentration not zero: {}", v);
+    }
+}
+
+#[test]
+fn core_architecture_concentration_rises_then_falls() {
+    let result = ForwardEulerSolver.solve(&make_scenario(), &make_config()).unwrap();
+
+    // Sample node 0 concentration over time
+    let concs: Vec<f64> = result.states.iter()
+        .map(|s| s.as_scalar_field().unwrap()[0])
+        .collect();
+
+    // Should start near zero
+    assert!(concs[0].abs() < 1e-10);
+
+    // Should reach a peak above zero
+    let peak = concs.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+    assert!(peak > 0.01, "peak concentration too low: {}", peak);
+
+    // Final concentration should be lower than peak (injection ended, decay continues)
+    let final_c = *concs.last().unwrap();
+    assert!(
+        final_c < peak,
+        "final concentration {} >= peak {}", final_c, peak
+    );
+}
+
+#[test]
+fn core_architecture_all_states_are_finite() {
+    let result = ForwardEulerSolver.solve(&make_scenario(), &make_config()).unwrap();
+    for (i, state) in result.states.iter().enumerate() {
+        let field = state.as_scalar_field().unwrap();
+        for (j, v) in field.iter().enumerate() {
+            assert!(
+                v.is_finite(),
+                "non-finite value at step {} node {}: {}", i, j, v
+            );
+        }
+    }
+}
+
+#[test]
+fn core_architecture_n_steps_matches_time_span() {
+    let result = ForwardEulerSolver.solve(&make_scenario(), &make_config()).unwrap();
+    let expected_steps = (T_END / DT).ceil() as usize;
+    assert_eq!(result.n_steps, expected_steps);
+}
+
+#[test]
+fn core_architecture_context_requirements_declares_time() {
+    let scenario = make_scenario();
+    let reqs = scenario.context_requirements();
+    assert!(
+        reqs.contains(&ContextVariable::Time),
+        "Time not in requirements: {:?}", reqs
+    );
+}
+
+#[test]
+fn core_architecture_no_calculator_needed_for_time() {
+    // Time is a built-in variable — the chain should build without any user calculator
+    let config = make_config(); // no calculators added
+    let result = ForwardEulerSolver.solve(&make_scenario(), &config);
+    assert!(
+        result.is_ok(),
+        "solver failed without Time calculator: {:?}", result.err()
+    );
+}

--- a/tests/solver_pipeline_chromatography.rs
+++ b/tests/solver_pipeline_chromatography.rs
@@ -24,23 +24,21 @@
 //! - Peak concentration is reached and then decays
 //! - `context_requirements()` declares `[Time]`, calculator chain is built correctly
 
+use nalgebra::DVector;
 use oxiflow::{
     context::{
-        compute::ComputeContext,
-        error::OxiflowError,
-        value::ContextValue,
+        compute::ComputeContext, error::OxiflowError, value::ContextValue,
         variable::ContextVariable,
     },
     mesh::{Mesh, UniformGrid1D},
     model::traits::{PhysicalModel, RequiresContext},
     solver::{
+        config::{IntegratorKind, SolverConfiguration, StepControl, TimeConfiguration},
         methods::euler::ForwardEulerSolver,
         scenario::Scenario,
-        config::{IntegratorKind, SolverConfiguration, StepControl, TimeConfiguration},
         Solver,
     },
 };
-use nalgebra::DVector;
 
 // ── Model ─────────────────────────────────────────────────────────────────────
 
@@ -78,8 +76,7 @@ impl PhysicalModel for GaussianInjection {
         let c = state.as_scalar_field()?;
 
         // Gaussian injection source term
-        let injection = self.c_max
-            * (-(t - self.t_inj).powi(2) / (2.0 * self.sigma.powi(2))).exp();
+        let injection = self.c_max * (-(t - self.t_inj).powi(2) / (2.0 * self.sigma.powi(2))).exp();
 
         // dc/dt = -lambda * c + injection (same at every node — 0D per-node ODE)
         let dc_dt = c.map(|ci| -self.lambda * ci + injection);
@@ -104,13 +101,13 @@ impl PhysicalModel for GaussianInjection {
 // ── Parameters ────────────────────────────────────────────────────────────────
 
 const N_NODES: usize = 50;
-const L_COLUMN: f64 = 0.25;  // [m]
-const T_END: f64 = 60.0;     // [s]
-const DT: f64 = 0.5;         // [s]
-const LAMBDA: f64 = 0.05;    // [1/s]
-const T_INJ: f64 = 10.0;     // [s]
-const SIGMA: f64 = 2.0;      // [s]
-const C_MAX: f64 = 1.0;      // [mol/m³]
+const L_COLUMN: f64 = 0.25; // [m]
+const T_END: f64 = 60.0; // [s]
+const DT: f64 = 0.5; // [s]
+const LAMBDA: f64 = 0.05; // [1/s]
+const T_INJ: f64 = 10.0; // [s]
+const SIGMA: f64 = 2.0; // [s]
+const C_MAX: f64 = 1.0; // [mol/m³]
 
 fn make_scenario() -> Scenario {
     let model = Box::new(GaussianInjection {
@@ -140,7 +137,9 @@ fn core_architecture_solver_runs_to_completion() {
 
 #[test]
 fn core_architecture_result_has_correct_structure() {
-    let result = ForwardEulerSolver.solve(&make_scenario(), &make_config()).unwrap();
+    let result = ForwardEulerSolver
+        .solve(&make_scenario(), &make_config())
+        .unwrap();
 
     // states and times have the same length
     assert_eq!(result.states.len(), result.times.len());
@@ -151,12 +150,19 @@ fn core_architecture_result_has_correct_structure() {
 
     // Final time is close to t_end
     let t_final = result.t_final().unwrap();
-    assert!(t_final > T_END - DT, "t_final={} < t_end-dt={}", t_final, T_END - DT);
+    assert!(
+        t_final > T_END - DT,
+        "t_final={} < t_end-dt={}",
+        t_final,
+        T_END - DT
+    );
 }
 
 #[test]
 fn core_architecture_initial_concentration_is_zero() {
-    let result = ForwardEulerSolver.solve(&make_scenario(), &make_config()).unwrap();
+    let result = ForwardEulerSolver
+        .solve(&make_scenario(), &make_config())
+        .unwrap();
     let initial = result.states[0].as_scalar_field().unwrap();
     assert_eq!(initial.len(), N_NODES);
     for v in initial.iter() {
@@ -166,10 +172,14 @@ fn core_architecture_initial_concentration_is_zero() {
 
 #[test]
 fn core_architecture_concentration_rises_then_falls() {
-    let result = ForwardEulerSolver.solve(&make_scenario(), &make_config()).unwrap();
+    let result = ForwardEulerSolver
+        .solve(&make_scenario(), &make_config())
+        .unwrap();
 
     // Sample node 0 concentration over time
-    let concs: Vec<f64> = result.states.iter()
+    let concs: Vec<f64> = result
+        .states
+        .iter()
         .map(|s| s.as_scalar_field().unwrap()[0])
         .collect();
 
@@ -184,19 +194,26 @@ fn core_architecture_concentration_rises_then_falls() {
     let final_c = *concs.last().unwrap();
     assert!(
         final_c < peak,
-        "final concentration {} >= peak {}", final_c, peak
+        "final concentration {} >= peak {}",
+        final_c,
+        peak
     );
 }
 
 #[test]
 fn core_architecture_all_states_are_finite() {
-    let result = ForwardEulerSolver.solve(&make_scenario(), &make_config()).unwrap();
+    let result = ForwardEulerSolver
+        .solve(&make_scenario(), &make_config())
+        .unwrap();
     for (i, state) in result.states.iter().enumerate() {
         let field = state.as_scalar_field().unwrap();
         for (j, v) in field.iter().enumerate() {
             assert!(
                 v.is_finite(),
-                "non-finite value at step {} node {}: {}", i, j, v
+                "non-finite value at step {} node {}: {}",
+                i,
+                j,
+                v
             );
         }
     }
@@ -204,7 +221,9 @@ fn core_architecture_all_states_are_finite() {
 
 #[test]
 fn core_architecture_n_steps_matches_time_span() {
-    let result = ForwardEulerSolver.solve(&make_scenario(), &make_config()).unwrap();
+    let result = ForwardEulerSolver
+        .solve(&make_scenario(), &make_config())
+        .unwrap();
     let expected_steps = (T_END / DT).ceil() as usize;
     assert_eq!(result.n_steps, expected_steps);
 }
@@ -215,7 +234,8 @@ fn core_architecture_context_requirements_declares_time() {
     let reqs = scenario.context_requirements();
     assert!(
         reqs.contains(&ContextVariable::Time),
-        "Time not in requirements: {:?}", reqs
+        "Time not in requirements: {:?}",
+        reqs
     );
 }
 
@@ -226,6 +246,7 @@ fn core_architecture_no_calculator_needed_for_time() {
     let result = ForwardEulerSolver.solve(&make_scenario(), &config);
     assert!(
         result.is_ok(),
-        "solver failed without Time calculator: {:?}", result.err()
+        "solver failed without Time calculator: {:?}",
+        result.err()
     );
 }


### PR DESCRIPTION
## Summary

Implements the exit criterion: the core architecture pipeline runs end-to-end with a real physical scenario.

## Changes

### Calculator chain (src/solver/chain.rs)
- `build_calculator_chain()`: validates that every required context   variable has a calculator, sorts by ascending priority
- Built-in variables `Time` and `TimeStep` are injected directly by   the solver — no user calculator needed
- Topological ordering (Kahn) reserved for J2 - #9

### ForwardEulerSolver (src/solver/methods/)
- `ForwardEulerSolver` implementing `Solver` for single-domain, fixed-step problems (named to distinguish from `BackwardEulerSolver` at [v0.4.0](https://github.com/biface/oxiflow/milestone/15)
- `DiscreteOperator` (#4) arrives at [v0.5.0](https://github.com/biface/oxiflow/milestone/16) via the calculator chain — `compute_physics()` signature is stable
- Divergence detection via `check_finite()` at each step

### Debug derives (src/context/calculator.rs, src/solver/mod.rs, src/solver/config.rs)
- `ContextCalculator`: `Debug` supertrait
- `SimulationResult`: `#[derive(Debug)]`
- Doctest fixtures annotated accordingly

### model/mod.rs
- `PhysicalModel` re-export was missing — added

## Integration test (tests/solver_pipeline_chromatography.rs)

`GaussianInjection` model: `dc/dt = −λc + c_max·exp(−(t−t_inj)²/2σ²)`

8 tests validating:
- Pipeline runs to completion
- Result structure (`states`, `times`, `n_steps`)
- Initial concentration is zero
- Concentration rises then falls (Gaussian peak)
- All states are finite
- Step count matches time span
- `Time` declared in `context_requirements()`
- No calculator needed for built-in `Time`

## Closes

Closes #33