### PR TITLE
feat(v0.2.0): Complete Context — boundary conditions, calculator chain, built-in calculators

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -46,10 +46,10 @@ flags:
   #   carryforward: false
 
   # J5 (v0.6) — activate when `serde` feature is declared in Cargo.toml
-  # serde:
-  #   paths:
-  #     - src/
-  #   carryforward: false
+  serde:
+    paths:
+      - src/
+    carryforward: false
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Components — per-module coverage visibility

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -68,12 +68,10 @@ jobs:
       #       --lcov --output-path lcov-parallel.info
 
       # ── Run 4 : serde feature only ────────────────────────────────────────
-      # À activer quand Cargo.toml contient : [features] serde = [...]
-      #
-      # - name: Coverage — serde feature
-      #   run: |
-      #     cargo llvm-cov --all-targets --features serde \
-      #       --lcov --output-path lcov-serde.info
+      - name: Coverage — serde feature
+        run: |
+          cargo llvm-cov --all-targets --features serde \
+            --lcov --output-path lcov-serde.info
 
       # ── FEM invariants integration test ───────────────────────────────────
       # Dédié aux tests INV-1/2/3 dans tests/fem_invariants.rs.
@@ -88,6 +86,6 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
         with:
-          files: lcov-default.info
+          files: lcov-default.info,lcov-serde.info
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "oxiflow"
-version     = "0.0.5"
+version     = "0.2.0"
 edition     = "2021"
 rust-version = "1.80"
 
@@ -29,7 +29,7 @@ thiserror = "2"
 rayon = { version = "1", optional = true }
 # feature `serde`    — sérialisation des types publics (J6)
 serde = { version = "1", features = ["derive"], optional = true }
-# feature `hdf5`     — lecture/écriture de données externes (J2)
+# feature `hdf5`     — large experimental dataset I/O (planned J3+)
 hdf5  = { version = "0.8", optional = true }
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,7 +17,7 @@ all implementation work from v0.1 to v3.0.
 3. [J1 — Core Architecture (v0.2)](#3-j1--core-architecture-v02)
 4. [J2 — Complete Context (v0.3)](#4-j2--complete-context-v03)
 5. [J3 — Multi-Component (v0.4)](#5-j3--multi-component-v04)
-6. [J4 — Solvers & Discretisation (v0.5–0.6)](#6-j4--solvers--discretisation-v05-06)
+6. [J4 — Solvers & Discretisation (v0.4–0.5)](#6-j4--solvers--discretisation-v04-05)
 7. [J5 — Performance (v0.7)](#7-j5--performance-v07)
 8. [J6 — Ecosystem v1.0](#8-j6--ecosystem-v10)
 9. [FEM Compatibility — v2.0 Trajectory](#9-fem-compatibility--v20-trajectory)
@@ -76,18 +76,18 @@ boilerplate.
 
 ## 2. Milestone Overview
 
-| Milestone | Version | Target | Theme |
-|---|---|---|---|
-| J0 — Foundations | v0.1 | Acquired | crates.io placeholder · CI · project structure |
-| J1 — Core Architecture | v0.2 | M+2 | ContextValue · OxiflowError · Mesh (INV-1) |
-| J2 — Complete Context | v0.3 | M+4 | Requiring BCs · topological ordering |
-| J3 — Multi-Component | v0.4 | M+6 | PhysicalQuantity · CouplingOperator (INV-3) |
-| J4a — Integrators | v0.5 | M+8 | Temporal integrators |
-| J4b — Discretisation | v0.6 | M+10 | DiscreteOperator (INV-2) · FD/FV/WENO |
-| J5 — Performance | v0.7 | M+13 | Rayon · cache · benchmarks |
-| J6 — Ecosystem v1.0 | v1.0 | M+16 | 7 examples · FEM audit · stable API |
-| J7 — FEM | v2.0 | M+24 | Unstructured meshes · ALE · INV-4 plugin-safe |
-| J8 — Frameworks | v3.0 | M+32 | oxiflow-chrom · oxiflow-geo · CLI · third-party |
+| Milestone              | Version | Target   | Theme                                           |
+|------------------------|---------|----------|-------------------------------------------------|
+| J0 — Foundations       | v0.0.5  | Acquired | crates.io placeholder · CI · project structure  |
+| J1 — Core Architecture | v0.1    | Acquired | ContextValue · OxiflowError · Mesh (INV-1)      |
+| J2 — Complete Context  | v0.2    | M+4      | Requiring BCs · topological ordering            |
+| J3 — Multi-Component   | v0.3    | M+6      | PhysicalQuantity · CouplingOperator (INV-3)     |
+| J4a — Integrators      | v0.4    | M+8      | Temporal integrators                            |
+| J4b — Discretisation   | v0.5    | M+10     | DiscreteOperator (INV-2) · FD/FV/WENO           |
+| J5 — Performance       | v0.6    | M+13     | Rayon · cache · benchmarks                      |
+| J6 — Ecosystem v1.0    | v1.0    | M+16     | 7 examples · FEM audit · stable API             |
+| J7 — FEM               | v2.0    | M+24     | Unstructured meshes · ALE · INV-4 plugin-safe   |
+| J8 — Frameworks        | v3.0    | M+32     | oxiflow-chrom · oxiflow-geo · CLI · third-party |
 
 Each milestone is independently deliverable. J1 alone (v0.2) is a usable library for
 chromatography modelling. Third-party framework development can begin as soon as v2.0
@@ -166,11 +166,11 @@ quadrature, external tabulated data, HDF5 file reader).
 
 Chromatography BC mappings:
 
-| Chromatography BC | Mathematical type | Context needed |
-|---|---|---|
-| Simplified BC | Dirichlet | injection concentration profile |
-| Danckwerts inlet | Robin | time + gradient |
-| Danckwerts outlet | Neumann | gradient only |
+| Chromatography BC | Mathematical type | Context needed                  |
+|-------------------|-------------------|---------------------------------|
+| Simplified BC     | Dirichlet         | injection concentration profile |
+| Danckwerts inlet  | Robin             | time + gradient                 |
+| Danckwerts outlet | Neumann           | gradient only                   |
 
 ---
 
@@ -181,7 +181,7 @@ Proto lahar–lake example on regular grids — the regression base for v2.0 FEM
 
 ---
 
-## 6. J4 — Solvers & Discretisation (v0.5–0.6)
+## 6. J4 — Solvers & Discretisation (v0.4–0.5)
 
 Temporal integrators: Forward Euler, RK4, DoPri45, Backward Euler, Crank–Nicolson, BDF2/3,
 IMEX (Strang splitting).
@@ -232,11 +232,11 @@ A rapid gravitational movement (lahar, landslide) entering a body of water and g
 a submersion wave. Requires unstructured meshing for irregular geometry and adaptive
 refinement for the wave front — both impossible with finite differences.
 
-| Component | Model | Challenge |
-|---|---|---|
-| Granular domain | Bingham + extended Saint-Venant | moving boundary · adaptive mesh |
-| Fluid domain | Shallow Water equations | irregular bathymetry |
-| Moving interface | ALE formulation | mass/momentum transfer |
+| Component        | Model                           | Challenge                       |
+|------------------|---------------------------------|---------------------------------|
+| Granular domain  | Bingham + extended Saint-Venant | moving boundary · adaptive mesh |
+| Fluid domain     | Shallow Water equations         | irregular bathymetry            |
+| Moving interface | ALE formulation                 | mass/momentum transfer          |
 
 ### 9.2 INV-4 — Plugin-safe API
 
@@ -338,12 +338,12 @@ oxiflow list models --framework chrom
 
 ### 10.4 Planned first-party frameworks
 
-| Crate | Domain | Key models |
-|---|---|---|
-| `oxiflow-chrom` | Chromatography | Langmuir, SMA, Thomas, gradient elution, Danckwerts BC |
-| `oxiflow-geo` | Surface geophysics | Bingham Saint-Venant, Shallow Water, ALE interface |
-| `oxiflow-thermo` | Heat transfer | Fourier flux, Robin BC, phase change |
-| `oxiflow-em` | Diffusive electromagnetism | magnetic diffusion, eddy currents |
+| Crate            | Domain                     | Key models                                             |
+|------------------|----------------------------|--------------------------------------------------------|
+| `oxiflow-chrom`  | Chromatography             | Langmuir, SMA, Thomas, gradient elution, Danckwerts BC |
+| `oxiflow-geo`    | Surface geophysics         | Bingham Saint-Venant, Shallow Water, ALE interface     |
+| `oxiflow-thermo` | Heat transfer              | Fourier flux, Robin BC, phase change                   |
+| `oxiflow-em`     | Diffusive electromagnetism | magnetic diffusion, eddy currents                      |
 
 ### 10.5 Third-party frameworks
 
@@ -361,12 +361,12 @@ Requirements for a third-party framework:
 
 ## 11. Known Ecosystem Frameworks
 
-| Crate | Domain | Maintainer | Status |
-|---|---|---|---|
-| `oxiflow-chrom` | Chromatography | oxiflow core team | Planned v3.0 |
-| `oxiflow-geo` | Surface geophysics | oxiflow core team | Planned v3.0 |
-| `oxiflow-thermo` | Heat transfer | oxiflow core team | Planned v3.0 |
-| `oxiflow-em` | Diffusive EM | oxiflow core team | Planned v3.0 |
+| Crate            | Domain             | Maintainer        | Status       |
+|------------------|--------------------|-------------------|--------------|
+| `oxiflow-chrom`  | Chromatography     | oxiflow core team | Planned v3.0 |
+| `oxiflow-geo`    | Surface geophysics | oxiflow core team | Planned v3.0 |
+| `oxiflow-thermo` | Heat transfer      | oxiflow core team | Planned v3.0 |
+| `oxiflow-em`     | Diffusive EM       | oxiflow core team | Planned v3.0 |
 
 *To add a framework to this list, open a PR modifying this table.*
 
@@ -374,62 +374,62 @@ Requirements for a third-party framework:
 
 ## 12. Architectural Decision Log
 
-| Decision | Choice | Rejected alternative | Milestone | Invariant |
-|---|---|---|---|---|
-| Calculator return type | `ContextValue` enum | `f64` scalar only | J1 | |
-| Error type | `OxiflowError` enum | `String` | J1 | |
-| Context access API | `ComputeContext` type-safe from v0.2 | Progressive migration | J1 | |
-| Needs declaration | Separate `RequiresContext` trait | Method on `PhysicalModel` | J1 | |
-| Spatial support | Abstract `Mesh` trait | `dx`/`nx` in `PhysicalState` | J1 | INV-1 |
-| BC requirements | `RequiresContext` on `BoundaryCondition` | Manual aggregation | J2 | |
-| Ordering | Hybrid topology + priority | Pure DAG or priority only | J2 | |
-| Multi-component | Indexed `PhysicalQuantity` | Flat enum with breaking changes | J3 | |
-| Multi-domain coupling | `CouplingOperator` with `DomainId` + `Interface` | Ad-hoc method | J3 | INV-3 |
-| Spatial operators | Abstract `DiscreteOperator` parameterised by `Mesh` | FD hardcoded | J4 | INV-2 |
-| Linear solvers | `faer`/`nalgebra` delegation | Custom implementation | J4 | |
-| Parallelism | Rayon, opt-in feature flag | Mandatory or absent | J5 | |
-| Caching | Dirty flag + temporal invalidation | Systematic recomputation | J5 | |
-| API stability | SemVer + `cargo-semver-checks` + FEM audit | Informal convention | J6 | |
-| Plugin architecture | Object-safe traits + `PluginRegistry` | Monolithic crate | J7 | INV-4 |
-| Framework config | TOML + runtime registry | proc-macro DSL | J8 | |
-| License | Apache 2.0 only | MIT or dual MIT/Apache | J0 | |
+| Decision               | Choice                                              | Rejected alternative            | Milestone | Invariant |
+|------------------------|-----------------------------------------------------|---------------------------------|-----------|-----------|
+| Calculator return type | `ContextValue` enum                                 | `f64` scalar only               | J1        |           |
+| Error type             | `OxiflowError` enum                                 | `String`                        | J1        |           |
+| Context access API     | `ComputeContext` type-safe from v0.2                | Progressive migration           | J1        |           |
+| Needs declaration      | Separate `RequiresContext` trait                    | Method on `PhysicalModel`       | J1        |           |
+| Spatial support        | Abstract `Mesh` trait                               | `dx`/`nx` in `PhysicalState`    | J1        | INV-1     |
+| BC requirements        | `RequiresContext` on `BoundaryCondition`            | Manual aggregation              | J2        |           |
+| Ordering               | Hybrid topology + priority                          | Pure DAG or priority only       | J2        |           |
+| Multi-component        | Indexed `PhysicalQuantity`                          | Flat enum with breaking changes | J3        |           |
+| Multi-domain coupling  | `CouplingOperator` with `DomainId` + `Interface`    | Ad-hoc method                   | J3        | INV-3     |
+| Spatial operators      | Abstract `DiscreteOperator` parameterised by `Mesh` | FD hardcoded                    | J4        | INV-2     |
+| Linear solvers         | `faer`/`nalgebra` delegation                        | Custom implementation           | J4        |           |
+| Parallelism            | Rayon, opt-in feature flag                          | Mandatory or absent             | J5        |           |
+| Caching                | Dirty flag + temporal invalidation                  | Systematic recomputation        | J5        |           |
+| API stability          | SemVer + `cargo-semver-checks` + FEM audit          | Informal convention             | J6        |           |
+| Plugin architecture    | Object-safe traits + `PluginRegistry`               | Monolithic crate                | J7        | INV-4     |
+| Framework config       | TOML + runtime registry                             | proc-macro DSL                  | J8        |           |
+| License                | Apache 2.0 only                                     | MIT or dual MIT/Apache          | J0        |           |
 
 ---
 
 ## 13. Risk Register
 
-| ID | Risk | Probability | Mitigation |
-|---|---|---|---|
-| R1 | `ContextValue` generics too complex for users | Medium | Ergonomic helpers (`.as_scalar()?`); user testing at v0.2 |
-| R2 | Silent dependency ordering bugs | Low | Exhaustive cycle detection tests; debug logging |
-| R3 | `PhysicalQuantity` indexing too verbose | Medium | Idiomatic constructors (`::solute(k)`); UX feedback before v1.0 |
-| R4 | Implicit solvers require heavy linear algebra | High | Delegate to `faer`/`nalgebra`; document limits |
-| R5 | Rayon + potential `unsafe` | Low | Opt-in flag; ThreadSanitizer in CI; explicit `unsafe` review |
-| R6 | Scope too ambitious — no milestone delivered | Medium | Each milestone independently deliverable |
-| R7 | Breaking change forced before v1.0 | Low | Accepted pre-1.0 but documented |
-| R8 | INV-1/2/3 silently violated during J1–J6 | Medium | Formal audit at J6; dedicated integration tests |
-| R9 | ALE incompatible with CouplingOperator design | Low | Proto lahar–lake at J3 is the test bench |
-| **R10** | **INV-4 violated — third-party frameworks break on engine update** | **Medium** | **`oxiflow-test-plugin` external crate in CI from v2.0; `cargo-semver-checks` in release pipeline** |
-| **R11** | **Fragmentation — incompatible third-party frameworks** | **Low** | **INV-4 + stable public API is the only compatibility contract; framework authors are responsible for their own SemVer** |
+| ID      | Risk                                                               | Probability | Mitigation                                                                                                               |
+|---------|--------------------------------------------------------------------|-------------|--------------------------------------------------------------------------------------------------------------------------|
+| R1      | `ContextValue` generics too complex for users                      | Medium      | Ergonomic helpers (`.as_scalar()?`); user testing at v0.2                                                                |
+| R2      | Silent dependency ordering bugs                                    | Low         | Exhaustive cycle detection tests; debug logging                                                                          |
+| R3      | `PhysicalQuantity` indexing too verbose                            | Medium      | Idiomatic constructors (`::solute(k)`); UX feedback before v1.0                                                          |
+| R4      | Implicit solvers require heavy linear algebra                      | High        | Delegate to `faer`/`nalgebra`; document limits                                                                           |
+| R5      | Rayon + potential `unsafe`                                         | Low         | Opt-in flag; ThreadSanitizer in CI; explicit `unsafe` review                                                             |
+| R6      | Scope too ambitious — no milestone delivered                       | Medium      | Each milestone independently deliverable                                                                                 |
+| R7      | Breaking change forced before v1.0                                 | Low         | Accepted pre-1.0 but documented                                                                                          |
+| R8      | INV-1/2/3 silently violated during J1–J6                           | Medium      | Formal audit at J6; dedicated integration tests                                                                          |
+| R9      | ALE incompatible with CouplingOperator design                      | Low         | Proto lahar–lake at J3 is the test bench                                                                                 |
+| **R10** | **INV-4 violated — third-party frameworks break on engine update** | **Medium**  | **`oxiflow-test-plugin` external crate in CI from v2.0; `cargo-semver-checks` in release pipeline**                      |
+| **R11** | **Fragmentation — incompatible third-party frameworks**            | **Low**     | **INV-4 + stable public API is the only compatibility contract; framework authors are responsible for their own SemVer** |
 
 ---
 
 ## 14. Timeline
 
-| Month | Milestone | Key objectives |
-|---|---|---|
-| M0 | v0.1 — Foundations | crates.io placeholder · CI · README · NOTICE |
-| M+1–2 | v0.2 — J1 | ContextValue · OxiflowError · Mesh (INV-1) |
-| M+3–4 | v0.3 — J2 | Requiring BCs · topology · built-in calculators |
-| M+5–6 | v0.4 — J3 | PhysicalQuantity · CouplingOperator (INV-3) · proto lahar–lake |
-| M+7–8 | v0.5 — J4a | Temporal integrators |
-| M+9–10 | v0.6 — J4b | DiscreteOperator (INV-2) · FD/FV · WENO |
-| M+11–13 | v0.7 — J5 | Rayon · cache · benchmarks |
-| M+14–15 | v0.9 — RC | 7 examples · API freeze · FEM audit |
-| M+16 | v1.0 | Stable release · official publication |
-| M+17–24 | v2.0 — J7 | Unstructured mesh · FEM assembler · ALE · INV-4 |
-| M+25–32 | v3.0 — J8 | oxiflow-chrom · oxiflow-geo · oxiflow-thermo · CLI |
-| M+32+ | Third-party | Community frameworks on crates.io |
+| Month   | Milestone            | Key objectives                                                 |
+|---------|----------------------|----------------------------------------------------------------|
+| M0      | v0.0.5 — Foundations | crates.io placeholder · CI · README · NOTICE                   |
+| M+1–2   | v0.1 — J1            | ContextValue · OxiflowError · Mesh (INV-1)                     |
+| M+3–4   | v0.2 — J2            | Requiring BCs · topology · built-in calculators                |
+| M+5–6   | v0.3 — J3            | PhysicalQuantity · CouplingOperator (INV-3) · proto lahar–lake |
+| M+7–8   | v0.4 — J4a           | Temporal integrators                                           |
+| M+9–10  | v0.5 — J4b           | DiscreteOperator (INV-2) · FD/FV · WENO                        |
+| M+11–13 | v0.6 — J5            | Rayon · cache · benchmarks                                     |
+| M+14–15 | v0.9 — RC            | 7 examples · API freeze · FEM audit                            |
+| M+16    | v1.0                 | Stable release · official publication                          |
+| M+17–24 | v2.0 — J7            | Unstructured mesh · FEM assembler · ALE · INV-4                |
+| M+25–32 | v3.0 — J8            | oxiflow-chrom · oxiflow-geo · oxiflow-thermo · CLI             |
+| M+32+   | Third-party          | Community frameworks on crates.io                              |
 
 ---
 

--- a/DEVELOPPEMENT.md
+++ b/DEVELOPPEMENT.md
@@ -17,7 +17,7 @@ journal de décisions qui guident l'ensemble du travail d'implémentation de v0.
 3. [J1 — Architecture cœur (v0.2)](#3-j1--architecture-cœur-v02)
 4. [J2 — Contexte complet (v0.3)](#4-j2--contexte-complet-v03)
 5. [J3 — Multi-composants (v0.4)](#5-j3--multi-composants-v04)
-6. [J4 — Solveurs & Discrétisation (v0.5–0.6)](#6-j4--solveurs--discrétisation-v05-06)
+6. [J4 — Solveurs & Discrétisation (v0.4–0.5)](#6-j4--solveurs--discrétisation-v05-06)
 7. [J5 — Performance (v0.7)](#7-j5--performance-v07)
 8. [J6 — Écosystème v1.0](#8-j6--écosystème-v10)
 9. [Compatibilité FEM — Trajectoire v2.0](#9-compatibilité-fem--trajectoire-v20)
@@ -78,18 +78,18 @@ scientifiques spécifiques avec un minimum de code de plomberie.
 
 ## 2. Vue d'ensemble des jalons
 
-| Jalon | Version | Échéance | Thème |
-|---|---|---|---|
-| J0 — Fondations | v0.1 | Acquis | placeholder crates.io · CI · structure projet |
-| J1 — Architecture cœur | v0.2 | M+2 | ContextValue · OxiflowError · Mesh (INV-1) |
-| J2 — Contexte complet | v0.3 | M+4 | BCs requirantes · ordonnancement topologique |
-| J3 — Multi-composants | v0.4 | M+6 | PhysicalQuantity · CouplingOperator (INV-3) |
-| J4a — Intégrateurs | v0.5 | M+8 | Intégrateurs temporels |
-| J4b — Discrétisation | v0.6 | M+10 | DiscreteOperator (INV-2) · FD/FV/WENO |
-| J5 — Performance | v0.7 | M+13 | Rayon · cache · benchmarks |
-| J6 — Écosystème v1.0 | v1.0 | M+16 | 7 exemples · audit FEM · API stable |
-| J7 — FEM | v2.0 | M+24 | Maillages non structurés · ALE · INV-4 plugin-safe |
-| J8 — Frameworks | v3.0 | M+32 | oxiflow-chrom · oxiflow-geo · CLI · tiers |
+| Jalon                  | Version | Échéance | Thème                                              |
+|------------------------|---------|----------|----------------------------------------------------|
+| J0 — Fondations        | v0.0.5  | Acquis   | placeholder crates.io · CI · structure projet      |
+| J1 — Architecture cœur | v0.1    | Acquis   | ContextValue · OxiflowError · Mesh (INV-1)         |
+| J2 — Contexte complet  | v0.2    | M+4      | BCs requirantes · ordonnancement topologique       |
+| J3 — Multi-composants  | v0.3    | M+6      | PhysicalQuantity · CouplingOperator (INV-3)        |
+| J4a — Intégrateurs     | v0.4    | M+8      | Intégrateurs temporels                             |
+| J4b — Discrétisation   | v0.5    | M+10     | DiscreteOperator (INV-2) · FD/FV/WENO              |
+| J5 — Performance       | v0.6    | M+13     | Rayon · cache · benchmarks                         |
+| J6 — Écosystème v1.0   | v1.0    | M+16     | 7 exemples · audit FEM · API stable                |
+| J7 — FEM               | v2.0    | M+24     | Maillages non structurés · ALE · INV-4 plugin-safe |
+| J8 — Frameworks        | v3.0    | M+32     | oxiflow-chrom · oxiflow-geo · CLI · tiers          |
 
 Chaque jalon est livrable indépendamment. J1 seul (v0.2) est une bibliothèque utilisable
 pour la modélisation en chromatographie. Le développement de frameworks tiers peut démarrer
@@ -168,11 +168,11 @@ gradient FD, Laplacien, quadrature, interpolation tabulée externe, lecteur HDF5
 
 Correspondances BC chromatographiques :
 
-| BC chromatographique | Type mathématique | Contexte nécessaire |
-|---|---|---|
-| BC simplifiée | Dirichlet | profil de concentration d'injection |
-| BC de Danckwerts (entrée) | Robin | temps + gradient |
-| BC de Danckwerts (sortie) | Neumann | gradient uniquement |
+| BC chromatographique      | Type mathématique | Contexte nécessaire                 |
+|---------------------------|-------------------|-------------------------------------|
+| BC simplifiée             | Dirichlet         | profil de concentration d'injection |
+| BC de Danckwerts (entrée) | Robin             | temps + gradient                    |
+| BC de Danckwerts (sortie) | Neumann           | gradient uniquement                 |
 
 ---
 
@@ -183,7 +183,7 @@ Proto lahar–lac sur grilles régulières — base de régression pour la FEM v
 
 ---
 
-## 6. J4 — Solveurs & Discrétisation (v0.5–0.6)
+## 6. J4 — Solveurs & Discrétisation (v0.4–0.5)
 
 Intégrateurs temporels : Euler explicite, RK4, DoPri45, Euler implicite, Crank–Nicolson,
 BDF2/3, IMEX (splitting de Strang).
@@ -236,11 +236,11 @@ et générant une vague de submersion. Nécessite un maillage non structuré pou
 irrégulière et un raffinement adaptatif pour le front d'onde — impossible avec les
 différences finies.
 
-| Composante | Modèle | Défi numérique |
-|---|---|---|
+| Composante         | Modèle                        | Défi numérique                        |
+|--------------------|-------------------------------|---------------------------------------|
 | Domaine granulaire | Bingham + Saint-Venant étendu | frontière mobile · maillage adaptatif |
-| Domaine fluide | Équations de Shallow Water | bathymétrie irrégulière |
-| Interface mobile | Formulation ALE | transfert masse/quantité de mouvement |
+| Domaine fluide     | Équations de Shallow Water    | bathymétrie irrégulière               |
+| Interface mobile   | Formulation ALE               | transfert masse/quantité de mouvement |
 
 ### 9.2 INV-4 — API plugin-safe
 
@@ -344,12 +344,12 @@ oxiflow list models --framework chrom
 
 ### 10.4 Frameworks first-party prévus
 
-| Crate | Domaine | Modèles clés |
-|---|---|---|
-| `oxiflow-chrom` | Chromatographie | Langmuir, SMA, Thomas, élution gradient, BC de Danckwerts |
-| `oxiflow-geo` | Géophysique de surface | Bingham Saint-Venant, Shallow Water, interface ALE |
-| `oxiflow-thermo` | Transfert thermique | flux de Fourier, BC de Robin, changement de phase |
-| `oxiflow-em` | Électromagnétisme diffusif | diffusion magnétique, courants de Foucault |
+| Crate            | Domaine                    | Modèles clés                                              |
+|------------------|----------------------------|-----------------------------------------------------------|
+| `oxiflow-chrom`  | Chromatographie            | Langmuir, SMA, Thomas, élution gradient, BC de Danckwerts |
+| `oxiflow-geo`    | Géophysique de surface     | Bingham Saint-Venant, Shallow Water, interface ALE        |
+| `oxiflow-thermo` | Transfert thermique        | flux de Fourier, BC de Robin, changement de phase         |
+| `oxiflow-em`     | Électromagnétisme diffusif | diffusion magnétique, courants de Foucault                |
 
 ### 10.5 Frameworks tiers
 
@@ -367,12 +367,12 @@ Conditions pour un framework tiers :
 
 ## 11. Frameworks de l'écosystème connus
 
-| Crate | Domaine | Mainteneur | Statut |
-|---|---|---|---|
-| `oxiflow-chrom` | Chromatographie | équipe core oxiflow | Planifié v3.0 |
-| `oxiflow-geo` | Géophysique de surface | équipe core oxiflow | Planifié v3.0 |
-| `oxiflow-thermo` | Transfert thermique | équipe core oxiflow | Planifié v3.0 |
-| `oxiflow-em` | Électromagnétisme diffusif | équipe core oxiflow | Planifié v3.0 |
+| Crate            | Domaine                    | Mainteneur          | Statut        |
+|------------------|----------------------------|---------------------|---------------|
+| `oxiflow-chrom`  | Chromatographie            | équipe core oxiflow | Planifié v3.0 |
+| `oxiflow-geo`    | Géophysique de surface     | équipe core oxiflow | Planifié v3.0 |
+| `oxiflow-thermo` | Transfert thermique        | équipe core oxiflow | Planifié v3.0 |
+| `oxiflow-em`     | Électromagnétisme diffusif | équipe core oxiflow | Planifié v3.0 |
 
 *Pour ajouter un framework à cette liste, ouvrir une PR modifiant ce tableau.*
 
@@ -380,62 +380,62 @@ Conditions pour un framework tiers :
 
 ## 12. Journal des décisions architecturales
 
-| Décision | Choix retenu | Alternative rejetée | Jalon | Invariant |
-|---|---|---|---|---|
-| Type de retour calculateur | `ContextValue` enum | `f64` scalaire | J1 | |
-| Type d'erreur | `OxiflowError` enum | `String` | J1 | |
-| API d'accès au contexte | `ComputeContext` type-safe dès v0.2 | Migration progressive | J1 | |
-| Déclaration des besoins | Trait `RequiresContext` séparé | Méthode sur `PhysicalModel` | J1 | |
-| Support spatial | Trait abstrait `Mesh` | `dx`/`nx` dans `PhysicalState` | J1 | INV-1 |
-| BCs requirantes | `RequiresContext` sur `BoundaryCondition` | Agrégation manuelle | J2 | |
-| Ordonnancement | Topologie + priorité hybride | DAG pur ou priorité seule | J2 | |
-| Multi-composants | `PhysicalQuantity` indexé | Enum plat avec breaking changes | J3 | |
-| Couplage multi-physique | `CouplingOperator` avec `DomainId` + `Interface` | Méthode ad-hoc | J3 | INV-3 |
-| Opérateurs spatiaux | `DiscreteOperator` abstrait paramétré par `Mesh` | FD codé en dur | J4 | INV-2 |
-| Solveurs linéaires | Délégation `faer`/`nalgebra` | Implémentation maison | J4 | |
-| Parallélisme | Rayon, opt-in feature flag | Obligatoire ou absent | J5 | |
-| Cache | Dirty flag + invalidation temporelle | Recalcul systématique | J5 | |
-| Stabilité API | SemVer + `cargo-semver-checks` + audit FEM | Convention informelle | J6 | |
-| Architecture plugin | Traits object-safe + `PluginRegistry` | Crate monolithique | J7 | INV-4 |
-| Config framework | TOML + registre runtime | DSL proc-macro | J8 | |
-| Licence | Apache 2.0 seule | MIT ou double MIT/Apache | J0 | |
+| Décision                   | Choix retenu                                     | Alternative rejetée             | Jalon | Invariant |
+|----------------------------|--------------------------------------------------|---------------------------------|-------|-----------|
+| Type de retour calculateur | `ContextValue` enum                              | `f64` scalaire                  | J1    |           |
+| Type d'erreur              | `OxiflowError` enum                              | `String`                        | J1    |           |
+| API d'accès au contexte    | `ComputeContext` type-safe dès v0.2              | Migration progressive           | J1    |           |
+| Déclaration des besoins    | Trait `RequiresContext` séparé                   | Méthode sur `PhysicalModel`     | J1    |           |
+| Support spatial            | Trait abstrait `Mesh`                            | `dx`/`nx` dans `PhysicalState`  | J1    | INV-1     |
+| BCs requirantes            | `RequiresContext` sur `BoundaryCondition`        | Agrégation manuelle             | J2    |           |
+| Ordonnancement             | Topologie + priorité hybride                     | DAG pur ou priorité seule       | J2    |           |
+| Multi-composants           | `PhysicalQuantity` indexé                        | Enum plat avec breaking changes | J3    |           |
+| Couplage multi-physique    | `CouplingOperator` avec `DomainId` + `Interface` | Méthode ad-hoc                  | J3    | INV-3     |
+| Opérateurs spatiaux        | `DiscreteOperator` abstrait paramétré par `Mesh` | FD codé en dur                  | J4    | INV-2     |
+| Solveurs linéaires         | Délégation `faer`/`nalgebra`                     | Implémentation maison           | J4    |           |
+| Parallélisme               | Rayon, opt-in feature flag                       | Obligatoire ou absent           | J5    |           |
+| Cache                      | Dirty flag + invalidation temporelle             | Recalcul systématique           | J5    |           |
+| Stabilité API              | SemVer + `cargo-semver-checks` + audit FEM       | Convention informelle           | J6    |           |
+| Architecture plugin        | Traits object-safe + `PluginRegistry`            | Crate monolithique              | J7    | INV-4     |
+| Config framework           | TOML + registre runtime                          | DSL proc-macro                  | J8    |           |
+| Licence                    | Apache 2.0 seule                                 | MIT ou double MIT/Apache        | J0    |           |
 
 ---
 
 ## 13. Registre des risques
 
-| ID | Risque | Probabilité | Mitigation |
-|---|---|---|---|
-| R1 | Généricité `ContextValue` trop complexe | Moyenne | Helpers ergonomiques ; tests utilisateurs dès v0.2 |
-| R2 | Bugs silencieux d'ordonnancement | Faible | Tests exhaustifs de détection de cycles ; logging debug |
-| R3 | `PhysicalQuantity` indexé trop verbeux | Moyenne | Constructeurs idiomatiques ; feedback UX avant v1.0 |
-| R4 | Solveurs implicites requièrent algèbre linéaire lourde | Haute | Déléguer à `faer`/`nalgebra` ; documenter les limites |
-| R5 | Rayon + `unsafe` potentiel | Faible | Feature flag opt-in ; ThreadSanitizer en CI |
-| R6 | Périmètre trop ambitieux | Moyenne | Chaque jalon livrable indépendamment |
-| R7 | Breaking change forcé avant v1.0 | Faible | Accepté pre-1.0 mais documenté |
-| R8 | INV-1/2/3 silencieusement violés | Moyenne | Audit formel à J6 ; tests d'intégration dédiés |
-| R9 | ALE incompatible avec CouplingOperator | Faible | Proto lahar–lac à J3 est le banc d'essai |
-| **R10** | **INV-4 violé — frameworks tiers cassés lors d'une mise à jour du moteur** | **Moyenne** | **Crate `oxiflow-test-plugin` externe en CI dès v2.0 ; `cargo-semver-checks` dans le pipeline** |
-| **R11** | **Fragmentation — frameworks tiers incompatibles entre eux** | **Faible** | **INV-4 + API publique stable est le seul contrat de compatibilité ; les auteurs de frameworks sont responsables de leur propre SemVer** |
+| ID      | Risque                                                                     | Probabilité | Mitigation                                                                                                                               |
+|---------|----------------------------------------------------------------------------|-------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| R1      | Généricité `ContextValue` trop complexe                                    | Moyenne     | Helpers ergonomiques ; tests utilisateurs dès v0.2                                                                                       |
+| R2      | Bugs silencieux d'ordonnancement                                           | Faible      | Tests exhaustifs de détection de cycles ; logging debug                                                                                  |
+| R3      | `PhysicalQuantity` indexé trop verbeux                                     | Moyenne     | Constructeurs idiomatiques ; feedback UX avant v1.0                                                                                      |
+| R4      | Solveurs implicites requièrent algèbre linéaire lourde                     | Haute       | Déléguer à `faer`/`nalgebra` ; documenter les limites                                                                                    |
+| R5      | Rayon + `unsafe` potentiel                                                 | Faible      | Feature flag opt-in ; ThreadSanitizer en CI                                                                                              |
+| R6      | Périmètre trop ambitieux                                                   | Moyenne     | Chaque jalon livrable indépendamment                                                                                                     |
+| R7      | Breaking change forcé avant v1.0                                           | Faible      | Accepté pre-1.0 mais documenté                                                                                                           |
+| R8      | INV-1/2/3 silencieusement violés                                           | Moyenne     | Audit formel à J6 ; tests d'intégration dédiés                                                                                           |
+| R9      | ALE incompatible avec CouplingOperator                                     | Faible      | Proto lahar–lac à J3 est le banc d'essai                                                                                                 |
+| **R10** | **INV-4 violé — frameworks tiers cassés lors d'une mise à jour du moteur** | **Moyenne** | **Crate `oxiflow-test-plugin` externe en CI dès v2.0 ; `cargo-semver-checks` dans le pipeline**                                          |
+| **R11** | **Fragmentation — frameworks tiers incompatibles entre eux**               | **Faible**  | **INV-4 + API publique stable est le seul contrat de compatibilité ; les auteurs de frameworks sont responsables de leur propre SemVer** |
 
 ---
 
 ## 14. Chronologie
 
-| Mois | Jalon | Objectifs clés |
-|---|---|---|
-| M0 | v0.1 — Fondations | placeholder crates.io · CI · README · NOTICE |
-| M+1–2 | v0.2 — J1 | ContextValue · OxiflowError · Mesh (INV-1) |
-| M+3–4 | v0.3 — J2 | BCs requirantes · topologie · calculateurs built-in |
-| M+5–6 | v0.4 — J3 | PhysicalQuantity · CouplingOperator (INV-3) · proto lahar–lac |
-| M+7–8 | v0.5 — J4a | Intégrateurs temporels |
-| M+9–10 | v0.6 — J4b | DiscreteOperator (INV-2) · FD/FV · WENO |
-| M+11–13 | v0.7 — J5 | Rayon · cache · benchmarks Criterion |
-| M+14–15 | v0.9 — RC | 7 exemples · gel API · audit FEM |
-| M+16 | v1.0 | Publication stable officielle |
-| M+17–24 | v2.0 — J7 | Maillage non structuré · assembleur FEM · ALE · INV-4 |
-| M+25–32 | v3.0 — J8 | oxiflow-chrom · oxiflow-geo · oxiflow-thermo · CLI |
-| M+32+ | Tiers | Frameworks communautaires sur crates.io |
+| Mois    | Jalon               | Objectifs clés                                                |
+|---------|---------------------|---------------------------------------------------------------|
+| M0      | v0.0.5 — Fondations | placeholder crates.io · CI · README · NOTICE                  |
+| M+1–2   | v0.1 — J1           | ContextValue · OxiflowError · Mesh (INV-1)                    |
+| M+3–4   | v0.2 — J2           | BCs requirantes · topologie · calculateurs built-in           |
+| M+5–6   | v0.3 — J3           | PhysicalQuantity · CouplingOperator (INV-3) · proto lahar–lac |
+| M+7–8   | v0.4 — J4a          | Intégrateurs temporels                                        |
+| M+9–10  | v0.5 — J4b          | DiscreteOperator (INV-2) · FD/FV · WENO                       |
+| M+11–13 | v0.6 — J5           | Rayon · cache · benchmarks Criterion                          |
+| M+14–15 | v0.9 — RC           | 7 exemples · gel API · audit FEM                              |
+| M+16    | v1.0                | Publication stable officielle                                 |
+| M+17–24 | v2.0 — J7           | Maillage non structuré · assembleur FEM · ALE · INV-4         |
+| M+25–32 | v3.0 — J8           | oxiflow-chrom · oxiflow-geo · oxiflow-thermo · CLI            |
+| M+32+   | Tiers               | Frameworks communautaires sur crates.io                       |
 
 ---
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,7 +1,7 @@
 # oxiflow
 
 [![CI](https://github.com/biface/oxiflow/actions/workflows/ci.yml/badge.svg)](https://github.com/biface/oxiflow/actions/workflows/ci.yml)
-[![Couverture](https://codecov.io/gh/[USER]/oxiflow/branch/main/graph/badge.svg)](https://codecov.io/gh/biface/oxiflow)
+[![Couverture](https://codecov.io/gh/biface/oxiflow/graph/badge.svg?token=M6807F5BDQ)](https://codecov.io/gh/biface/oxiflow)
 [![Crates.io](https://img.shields.io/crates/v/oxiflow.svg)](https://crates.io/crates/oxiflow)
 [![Docs.rs](https://docs.rs/oxiflow/badge.svg)](https://docs.rs/oxiflow)
 [![Licence](https://img.shields.io/badge/licence-Apache--2.0-blue.svg)](#licence)

--- a/README.fr.md
+++ b/README.fr.md
@@ -139,7 +139,7 @@ assurent la compatibilité des frameworks tiers entre les versions du moteur :
 | Invariant | Description                                                                           | Introduit en |
 |-----------|---------------------------------------------------------------------------------------|--------------|
 | **INV-1** | `Mesh` est abstrait — `PhysicalState` ne présuppose aucune structure de grille        | v0.2         |
-| **INV-2** | `DiscreteOperator` est abstrait — les intégrateurs sont génériques sur le schéma      | v0.6         |
+| **INV-2** | `DiscreteOperator` est abstrait — les intégrateurs sont génériques sur le schéma      | v0.5         |
 | **INV-3** | `CouplingOperator` supporte des domaines distincts avec interfaces mobiles            | v0.4         |
 | **INV-4** | Tous les traits publics sont object-safe — des crates tierces peuvent les implémenter | v2.0         |
 
@@ -147,17 +147,17 @@ assurent la compatibilité des frameworks tiers entre les versions du moteur :
 
 ## État de Développement
 
-| Jalon                  | Version  | Statut       | Thème                                              |
-|------------------------|----------|--------------|----------------------------------------------------|
-| J0 — Fondations        | v0.1     | ✅ Publié     | Placeholder · CI · structure projet                |
-| J1 — Architecture cœur | v0.2     | 🔄 En cours  | ContextValue · OxiflowError · Mesh (INV-1)         |
-| J2 — Contexte complet  | v0.3     | ⏳ Planifié   | BCs requirantes · ordonnancement                   |
-| J3 — Multi-composants  | v0.4     | ⏳ Planifié   | PhysicalQuantity · CouplingOperator (INV-3)        |
-| J4 — Solveurs          | v0.5–0.6 | ⏳ Planifié   | Intégrateurs · DiscreteOperator (INV-2)            |
-| J5 — Performance       | v0.7     | ⏳ Planifié   | Rayon · cache · benchmarks                         |
-| J6 — Écosystème v1.0   | v1.0     | ⏳ Planifié   | 7 exemples · audit FEM · API stable                |
-| J7 — FEM               | v2.0     | 🔭 Horizon   | Maillages non structurés · ALE · INV-4 plugin-safe |
-| J8 — Frameworks        | v3.0     | 🔭 Horizon   | oxiflow-chrom · oxiflow-geo · CLI `oxiflow run`    |
+| Jalon                  | Version  | Statut      | Thème                                              |
+|------------------------|----------|-------------|----------------------------------------------------|
+| J0 — Fondations        | v0.0.5   | ✅ Publié    | Placeholder · CI · structure projet                |
+| J1 — Architecture cœur | v0.1     | ✅ Publié    | ContextValue · OxiflowError · Mesh (INV-1)         |
+| J2 — Contexte complet  | v0.2     | 🔄 En cours | BCs requirantes · ordonnancement                   |
+| J3 — Multi-composants  | v0.3     | ⏳ Planifié  | PhysicalQuantity · CouplingOperator (INV-3)        |
+| J4 — Solveurs          | v0.4–0.5 | ⏳ Planifié  | Intégrateurs · DiscreteOperator (INV-2)            |
+| J5 — Performance       | v0.6     | ⏳ Planifié  | Rayon · cache · benchmarks                         |
+| J6 — Écosystème v1.0   | v1.0     | ⏳ Planifié  | 7 exemples · audit FEM · API stable                |
+| J7 — FEM               | v2.0     | 🔭 Horizon  | Maillages non structurés · ALE · INV-4 plugin-safe |
+| J8 — Frameworks        | v3.0     | 🔭 Horizon  | oxiflow-chrom · oxiflow-geo · CLI `oxiflow run`    |
 
 Voir [DEVELOPPEMENT.md](DEVELOPPEMENT.md) pour la spécification architecturale complète.
 
@@ -168,9 +168,9 @@ Voir [DEVELOPPEMENT.md](DEVELOPPEMENT.md) pour la spécification architecturale 
 | Flag       | Description                                           | Disponible dès |
 |------------|-------------------------------------------------------|----------------|
 | *(défaut)* | Moteur cœur, exécution séquentielle                   | v0.2           |
-| `parallel` | Parallélisme Rayon pour les calculateurs indépendants | v0.7           |
-| `serde`    | Sérialisation des états et scénarios                  | v0.7           |
-| `hdf5`     | Import/export HDF5 pour données tabulées externes     | v0.7           |
+| `parallel` | Parallélisme Rayon pour les calculateurs indépendants | v0.6           |
+| `serde`    | Sérialisation des états et scénarios                  | v0.6           |
+| `hdf5`     | Import/export HDF5 pour données tabulées externes     | v0.6           |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ third-party frameworks remain compatible across engine versions:
 | Invariant | Description                                                               | Introduced |
 |-----------|---------------------------------------------------------------------------|------------|
 | **INV-1** | `Mesh` is abstract — `PhysicalState` carries no grid assumptions          | v0.2       |
-| **INV-2** | `DiscreteOperator` is abstract — integrators are generic over the scheme  | v0.6       |
+| **INV-2** | `DiscreteOperator` is abstract — integrators are generic over the scheme  | v0.5       |
 | **INV-3** | `CouplingOperator` supports distinct domains with moving interfaces       | v0.4       |
 | **INV-4** | All public traits are object-safe — third-party crates can implement them | v2.0       |
 
@@ -147,12 +147,12 @@ third-party frameworks remain compatible across engine versions:
 
 | Milestone              | Version  | Status         | Theme                                           |
 |------------------------|----------|----------------|-------------------------------------------------|
-| J0 — Foundations       | v0.1     | ✅ Published    | Placeholder · CI · project structure            |
-| J1 — Core Architecture | v0.2     | 🔄 In progress | ContextValue · OxiflowError · Mesh (INV-1)      |
-| J2 — Complete Context  | v0.3     | ⏳ Planned      | Requiring BCs · topological ordering            |
-| J3 — Multi-Component   | v0.4     | ⏳ Planned      | PhysicalQuantity · CouplingOperator (INV-3)     |
-| J4 — Solvers           | v0.5–0.6 | ⏳ Planned      | Integrators · DiscreteOperator (INV-2)          |
-| J5 — Performance       | v0.7     | ⏳ Planned      | Rayon · cache · benchmarks                      |
+| J0 — Foundations       | v0.0.5   | ✅ Published    | Placeholder · CI · project structure            |
+| J1 — Core Architecture | v0.1     | 🔄 In progress | ContextValue · OxiflowError · Mesh (INV-1)      |
+| J2 — Complete Context  | v0.2     | ⏳ Planned      | Requiring BCs · topological ordering            |
+| J3 — Multi-Component   | v0.3     | ⏳ Planned      | PhysicalQuantity · CouplingOperator (INV-3)     |
+| J4 — Solvers           | v0.4–0.5 | ⏳ Planned      | Integrators · DiscreteOperator (INV-2)          |
+| J5 — Performance       | v0.6     | ⏳ Planned      | Rayon · cache · benchmarks                      |
 | J6 — Ecosystem v1.0    | v1.0     | ⏳ Planned      | 7 examples · FEM audit · stable API             |
 | J7 — FEM               | v2.0     | 🔭 Horizon     | Unstructured meshes · ALE · INV-4 plugin-safe   |
 | J8 — Frameworks        | v3.0     | 🔭 Horizon     | oxiflow-chrom · oxiflow-geo · CLI `oxiflow run` |
@@ -166,9 +166,9 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for the full architectural specification.
 | Flag        | Description                                    | Available from |
 |-------------|------------------------------------------------|----------------|
 | *(default)* | Engine core, serial execution                  | v0.2           |
-| `parallel`  | Rayon parallelism for independent calculators  | v0.7           |
-| `serde`     | Serialisation of states and scenarios          | v0.7           |
-| `hdf5`      | HDF5 import/export for tabulated external data | v0.7           |
+| `parallel`  | Rayon parallelism for independent calculators  | v0.6           |
+| `serde`     | Serialisation of states and scenarios          | v0.6           |
+| `hdf5`      | HDF5 import/export for tabulated external data | v0.6           |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # oxiflow
 
 [![CI](https://github.com/biface/oxiflow/actions/workflows/ci.yml/badge.svg)](https://github.com/biface/oxiflow/actions/workflows/ci.yml)
-[![Coverage](https://codecov.io/gh/[USER]/oxiflow/branch/main/graph/badge.svg)](https://codecov.io/gh/biface/oxiflow)
+[![Coverage](https://codecov.io/gh/biface/oxiflow/graph/badge.svg?token=M6807F5BDQ)](https://codecov.io/gh/biface/oxiflow)
 [![Crates.io](https://img.shields.io/crates/v/oxiflow.svg)](https://crates.io/crates/oxiflow)
 [![Docs.rs](https://docs.rs/oxiflow/badge.svg)](https://docs.rs/oxiflow)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](#license)

--- a/src/boundary/danckwerts.rs
+++ b/src/boundary/danckwerts.rs
@@ -1,0 +1,567 @@
+//! # Module `boundary::danckwerts`
+//!
+//! Danckwerts boundary conditions for convection-diffusion problems (issue #35).
+//!
+//! ## Physical context
+//!
+//! Danckwerts conditions arise from a mass balance at the boundaries of a porous
+//! medium column (chromatography, fixed-bed reactors, dispersion in soil). They
+//! account for both convective and dispersive fluxes at the inlet and impose zero
+//! dispersive flux at the outlet.
+//!
+//! ## Inlet — Robin condition
+//!
+//! At $x = 0$, the total mass flux is continuous:
+//!
+//! $$v \, u(0, t) - D \left.\frac{\partial u}{\partial x}\right|_{x=0}
+//!   = v \, u_{\text{feed}}(t)$$
+//!
+//! Rearranged into an explicit assignment for the inlet node:
+//!
+//! $$u(0, t) = u_{\text{feed}}(t) + \frac{D}{v}
+//!   \left.\frac{\partial u}{\partial x}\right|_{x=0}$$
+//!
+//! The feed concentration $u_{\text{feed}}(t)$ is read from [`ComputeContext`] via
+//! a typed [`ContextVariable`] key — it can be constant, time-dependent, or
+//! produced by any user-supplied [`ContextCalculator`].
+//!
+//! ## Outlet — Neumann condition
+//!
+//! At $x = L$, the dispersive flux vanishes:
+//!
+//! $$\left.\frac{\partial u}{\partial x}\right|_{x=L} = 0$$
+//!
+//! Applied as a first-order finite-difference approximation: the last node value
+//! is set equal to its immediate predecessor, enforcing zero gradient.
+//!
+//! ## Souplesse
+//!
+//! The physical parameters $D$ (dispersion) and $v$ (velocity) are struct fields —
+//! they characterise the medium and do not change during a simulation. The feed
+//! concentration is deliberately read from context via a [`ContextVariable`] key,
+//! allowing any dynamics: constant injection, step injection, gradient elution, or
+//! a user-computed profile that itself depends on `Time` or other variables.
+//!
+//! ## Serialisation
+//!
+//! Both types implement `serde::Serialize` / `serde::Deserialize` under the `serde`
+//! feature flag. All fields are either `f64` or [`ContextVariable`] — both
+//! already serialisable.
+//!
+//! [`ComputeContext`]: crate::context::compute::ComputeContext
+//! [`ContextCalculator`]: crate::context::calculator::ContextCalculator
+//! [`ContextVariable`]: crate::context::variable::ContextVariable
+
+use crate::boundary::BoundaryCondition;
+use crate::context::compute::ComputeContext;
+use crate::context::error::OxiflowError;
+use crate::context::variable::ContextVariable;
+use crate::mesh::Mesh;
+use crate::model::traits::RequiresContext;
+use nalgebra::DVector;
+
+// ── DanckwertsInlet ───────────────────────────────────────────────────────────
+
+/// Danckwerts inlet condition — Robin BC at $x = 0$.
+///
+/// Enforces mass-flux continuity at the column inlet:
+///
+/// $$u(0, t) = u_{\text{feed}}(t) + \frac{D}{v}
+///   \left.\frac{\partial u}{\partial x}\right|_{x=0}$$
+///
+/// # Parameters
+///
+/// - `dispersion` — axial dispersion coefficient $D$ $[\text{m}^2 \cdot \text{s}^{-1}]$.
+/// - `velocity` — interstitial velocity $v$ $[\text{m} \cdot \text{s}^{-1}]$.
+/// - `feed_variable` — typed key used to read $u_{\text{feed}}(t)$ from
+///   [`ComputeContext`]. Any `ContextVariable` is accepted — typically an
+///   [`External`](crate::context::variable::ContextVariable::External) variable
+///   produced by a user-supplied calculator (constant, step, gradient elution…).
+///
+/// # Requirements
+///
+/// Declares two required context variables:
+///
+/// - `ContextVariable::SpatialGradient { dimension: 0, component: None }` —
+///   the nodal gradient field $\partial u / \partial x$ computed by a gradient
+///   calculator registered in `SolverConfiguration`.
+/// - `feed_variable` — the feed concentration $u_{\text{feed}}(t)$.
+///
+/// The solver validates that both are covered before the first time step.
+///
+/// # Serialisation
+///
+/// Implements `Serialize` / `Deserialize` under the `serde` feature flag.
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::boundary::danckwerts::DanckwertsInlet;
+/// use oxiflow::context::variable::ContextVariable;
+/// use oxiflow::model::RequiresContext;
+///
+/// let feed_var = ContextVariable::External { name: "feed_concentration".into() };
+/// let inlet = DanckwertsInlet::new(1e-7, 1e-3, feed_var);
+/// assert_eq!(inlet.priority(), 50);
+/// ```
+///
+/// [`ComputeContext`]: crate::context::compute::ComputeContext
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct DanckwertsInlet {
+    /// Axial dispersion coefficient $D$.
+    pub dispersion: f64,
+    /// Interstitial velocity $v$.
+    pub velocity: f64,
+    /// Context key used to read the feed concentration $u_{\text{feed}}(t)$.
+    pub feed_variable: ContextVariable,
+}
+
+impl DanckwertsInlet {
+    /// Creates a new `DanckwertsInlet`.
+    ///
+    /// # Parameters
+    ///
+    /// - `dispersion` — axial dispersion coefficient $D$.
+    /// - `velocity`   — interstitial velocity $v$ (must be non-zero at apply time).
+    /// - `feed_variable` — context key for $u_{\text{feed}}(t)$.
+    pub fn new(dispersion: f64, velocity: f64, feed_variable: ContextVariable) -> Self {
+        Self {
+            dispersion,
+            velocity,
+            feed_variable,
+        }
+    }
+}
+
+impl RequiresContext for DanckwertsInlet {
+    fn required_variables(&self) -> Vec<ContextVariable> {
+        vec![
+            ContextVariable::SpatialGradient {
+                dimension: 0,
+                component: None,
+            },
+            self.feed_variable.clone(),
+        ]
+    }
+
+    fn priority(&self) -> u32 {
+        50
+    }
+}
+
+impl BoundaryCondition for DanckwertsInlet {
+    /// Applies the Danckwerts inlet condition to `state[0]`.
+    ///
+    /// Reads `∂u/∂x|_{x=0}` from the gradient field at node 0 and
+    /// $u_{\text{feed}}$ from the context variable declared at construction.
+    ///
+    /// # Errors
+    ///
+    /// - [`OxiflowError::MissingCalculator`] if the gradient field or the feed
+    ///   variable is absent from the context.
+    /// - [`OxiflowError::TypeMismatch`] if the feed variable is not a `Scalar`.
+    /// - [`OxiflowError::PreconditionFailed`] if the mesh has no nodes or if
+    ///   `velocity` is zero (division by zero in $D/v$).
+    fn apply(
+        &self,
+        state: &mut DVector<f64>,
+        ctx: &ComputeContext,
+        mesh: &dyn Mesh,
+    ) -> Result<(), OxiflowError> {
+        if mesh.n_dof() == 0 {
+            return Err(OxiflowError::PreconditionFailed {
+                context: "DanckwertsInlet",
+                message: "mesh has no degrees of freedom".into(),
+            });
+        }
+        if self.velocity == 0.0 {
+            return Err(OxiflowError::PreconditionFailed {
+                context: "DanckwertsInlet",
+                message: "velocity must be non-zero".into(),
+            });
+        }
+
+        let gradient = ctx.gradient(0)?;
+        let du_dx_0 = gradient[0];
+        let u_feed = ctx.external(self.feed_variable.clone())?.as_scalar()?;
+
+        state[0] = u_feed + (self.dispersion / self.velocity) * du_dx_0;
+        Ok(())
+    }
+}
+
+// ── DanckwertsOutlet ──────────────────────────────────────────────────────────
+
+/// Danckwerts outlet condition — Neumann BC at $x = L$.
+///
+/// Enforces zero dispersive flux at the column outlet:
+///
+/// $$\left.\frac{\partial u}{\partial x}\right|_{x=L} = 0$$
+///
+/// Applied as a first-order finite-difference approximation:
+///
+/// $$u_{n-1} = u_{n-2}$$
+///
+/// No context variables are required — the condition depends only on the
+/// current field state and the mesh geometry.
+///
+/// # Serialisation
+///
+/// Implements `Serialize` / `Deserialize` under the `serde` feature flag.
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::boundary::danckwerts::DanckwertsOutlet;
+/// use oxiflow::model::RequiresContext;
+///
+/// let outlet = DanckwertsOutlet::new();
+/// assert_eq!(outlet.priority(), 60);
+/// ```
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct DanckwertsOutlet;
+
+impl DanckwertsOutlet {
+    /// Creates a new `DanckwertsOutlet`.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for DanckwertsOutlet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RequiresContext for DanckwertsOutlet {
+    fn required_variables(&self) -> Vec<ContextVariable> {
+        vec![]
+    }
+
+    fn priority(&self) -> u32 {
+        60
+    }
+}
+
+impl BoundaryCondition for DanckwertsOutlet {
+    /// Applies the Danckwerts outlet condition.
+    ///
+    /// Sets `state[n-1] = state[n-2]` — first-order approximation of zero
+    /// gradient at the outlet. Requires at least two nodes.
+    ///
+    /// # Errors
+    ///
+    /// - [`OxiflowError::PreconditionFailed`] if the mesh has fewer than two nodes.
+    fn apply(
+        &self,
+        state: &mut DVector<f64>,
+        _ctx: &ComputeContext,
+        mesh: &dyn Mesh,
+    ) -> Result<(), OxiflowError> {
+        let n = mesh.n_dof();
+        if n < 2 {
+            return Err(OxiflowError::PreconditionFailed {
+                context: "DanckwertsOutlet",
+                message: "mesh must have at least 2 nodes".into(),
+            });
+        }
+        state[n - 1] = state[n - 2];
+        Ok(())
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::value::ContextValue;
+    use crate::mesh::structured::UniformGrid1D;
+    use nalgebra::DVector;
+
+    // ── Fixtures ──────────────────────────────────────────────────────────────
+
+    fn feed_var() -> ContextVariable {
+        ContextVariable::External {
+            name: "feed_concentration".into(),
+        }
+    }
+
+    fn make_inlet(d: f64, v: f64) -> DanckwertsInlet {
+        DanckwertsInlet::new(d, v, feed_var())
+    }
+
+    fn make_mesh(n: usize) -> UniformGrid1D {
+        UniformGrid1D::new(n, 0.0, 1.0).unwrap()
+    }
+
+    fn make_ctx_with_gradient_and_feed(gradient_at_0: f64, u_feed: f64) -> ComputeContext {
+        let mut ctx = ComputeContext::new(0.0, 0.01);
+        let n = 5;
+        let mut grad = DVector::zeros(n);
+        grad[0] = gradient_at_0;
+        ctx.insert(
+            ContextVariable::SpatialGradient {
+                dimension: 0,
+                component: None,
+            },
+            ContextValue::ScalarField(grad),
+        );
+        ctx.insert(feed_var(), ContextValue::Scalar(u_feed));
+        ctx
+    }
+
+    // ── RequiresContext — DanckwertsInlet ─────────────────────────────────────
+
+    #[test]
+    fn inlet_required_variables_contains_gradient_and_feed() {
+        let inlet = make_inlet(1e-7, 1e-3);
+        let reqs = inlet.required_variables();
+        assert!(reqs.contains(&ContextVariable::SpatialGradient {
+            dimension: 0,
+            component: None,
+        }));
+        assert!(reqs.contains(&feed_var()));
+        assert_eq!(reqs.len(), 2);
+    }
+
+    #[test]
+    fn inlet_optional_variables_default_empty() {
+        assert!(make_inlet(1e-7, 1e-3).optional_variables().is_empty());
+    }
+
+    #[test]
+    fn inlet_depends_on_default_empty() {
+        assert!(make_inlet(1e-7, 1e-3).depends_on().is_empty());
+    }
+
+    #[test]
+    fn inlet_priority_is_50() {
+        assert_eq!(make_inlet(1e-7, 1e-3).priority(), 50);
+    }
+
+    // ── RequiresContext — DanckwertsOutlet ────────────────────────────────────
+
+    #[test]
+    fn outlet_required_variables_is_empty() {
+        assert!(DanckwertsOutlet::new().required_variables().is_empty());
+    }
+
+    #[test]
+    fn outlet_priority_is_60() {
+        assert_eq!(DanckwertsOutlet::new().priority(), 60);
+    }
+
+    // ── apply — DanckwertsInlet ───────────────────────────────────────────────
+
+    #[test]
+    fn inlet_apply_zero_gradient_equals_u_feed() {
+        // When ∂u/∂x|₀ = 0, state[0] = u_feed exactly.
+        let inlet = make_inlet(1e-7, 1e-3);
+        let mesh = make_mesh(5);
+        let ctx = make_ctx_with_gradient_and_feed(0.0, 1.0);
+        let mut state = DVector::zeros(5);
+        inlet.apply(&mut state, &ctx, &mesh).unwrap();
+        assert!((state[0] - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn inlet_apply_formula_is_correct() {
+        // u(0) = u_feed + (D/v) * du_dx_0
+        // With D=1e-4, v=1e-2, du_dx_0=0.5, u_feed=0.8:
+        // u(0) = 0.8 + (1e-4/1e-2)*0.5 = 0.8 + 0.005 = 0.805
+        let inlet = make_inlet(1e-4, 1e-2);
+        let mesh = make_mesh(5);
+        let ctx = make_ctx_with_gradient_and_feed(0.5, 0.8);
+        let mut state = DVector::zeros(5);
+        inlet.apply(&mut state, &ctx, &mesh).unwrap();
+        let expected = 0.8 + (1e-4 / 1e-2) * 0.5;
+        assert!((state[0] - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn inlet_apply_does_not_modify_other_nodes() {
+        let inlet = make_inlet(1e-7, 1e-3);
+        let mesh = make_mesh(5);
+        let ctx = make_ctx_with_gradient_and_feed(0.0, 1.0);
+        let mut state = DVector::from_element(5, 2.0);
+        inlet.apply(&mut state, &ctx, &mesh).unwrap();
+        // Only node 0 is changed.
+        for i in 1..5 {
+            assert!((state[i] - 2.0).abs() < 1e-12, "node {i} was modified");
+        }
+    }
+
+    #[test]
+    fn inlet_apply_missing_gradient_returns_error() {
+        let inlet = make_inlet(1e-7, 1e-3);
+        let mesh = make_mesh(5);
+        let mut ctx = ComputeContext::new(0.0, 0.01);
+        ctx.insert(feed_var(), ContextValue::Scalar(1.0));
+        // Gradient not inserted.
+        let mut state = DVector::zeros(5);
+        let err = inlet.apply(&mut state, &ctx, &mesh).unwrap_err();
+        assert!(matches!(err, OxiflowError::MissingCalculator(_)));
+    }
+
+    #[test]
+    fn inlet_apply_missing_feed_returns_error() {
+        let inlet = make_inlet(1e-7, 1e-3);
+        let mesh = make_mesh(5);
+        let mut ctx = ComputeContext::new(0.0, 0.01);
+        let grad = ContextValue::ScalarField(DVector::zeros(5));
+        ctx.insert(
+            ContextVariable::SpatialGradient {
+                dimension: 0,
+                component: None,
+            },
+            grad,
+        );
+        // Feed not inserted.
+        let mut state = DVector::zeros(5);
+        let err = inlet.apply(&mut state, &ctx, &mesh).unwrap_err();
+        assert!(matches!(err, OxiflowError::MissingCalculator(_)));
+    }
+
+    #[test]
+    fn inlet_apply_zero_velocity_returns_error() {
+        let inlet = make_inlet(1e-7, 0.0);
+        let mesh = make_mesh(5);
+        let ctx = make_ctx_with_gradient_and_feed(0.0, 1.0);
+        let mut state = DVector::zeros(5);
+        let err = inlet.apply(&mut state, &ctx, &mesh).unwrap_err();
+        assert!(matches!(err, OxiflowError::PreconditionFailed { .. }));
+    }
+
+    #[test]
+    fn inlet_apply_empty_mesh_returns_error() {
+        let inlet = make_inlet(1e-7, 1e-3);
+        // UniformGrid1D requires n >= 2, so we use a DummyMesh for this edge case.
+        struct EmptyMesh;
+        impl Mesh for EmptyMesh {
+            fn n_dof(&self) -> usize {
+                0
+            }
+            fn coordinates(&self, _: usize) -> &[f64] {
+                &[]
+            }
+            fn spatial_dimension(&self) -> usize {
+                1
+            }
+            fn characteristic_length(&self) -> f64 {
+                0.0
+            }
+        }
+        impl std::fmt::Debug for EmptyMesh {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "EmptyMesh")
+            }
+        }
+        let mesh = EmptyMesh;
+        let ctx = make_ctx_with_gradient_and_feed(0.0, 1.0);
+        let mut state = DVector::zeros(0);
+        let err = inlet.apply(&mut state, &ctx, &mesh).unwrap_err();
+        assert!(matches!(err, OxiflowError::PreconditionFailed { .. }));
+    }
+
+    // ── apply — DanckwertsOutlet ──────────────────────────────────────────────
+
+    #[test]
+    fn outlet_apply_sets_last_node_to_predecessor() {
+        let mesh = make_mesh(5);
+        let ctx = ComputeContext::new(0.0, 0.01);
+        let mut state = DVector::from_vec(vec![1.0, 2.0, 3.0, 4.0, 9.9]);
+        DanckwertsOutlet::new()
+            .apply(&mut state, &ctx, &mesh)
+            .unwrap();
+        assert!((state[4] - state[3]).abs() < 1e-12);
+        assert!((state[4] - 4.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn outlet_apply_does_not_modify_other_nodes() {
+        let mesh = make_mesh(5);
+        let ctx = ComputeContext::new(0.0, 0.01);
+        let values = vec![1.0, 2.0, 3.0, 4.0, 9.9];
+        let mut state = DVector::from_vec(values.clone());
+        DanckwertsOutlet::new()
+            .apply(&mut state, &ctx, &mesh)
+            .unwrap();
+        for i in 0..4 {
+            assert!(
+                (state[i] - values[i]).abs() < 1e-12,
+                "node {i} was modified"
+            );
+        }
+    }
+
+    #[test]
+    fn outlet_apply_two_node_mesh() {
+        let mesh = make_mesh(2);
+        let ctx = ComputeContext::new(0.0, 0.01);
+        let mut state = DVector::from_vec(vec![3.0, 0.0]);
+        DanckwertsOutlet::new()
+            .apply(&mut state, &ctx, &mesh)
+            .unwrap();
+        assert!((state[1] - 3.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn outlet_apply_single_node_returns_error() {
+        struct SingleMesh;
+        impl Mesh for SingleMesh {
+            fn n_dof(&self) -> usize {
+                1
+            }
+            fn coordinates(&self, _: usize) -> &[f64] {
+                &[0.0]
+            }
+            fn spatial_dimension(&self) -> usize {
+                1
+            }
+            fn characteristic_length(&self) -> f64 {
+                0.0
+            }
+        }
+        impl std::fmt::Debug for SingleMesh {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "SingleMesh")
+            }
+        }
+        let mesh = SingleMesh;
+        let ctx = ComputeContext::new(0.0, 0.01);
+        let mut state = DVector::from_element(1, 1.0);
+        let err = DanckwertsOutlet::new()
+            .apply(&mut state, &ctx, &mesh)
+            .unwrap_err();
+        assert!(matches!(err, OxiflowError::PreconditionFailed { .. }));
+    }
+
+    // ── Object safety ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn both_bcs_are_object_safe() {
+        let bcs: Vec<Box<dyn BoundaryCondition>> = vec![
+            Box::new(make_inlet(1e-7, 1e-3)),
+            Box::new(DanckwertsOutlet::new()),
+        ];
+        assert_eq!(bcs.len(), 2);
+    }
+
+    #[test]
+    fn debug_inlet_is_non_empty() {
+        let s = format!("{:?}", make_inlet(1e-7, 1e-3));
+        assert!(s.contains("DanckwertsInlet"));
+        assert!(s.contains("dispersion"));
+    }
+
+    #[test]
+    fn debug_outlet_is_non_empty() {
+        assert!(!format!("{:?}", DanckwertsOutlet::new()).is_empty());
+    }
+}

--- a/src/boundary/danckwerts.rs
+++ b/src/boundary/danckwerts.rs
@@ -152,6 +152,14 @@ impl RequiresContext for DanckwertsInlet {
 }
 
 impl BoundaryCondition for DanckwertsInlet {
+    fn boundary_type(&self) -> crate::boundary::BoundaryType {
+        crate::boundary::BoundaryType::Robin
+    }
+
+    fn location(&self) -> Option<crate::boundary::BoundaryLocation> {
+        Some(crate::boundary::BoundaryLocation::Inlet)
+    }
+
     /// Applies the Danckwerts inlet condition to `state[0]`.
     ///
     /// Reads `∂u/∂x|_{x=0}` from the gradient field at node 0 and
@@ -249,6 +257,14 @@ impl RequiresContext for DanckwertsOutlet {
 }
 
 impl BoundaryCondition for DanckwertsOutlet {
+    fn boundary_type(&self) -> crate::boundary::BoundaryType {
+        crate::boundary::BoundaryType::Neumann
+    }
+
+    fn location(&self) -> Option<crate::boundary::BoundaryLocation> {
+        Some(crate::boundary::BoundaryLocation::Outlet)
+    }
+
     /// Applies the Danckwerts outlet condition.
     ///
     /// Sets `state[n-1] = state[n-2]` — first-order approximation of zero
@@ -314,6 +330,40 @@ mod tests {
         );
         ctx.insert(feed_var(), ContextValue::Scalar(u_feed));
         ctx
+    }
+
+    // ── boundary_type() and location() ───────────────────────────────────────
+
+    #[test]
+    fn inlet_boundary_type_is_robin() {
+        assert_eq!(
+            make_inlet(1e-7, 1e-3).boundary_type(),
+            crate::boundary::BoundaryType::Robin
+        );
+    }
+
+    #[test]
+    fn inlet_location_is_inlet() {
+        assert_eq!(
+            make_inlet(1e-7, 1e-3).location(),
+            Some(crate::boundary::BoundaryLocation::Inlet)
+        );
+    }
+
+    #[test]
+    fn outlet_boundary_type_is_neumann() {
+        assert_eq!(
+            DanckwertsOutlet::new().boundary_type(),
+            crate::boundary::BoundaryType::Neumann
+        );
+    }
+
+    #[test]
+    fn outlet_location_is_outlet() {
+        assert_eq!(
+            DanckwertsOutlet::new().location(),
+            Some(crate::boundary::BoundaryLocation::Outlet)
+        );
     }
 
     // ── RequiresContext — DanckwertsInlet ─────────────────────────────────────

--- a/src/boundary/mod.rs
+++ b/src/boundary/mod.rs
@@ -1,7 +1,314 @@
 //! # Module `boundary`
 //!
-//! Boundary conditions — `BoundaryCondition` trait.
+//! Boundary conditions — [`BoundaryCondition`] trait (DD-008, issue #34).
 //!
-//! From J2 (v0.3), boundary conditions will be able to require context variables
-//! by becoming super-traits of `RequiresContext` (DD-008). `Dirichlet`, `Neumann`
-//! and `Robin` types (Danckwerts conditions) will be implemented at that stage.
+//! ## Role
+//!
+//! A boundary condition constrains the primary field $u$ at the boundary of a
+//! spatial domain. It is applied **after** the context calculators have run and
+//! **before** `PhysicalModel::compute_physics` is called, so the full
+//! [`ComputeContext`] is available when `apply` executes.
+//!
+//! ## RequiresContext integration
+//!
+//! `BoundaryCondition` is a supertrait of [`RequiresContext`], giving every
+//! boundary condition the full four-method interface:
+//!
+//! | Method | Default | Purpose |
+//! |---|---|---|
+//! | `required_variables()` | — (required) | Variables that must be present in `ctx` |
+//! | `optional_variables()` | `vec![]` | Variables used if present |
+//! | `depends_on()` | `vec![]` | Ordering relative to other BCs (J3+) |
+//! | `priority()` | `100` | Execution order when multiple BCs are registered |
+//!
+//! The solver aggregates `required_variables()` from all boundary conditions into
+//! the global requirements list, validated by `build_calculator_chain` before
+//! the first time step.
+//!
+//! ## Execution order
+//!
+//! Multiple boundary conditions on the same domain are applied in ascending
+//! `priority()` order. `depends_on()` is available but not consumed by the
+//! engine at J2 — it is reserved for complex BC ordering at J3+.
+//!
+//! ## Object safety
+//!
+//! `BoundaryCondition` is object-safe. The solver stores BCs as
+//! `Vec<Box<dyn BoundaryCondition>>` inside [`Domain`].
+//!
+//! [`ComputeContext`]: crate::context::ComputeContext
+//! [`RequiresContext`]: crate::model::RequiresContext
+//! [`Domain`]: crate::solver::scenario::Domain
+
+use crate::context::compute::ComputeContext;
+use crate::context::error::OxiflowError;
+use crate::mesh::Mesh;
+use crate::model::traits::RequiresContext;
+use nalgebra::DVector;
+
+/// Constrains the primary field $u$ at the boundary of a spatial domain.
+///
+/// A boundary condition receives the current field state and the fully populated
+/// [`ComputeContext`], then modifies `state` in-place to enforce the constraint.
+///
+/// # Contract
+///
+/// - `apply` is called once per time step, after context calculators and before
+///   `PhysicalModel::compute_physics`.
+/// - `apply` must not modify `ctx` or `mesh` — only `state`.
+/// - Variables declared in `required_variables()` are guaranteed to be present
+///   in `ctx` when `apply` is called.
+///
+/// # Execution order
+///
+/// Multiple BCs on the same domain are applied in ascending `priority()` order
+/// (inherited from [`RequiresContext`]). `depends_on()` is reserved for J3+.
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::boundary::BoundaryCondition;
+/// use oxiflow::context::compute::ComputeContext;
+/// use oxiflow::context::error::OxiflowError;
+/// use oxiflow::context::variable::ContextVariable;
+/// use oxiflow::mesh::{Mesh, UniformGrid1D};
+/// use oxiflow::model::traits::RequiresContext;
+/// use nalgebra::DVector;
+///
+/// /// Homogeneous Neumann BC — zero flux at both ends.
+/// #[derive(Debug)]
+/// struct ZeroFluxBC;
+///
+/// impl RequiresContext for ZeroFluxBC {
+///     fn required_variables(&self) -> Vec<ContextVariable> { vec![] }
+/// }
+///
+/// impl BoundaryCondition for ZeroFluxBC {
+///     fn apply(
+///         &self,
+///         _state: &mut DVector<f64>,
+///         _ctx: &ComputeContext,
+///         _mesh: &dyn Mesh,
+///     ) -> Result<(), OxiflowError> {
+///         // Zero-flux: no modification needed (natural BC in weak form).
+///         Ok(())
+///     }
+/// }
+///
+/// let mesh = UniformGrid1D::new(10, 0.0, 1.0).unwrap();
+/// let mut state = DVector::from_element(mesh.n_dof(), 1.0);
+/// let ctx = ComputeContext::new(0.0, 0.01);
+/// let bc = ZeroFluxBC;
+/// assert!(bc.apply(&mut state, &ctx, &mesh).is_ok());
+/// ```
+///
+/// [`RequiresContext`]: crate::model::RequiresContext
+/// [`ComputeContext`]: crate::context::ComputeContext
+pub trait BoundaryCondition: RequiresContext + std::fmt::Debug {
+    /// Applies the boundary condition to `state`.
+    ///
+    /// Called once per time step, after all context calculators have run.
+    /// Modifies `state` in-place to enforce the constraint.
+    ///
+    /// # Parameters
+    ///
+    /// - `state` — current field $u$ as a DOF vector; modified in-place.
+    /// - `ctx`   — fully populated context (time, step, spatial quantities).
+    /// - `mesh`  — spatial discretisation of the domain.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OxiflowError`] if the constraint cannot be applied
+    /// (e.g., a required context value is missing or the state is inconsistent).
+    fn apply(
+        &self,
+        state: &mut DVector<f64>,
+        ctx: &ComputeContext,
+        mesh: &dyn Mesh,
+    ) -> Result<(), OxiflowError>;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::variable::ContextVariable;
+    use crate::mesh::structured::UniformGrid1D;
+
+    // ── Fixtures ──────────────────────────────────────────────────────────────
+
+    /// Zero-flux (homogeneous Neumann) — no context requirements, no-op apply.
+    #[derive(Debug)]
+    struct ZeroFluxBC;
+
+    impl RequiresContext for ZeroFluxBC {
+        fn required_variables(&self) -> Vec<ContextVariable> {
+            vec![]
+        }
+    }
+
+    impl BoundaryCondition for ZeroFluxBC {
+        fn apply(
+            &self,
+            _state: &mut DVector<f64>,
+            _ctx: &ComputeContext,
+            _mesh: &dyn Mesh,
+        ) -> Result<(), OxiflowError> {
+            Ok(())
+        }
+    }
+
+    /// Fixed inlet value — sets state[0] to a constant.
+    #[derive(Debug)]
+    struct FixedInletBC {
+        value: f64,
+    }
+
+    impl RequiresContext for FixedInletBC {
+        fn required_variables(&self) -> Vec<ContextVariable> {
+            vec![]
+        }
+        fn priority(&self) -> u32 {
+            50
+        }
+    }
+
+    impl BoundaryCondition for FixedInletBC {
+        fn apply(
+            &self,
+            state: &mut DVector<f64>,
+            _ctx: &ComputeContext,
+            _mesh: &dyn Mesh,
+        ) -> Result<(), OxiflowError> {
+            if !state.is_empty() {
+                state[0] = self.value;
+            }
+            Ok(())
+        }
+    }
+
+    /// BC that requires Time from context.
+    #[derive(Debug)]
+    struct TimeDependentBC;
+
+    impl RequiresContext for TimeDependentBC {
+        fn required_variables(&self) -> Vec<ContextVariable> {
+            vec![ContextVariable::Time]
+        }
+    }
+
+    impl BoundaryCondition for TimeDependentBC {
+        fn apply(
+            &self,
+            state: &mut DVector<f64>,
+            ctx: &ComputeContext,
+            _mesh: &dyn Mesh,
+        ) -> Result<(), OxiflowError> {
+            if !state.is_empty() {
+                state[0] = ctx.time();
+            }
+            Ok(())
+        }
+    }
+
+    fn make_mesh() -> UniformGrid1D {
+        UniformGrid1D::new(5, 0.0, 1.0).unwrap()
+    }
+
+    fn make_state(n: usize) -> DVector<f64> {
+        DVector::from_element(n, 0.0)
+    }
+
+    // ── Object safety ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn trait_is_object_safe() {
+        let bcs: Vec<Box<dyn BoundaryCondition>> =
+            vec![Box::new(ZeroFluxBC), Box::new(FixedInletBC { value: 1.0 })];
+        assert_eq!(bcs.len(), 2);
+    }
+
+    #[test]
+    fn boxed_bc_can_be_applied() {
+        let bc: Box<dyn BoundaryCondition> = Box::new(FixedInletBC { value: 3.14 });
+        let mesh = make_mesh();
+        let mut state = make_state(mesh.n_dof());
+        let ctx = ComputeContext::new(0.0, 0.01);
+        assert!(bc.apply(&mut state, &ctx, &mesh).is_ok());
+        assert!((state[0] - 3.14).abs() < 1e-12);
+    }
+
+    // ── RequiresContext supertrait ─────────────────────────────────────────────
+
+    #[test]
+    fn required_variables_forwarded_via_dyn() {
+        let bc: &dyn BoundaryCondition = &TimeDependentBC;
+        assert!(bc.required_variables().contains(&ContextVariable::Time));
+    }
+
+    #[test]
+    fn optional_variables_default_is_empty() {
+        let bc = ZeroFluxBC;
+        assert!(bc.optional_variables().is_empty());
+    }
+
+    #[test]
+    fn depends_on_default_is_empty() {
+        let bc = ZeroFluxBC;
+        assert!(bc.depends_on().is_empty());
+    }
+
+    #[test]
+    fn priority_default_is_100() {
+        let bc = ZeroFluxBC;
+        assert_eq!(bc.priority(), 100);
+    }
+
+    #[test]
+    fn priority_can_be_overridden() {
+        let bc = FixedInletBC { value: 0.0 };
+        assert_eq!(bc.priority(), 50);
+    }
+
+    // ── apply() ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn zero_flux_bc_does_not_modify_state() {
+        let mesh = make_mesh();
+        let mut state = DVector::from_element(mesh.n_dof(), 2.0);
+        let ctx = ComputeContext::new(0.0, 0.01);
+        ZeroFluxBC.apply(&mut state, &ctx, &mesh).unwrap();
+        assert!(state.iter().all(|&v| (v - 2.0).abs() < 1e-12));
+    }
+
+    #[test]
+    fn fixed_inlet_bc_sets_first_dof() {
+        let mesh = make_mesh();
+        let mut state = make_state(mesh.n_dof());
+        let ctx = ComputeContext::new(0.0, 0.01);
+        FixedInletBC { value: 42.0 }
+            .apply(&mut state, &ctx, &mesh)
+            .unwrap();
+        assert!((state[0] - 42.0).abs() < 1e-12);
+        // Other DOFs unchanged
+        assert!(state.iter().skip(1).all(|&v| v == 0.0));
+    }
+
+    #[test]
+    fn time_dependent_bc_reads_context_time() {
+        let mesh = make_mesh();
+        let mut state = make_state(mesh.n_dof());
+        let ctx = ComputeContext::new(3.5, 0.01);
+        TimeDependentBC.apply(&mut state, &ctx, &mesh).unwrap();
+        assert!((state[0] - 3.5).abs() < 1e-12);
+    }
+
+    // ── Debug supertrait ──────────────────────────────────────────────────────
+
+    #[test]
+    fn debug_output_is_non_empty() {
+        let bc: &dyn BoundaryCondition = &ZeroFluxBC;
+        assert!(!format!("{:?}", bc).is_empty());
+    }
+}

--- a/src/boundary/mod.rs
+++ b/src/boundary/mod.rs
@@ -1,6 +1,14 @@
 //! # Module `boundary`
 //!
-//! Boundary conditions — [`BoundaryCondition`] trait (DD-008, issue #34).
+//! Boundary conditions — [`BoundaryCondition`] trait (DD-008, issue #34)
+//! and built-in implementations (issue #35).
+//!
+//! ## Available implementations
+//!
+//! | Type | Condition | Location |
+//! |---|---|---|
+//! | [`DanckwertsInlet`] | Robin BC at $x = 0$ — convection-diffusion inlet | `boundary::danckwerts` |
+//! | [`DanckwertsOutlet`] | Neumann BC at $x = L$ — zero dispersive flux | `boundary::danckwerts` |
 //!
 //! ## Role
 //!
@@ -39,12 +47,17 @@
 //! [`ComputeContext`]: crate::context::ComputeContext
 //! [`RequiresContext`]: crate::model::RequiresContext
 //! [`Domain`]: crate::solver::scenario::Domain
+//! [`DanckwertsInlet`]: crate::boundary::DanckwertsInlet
+//! [`DanckwertsOutlet`]: crate::boundary::DanckwertsOutlet
 
 use crate::context::compute::ComputeContext;
 use crate::context::error::OxiflowError;
 use crate::mesh::Mesh;
 use crate::model::traits::RequiresContext;
 use nalgebra::DVector;
+
+pub mod danckwerts;
+pub use danckwerts::{DanckwertsInlet, DanckwertsOutlet};
 
 /// Constrains the primary field $u$ at the boundary of a spatial domain.
 ///
@@ -63,6 +76,14 @@ use nalgebra::DVector;
 ///
 /// Multiple BCs on the same domain are applied in ascending `priority()` order
 /// (inherited from [`RequiresContext`]). `depends_on()` is reserved for J3+.
+///
+/// # Serialisation
+///
+/// `BoundaryCondition` does not implement `serde::Serialize` / `serde::Deserialize`.
+/// Concrete implementations may hold arbitrary state (closures, mesh references,
+/// physical parameters backed by trait objects) that cannot be serialised generically.
+/// If persistence of boundary condition parameters is required, provide a dedicated
+/// configuration type and reconstruct the BC from it — see `SimulationSnapshot` (DD-025).
 ///
 /// # Examples
 ///

--- a/src/boundary/mod.rs
+++ b/src/boundary/mod.rs
@@ -3,12 +3,25 @@
 //! Boundary conditions — [`BoundaryCondition`] trait (DD-008, issue #34)
 //! and built-in implementations (issue #35).
 //!
+//! ## Classification
+//!
+//! Two orthogonal enums characterise every boundary condition:
+//!
+//! | Enum | Axis | Purpose |
+//! |---|---|---|
+//! | [`BoundaryType`] | Mathematical | Nature of the constraint (Dirichlet, Neumann, Robin, Periodic) |
+//! | [`BoundaryLocation`] | Geometric | Position in the domain (Inlet, Wall, Interface, …) |
+//!
+//! `boundary_type()` is required on the trait. `location()` is optional
+//! (default `None`) — relevant for structured 1D cases but essential for
+//! complex meshes, FEM, and multi-phase problems.
+//!
 //! ## Available implementations
 //!
-//! | Type | Condition | Location |
+//! | Type | `BoundaryType` | `BoundaryLocation` |
 //! |---|---|---|
-//! | [`DanckwertsInlet`] | Robin BC at $x = 0$ — convection-diffusion inlet | `boundary::danckwerts` |
-//! | [`DanckwertsOutlet`] | Neumann BC at $x = L$ — zero dispersive flux | `boundary::danckwerts` |
+//! | [`DanckwertsInlet`] | `Robin` | `Some(Inlet)` |
+//! | [`DanckwertsOutlet`] | `Neumann` | `Some(Outlet)` |
 //!
 //! ## Role
 //!
@@ -29,10 +42,6 @@
 //! | `depends_on()` | `vec![]` | Ordering relative to other BCs (J3+) |
 //! | `priority()` | `100` | Execution order when multiple BCs are registered |
 //!
-//! The solver aggregates `required_variables()` from all boundary conditions into
-//! the global requirements list, validated by `build_calculator_chain` before
-//! the first time step.
-//!
 //! ## Execution order
 //!
 //! Multiple boundary conditions on the same domain are applied in ascending
@@ -50,6 +59,8 @@
 //! [`DanckwertsInlet`]: crate::boundary::DanckwertsInlet
 //! [`DanckwertsOutlet`]: crate::boundary::DanckwertsOutlet
 
+use std::borrow::Cow;
+
 use crate::context::compute::ComputeContext;
 use crate::context::error::OxiflowError;
 use crate::mesh::Mesh;
@@ -58,6 +69,113 @@ use nalgebra::DVector;
 
 pub mod danckwerts;
 pub use danckwerts::{DanckwertsInlet, DanckwertsOutlet};
+
+// ── BoundaryType ──────────────────────────────────────────────────────────────
+
+/// Mathematical classification of a boundary condition.
+///
+/// Describes the nature of the constraint imposed on the primary field $u$:
+///
+/// | Variant | Constraint | Example |
+/// |---|---|---|
+/// | `Dirichlet` | $u = g$ on $\partial\Omega$ | Fixed concentration at inlet |
+/// | `Neumann` | $\nabla u \cdot \mathbf{n} = g$ | Zero flux at outlet |
+/// | `Robin` | $\alpha u + \beta \nabla u \cdot \mathbf{n} = g$ | Danckwerts inlet |
+/// | `Periodic` | $u(x_0) = u(x_L)$ | Periodic column simulation |
+///
+/// # Serialisation
+///
+/// Implements `Serialize` / `Deserialize` under the `serde` feature flag.
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::boundary::BoundaryType;
+///
+/// assert_eq!(BoundaryType::Robin.clone(), BoundaryType::Robin);
+/// assert_ne!(BoundaryType::Dirichlet, BoundaryType::Neumann);
+/// ```
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum BoundaryType {
+    /// Prescribed value: $u = g$ on the boundary.
+    Dirichlet,
+    /// Prescribed normal flux: $\nabla u \cdot \mathbf{n} = g$.
+    ///
+    /// `g = 0` gives the homogeneous Neumann (no-flux, insulation) condition.
+    Neumann,
+    /// Linear combination: $\alpha u + \beta \nabla u \cdot \mathbf{n} = g$.
+    ///
+    /// Generalises Dirichlet ($\beta = 0$) and Neumann ($\alpha = 0$).
+    /// Used for Danckwerts inlet, convective heat transfer, impedance BCs.
+    Robin,
+    /// Periodic link: $u(x_0) = u(x_L)$ with matching normal flux.
+    Periodic,
+}
+
+// ── BoundaryLocation ──────────────────────────────────────────────────────────
+
+/// Geometric location of a boundary condition within the domain.
+///
+/// Describes *where* in the spatial domain the condition is applied. Optional
+/// for simple 1D structured problems, but essential for complex meshes (FEM,
+/// unstructured grids), multi-phase flows, and inter-domain coupling.
+///
+/// # Extensibility
+///
+/// `#[non_exhaustive]` allows future variants at minor versions without
+/// breaking downstream code. The `Custom` variant covers user-defined locations
+/// with a `Cow<'static, str>` key, consistent with
+/// [`ContextVariable::External`](crate::context::variable::ContextVariable::External).
+///
+/// # Serialisation
+///
+/// Implements `Serialize` / `Deserialize` under the `serde` feature flag.
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::boundary::BoundaryLocation;
+///
+/// let loc = BoundaryLocation::Inlet;
+/// assert_ne!(loc, BoundaryLocation::Outlet);
+///
+/// let custom = BoundaryLocation::Custom("membrane_left".into());
+/// assert!(matches!(custom, BoundaryLocation::Custom(_)));
+/// ```
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum BoundaryLocation {
+    /// Upstream entry — convective flux enters here.
+    Inlet,
+    /// Downstream exit — convective flux leaves here.
+    Outlet,
+    /// Solid wall — no-slip or no-flux depending on the physics.
+    Wall,
+    /// Symmetry plane — zero normal gradient and zero normal velocity.
+    Symmetry,
+    /// Periodic face — linked to another `Periodic` face of the domain.
+    Periodic,
+    /// Interface between two distinct materials or porous media.
+    ///
+    /// Used for heterogeneous columns, composite materials, soil layers.
+    Interface,
+    /// Phase interface — boundary between two thermodynamic phases.
+    ///
+    /// Relevant for Stefan problems, solidification fronts, boiling,
+    /// condensation. The interface position may evolve during the simulation.
+    PhaseInterface,
+    /// Coupling interface between two domains (INV-3, J3+).
+    ///
+    /// Managed by `CouplingOperator` — reserved from v0.3.0.
+    CouplingInterface,
+    /// User-defined location not covered by built-in variants.
+    Custom(Cow<'static, str>),
+}
+
+// ── BoundaryCondition ─────────────────────────────────────────────────────────
 
 /// Constrains the primary field $u$ at the boundary of a spatial domain.
 ///
@@ -72,23 +190,23 @@ pub use danckwerts::{DanckwertsInlet, DanckwertsOutlet};
 /// - Variables declared in `required_variables()` are guaranteed to be present
 ///   in `ctx` when `apply` is called.
 ///
-/// # Execution order
+/// # Classification
 ///
-/// Multiple BCs on the same domain are applied in ascending `priority()` order
-/// (inherited from [`RequiresContext`]). `depends_on()` is reserved for J3+.
+/// Every implementation must declare its mathematical nature via `boundary_type()`.
+/// The geometric location may be declared via `location()` (default `None`) —
+/// essential for complex meshes, FEM, and multi-phase problems.
 ///
 /// # Serialisation
 ///
 /// `BoundaryCondition` does not implement `serde::Serialize` / `serde::Deserialize`.
-/// Concrete implementations may hold arbitrary state (closures, mesh references,
-/// physical parameters backed by trait objects) that cannot be serialised generically.
-/// If persistence of boundary condition parameters is required, provide a dedicated
-/// configuration type and reconstruct the BC from it — see `SimulationSnapshot` (DD-025).
+/// Concrete implementations may hold arbitrary state that cannot be serialised
+/// generically. If persistence is required, provide a dedicated configuration
+/// type and reconstruct the BC from it — see `SimulationSnapshot` (DD-025).
 ///
 /// # Examples
 ///
 /// ```rust
-/// use oxiflow::boundary::BoundaryCondition;
+/// use oxiflow::boundary::{BoundaryCondition, BoundaryType};
 /// use oxiflow::context::compute::ComputeContext;
 /// use oxiflow::context::error::OxiflowError;
 /// use oxiflow::context::variable::ContextVariable;
@@ -96,7 +214,6 @@ pub use danckwerts::{DanckwertsInlet, DanckwertsOutlet};
 /// use oxiflow::model::traits::RequiresContext;
 /// use nalgebra::DVector;
 ///
-/// /// Homogeneous Neumann BC — zero flux at both ends.
 /// #[derive(Debug)]
 /// struct ZeroFluxBC;
 ///
@@ -105,27 +222,39 @@ pub use danckwerts::{DanckwertsInlet, DanckwertsOutlet};
 /// }
 ///
 /// impl BoundaryCondition for ZeroFluxBC {
+///     fn boundary_type(&self) -> BoundaryType { BoundaryType::Neumann }
+///
 ///     fn apply(
 ///         &self,
 ///         _state: &mut DVector<f64>,
 ///         _ctx: &ComputeContext,
 ///         _mesh: &dyn Mesh,
-///     ) -> Result<(), OxiflowError> {
-///         // Zero-flux: no modification needed (natural BC in weak form).
-///         Ok(())
-///     }
+///     ) -> Result<(), OxiflowError> { Ok(()) }
 /// }
 ///
-/// let mesh = UniformGrid1D::new(10, 0.0, 1.0).unwrap();
-/// let mut state = DVector::from_element(mesh.n_dof(), 1.0);
-/// let ctx = ComputeContext::new(0.0, 0.01);
 /// let bc = ZeroFluxBC;
-/// assert!(bc.apply(&mut state, &ctx, &mesh).is_ok());
+/// assert_eq!(bc.boundary_type(), BoundaryType::Neumann);
+/// assert!(bc.location().is_none());
 /// ```
 ///
 /// [`RequiresContext`]: crate::model::RequiresContext
 /// [`ComputeContext`]: crate::context::ComputeContext
 pub trait BoundaryCondition: RequiresContext + std::fmt::Debug {
+    /// Returns the mathematical type of this boundary condition.
+    ///
+    /// Required — every implementation must declare whether it enforces a
+    /// Dirichlet, Neumann, Robin, or Periodic constraint.
+    fn boundary_type(&self) -> BoundaryType;
+
+    /// Returns the geometric location of this boundary condition, if known.
+    ///
+    /// Optional — defaults to `None` for simple or location-agnostic BCs.
+    /// Override for complex meshes, FEM, and multi-phase problems where the
+    /// location carries semantic meaning for the solver or post-processor.
+    fn location(&self) -> Option<BoundaryLocation> {
+        None
+    }
+
     /// Applies the boundary condition to `state`.
     ///
     /// Called once per time step, after all context calculators have run.
@@ -139,8 +268,7 @@ pub trait BoundaryCondition: RequiresContext + std::fmt::Debug {
     ///
     /// # Errors
     ///
-    /// Returns [`OxiflowError`] if the constraint cannot be applied
-    /// (e.g., a required context value is missing or the state is inconsistent).
+    /// Returns [`OxiflowError`] if the constraint cannot be applied.
     fn apply(
         &self,
         state: &mut DVector<f64>,
@@ -159,7 +287,6 @@ mod tests {
 
     // ── Fixtures ──────────────────────────────────────────────────────────────
 
-    /// Zero-flux (homogeneous Neumann) — no context requirements, no-op apply.
     #[derive(Debug)]
     struct ZeroFluxBC;
 
@@ -170,6 +297,9 @@ mod tests {
     }
 
     impl BoundaryCondition for ZeroFluxBC {
+        fn boundary_type(&self) -> BoundaryType {
+            BoundaryType::Neumann
+        }
         fn apply(
             &self,
             _state: &mut DVector<f64>,
@@ -180,7 +310,6 @@ mod tests {
         }
     }
 
-    /// Fixed inlet value — sets state[0] to a constant.
     #[derive(Debug)]
     struct FixedInletBC {
         value: f64,
@@ -196,6 +325,12 @@ mod tests {
     }
 
     impl BoundaryCondition for FixedInletBC {
+        fn boundary_type(&self) -> BoundaryType {
+            BoundaryType::Dirichlet
+        }
+        fn location(&self) -> Option<BoundaryLocation> {
+            Some(BoundaryLocation::Inlet)
+        }
         fn apply(
             &self,
             state: &mut DVector<f64>,
@@ -209,7 +344,6 @@ mod tests {
         }
     }
 
-    /// BC that requires Time from context.
     #[derive(Debug)]
     struct TimeDependentBC;
 
@@ -220,6 +354,9 @@ mod tests {
     }
 
     impl BoundaryCondition for TimeDependentBC {
+        fn boundary_type(&self) -> BoundaryType {
+            BoundaryType::Dirichlet
+        }
         fn apply(
             &self,
             state: &mut DVector<f64>,
@@ -241,6 +378,81 @@ mod tests {
         DVector::from_element(n, 0.0)
     }
 
+    // ── BoundaryType ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn boundary_type_variants_are_distinct() {
+        assert_ne!(BoundaryType::Dirichlet, BoundaryType::Neumann);
+        assert_ne!(BoundaryType::Neumann, BoundaryType::Robin);
+        assert_ne!(BoundaryType::Robin, BoundaryType::Periodic);
+    }
+
+    #[test]
+    fn boundary_type_clone_preserves_equality() {
+        assert_eq!(BoundaryType::Robin.clone(), BoundaryType::Robin);
+    }
+
+    #[test]
+    fn boundary_type_debug_non_empty() {
+        for t in [
+            BoundaryType::Dirichlet,
+            BoundaryType::Neumann,
+            BoundaryType::Robin,
+            BoundaryType::Periodic,
+        ] {
+            assert!(!format!("{:?}", t).is_empty());
+        }
+    }
+
+    // ── BoundaryLocation ──────────────────────────────────────────────────────
+
+    #[test]
+    fn boundary_location_variants_are_distinct() {
+        assert_ne!(BoundaryLocation::Inlet, BoundaryLocation::Outlet);
+        assert_ne!(BoundaryLocation::Wall, BoundaryLocation::Symmetry);
+        assert_ne!(
+            BoundaryLocation::Interface,
+            BoundaryLocation::PhaseInterface
+        );
+        assert_ne!(
+            BoundaryLocation::PhaseInterface,
+            BoundaryLocation::CouplingInterface,
+        );
+    }
+
+    #[test]
+    fn boundary_location_custom_equality_by_name() {
+        let a = BoundaryLocation::Custom("membrane".into());
+        let b = BoundaryLocation::Custom("membrane".into());
+        let c = BoundaryLocation::Custom("wall_left".into());
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn boundary_location_clone_preserves_equality() {
+        let loc = BoundaryLocation::Custom("top".into());
+        assert_eq!(loc.clone(), loc);
+    }
+
+    #[test]
+    fn boundary_location_debug_non_empty() {
+        let locations = [
+            BoundaryLocation::Inlet,
+            BoundaryLocation::Outlet,
+            BoundaryLocation::Wall,
+            BoundaryLocation::Symmetry,
+            BoundaryLocation::Periodic,
+            BoundaryLocation::Interface,
+            BoundaryLocation::PhaseInterface,
+            BoundaryLocation::CouplingInterface,
+            BoundaryLocation::Custom("test".into()),
+        ];
+        for loc in &locations {
+            assert!(!format!("{:?}", loc).is_empty());
+        }
+    }
+
     // ── Object safety ─────────────────────────────────────────────────────────
 
     #[test]
@@ -260,6 +472,46 @@ mod tests {
         assert!((state[0] - 3.14).abs() < 1e-12);
     }
 
+    // ── boundary_type() ───────────────────────────────────────────────────────
+
+    #[test]
+    fn boundary_type_returned_correctly() {
+        assert_eq!(ZeroFluxBC.boundary_type(), BoundaryType::Neumann);
+        assert_eq!(
+            FixedInletBC { value: 0.0 }.boundary_type(),
+            BoundaryType::Dirichlet
+        );
+        assert_eq!(TimeDependentBC.boundary_type(), BoundaryType::Dirichlet);
+    }
+
+    #[test]
+    fn boundary_type_accessible_via_dyn() {
+        let bc: &dyn BoundaryCondition = &ZeroFluxBC;
+        assert_eq!(bc.boundary_type(), BoundaryType::Neumann);
+    }
+
+    // ── location() ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn location_default_is_none() {
+        assert!(ZeroFluxBC.location().is_none());
+        assert!(TimeDependentBC.location().is_none());
+    }
+
+    #[test]
+    fn location_override_returned_correctly() {
+        assert_eq!(
+            FixedInletBC { value: 0.0 }.location(),
+            Some(BoundaryLocation::Inlet)
+        );
+    }
+
+    #[test]
+    fn location_accessible_via_dyn() {
+        let bc: &dyn BoundaryCondition = &FixedInletBC { value: 0.0 };
+        assert_eq!(bc.location(), Some(BoundaryLocation::Inlet));
+    }
+
     // ── RequiresContext supertrait ─────────────────────────────────────────────
 
     #[test]
@@ -270,26 +522,22 @@ mod tests {
 
     #[test]
     fn optional_variables_default_is_empty() {
-        let bc = ZeroFluxBC;
-        assert!(bc.optional_variables().is_empty());
+        assert!(ZeroFluxBC.optional_variables().is_empty());
     }
 
     #[test]
     fn depends_on_default_is_empty() {
-        let bc = ZeroFluxBC;
-        assert!(bc.depends_on().is_empty());
+        assert!(ZeroFluxBC.depends_on().is_empty());
     }
 
     #[test]
     fn priority_default_is_100() {
-        let bc = ZeroFluxBC;
-        assert_eq!(bc.priority(), 100);
+        assert_eq!(ZeroFluxBC.priority(), 100);
     }
 
     #[test]
     fn priority_can_be_overridden() {
-        let bc = FixedInletBC { value: 0.0 };
-        assert_eq!(bc.priority(), 50);
+        assert_eq!(FixedInletBC { value: 0.0 }.priority(), 50);
     }
 
     // ── apply() ───────────────────────────────────────────────────────────────
@@ -312,7 +560,6 @@ mod tests {
             .apply(&mut state, &ctx, &mesh)
             .unwrap();
         assert!((state[0] - 42.0).abs() < 1e-12);
-        // Other DOFs unchanged
         assert!(state.iter().skip(1).all(|&v| v == 0.0));
     }
 

--- a/src/context/calculator.rs
+++ b/src/context/calculator.rs
@@ -174,7 +174,7 @@ mod tests {
     impl ContextCalculator for TimeDependentCalculator {
         fn provides(&self) -> ContextVariable {
             ContextVariable::External {
-                name: "double_time",
+                name: "double_time".into(),
             }
         }
         fn compute(
@@ -217,7 +217,7 @@ mod tests {
     #[test]
     fn constant_calculator_returns_fixed_value() {
         let calc = ConstantCalculator {
-            var: ContextVariable::External { name: "D_ax" },
+            var: ContextVariable::External { name: "D_ax".into() },
             value: 1.5e-4,
         };
         let ctx = ComputeContext::new(0.0, 0.01);

--- a/src/context/calculator.rs
+++ b/src/context/calculator.rs
@@ -217,7 +217,9 @@ mod tests {
     #[test]
     fn constant_calculator_returns_fixed_value() {
         let calc = ConstantCalculator {
-            var: ContextVariable::External { name: "D_ax".into() },
+            var: ContextVariable::External {
+                name: "D_ax".into(),
+            },
             value: 1.5e-4,
         };
         let ctx = ComputeContext::new(0.0, 0.01);

--- a/src/context/calculators/integral.rs
+++ b/src/context/calculators/integral.rs
@@ -1,0 +1,252 @@
+//! # Module `context::calculators::integral`
+//!
+//! Spatial quadrature calculator using the trapezoidal rule.
+
+use std::sync::Arc;
+
+use crate::context::calculator::ContextCalculator;
+use crate::context::compute::ComputeContext;
+use crate::context::error::OxiflowError;
+use crate::context::value::ContextValue;
+use crate::context::variable::ContextVariable;
+use crate::mesh::Mesh;
+use crate::model::traits::RequiresContext;
+
+// ── TrapezoidalIntegral ───────────────────────────────────────────────────────
+
+/// Computes the spatial integral of the primary field using the trapezoidal rule.
+///
+/// $$I = \int_\Omega u \, dx \approx \sum_{i=0}^{n-2} \frac{u_i + u_{i+1}}{2} \Delta x_i$$
+///
+/// where $\Delta x_i = x_{i+1} - x_i$ is taken from the mesh coordinates.
+/// This works correctly for both uniform and non-uniform 1D meshes.
+///
+/// The result is exposed under a user-chosen `ContextVariable::External { name }`,
+/// typically `"spatial_mean"`, `"total_mass"`, or similar.
+///
+/// # Limitations (J2)
+///
+/// Only 1D meshes are supported at this milestone. The calculator returns
+/// `PreconditionFailed` for meshes with `spatial_dimension() != 1`.
+///
+/// # Examples
+///
+/// ```rust
+/// use std::sync::Arc;
+/// use std::borrow::Cow;
+/// use oxiflow::context::calculator::ContextCalculator;
+/// use oxiflow::context::calculators::TrapezoidalIntegral;
+/// use oxiflow::context::compute::ComputeContext;
+/// use oxiflow::context::value::ContextValue;
+/// use oxiflow::context::variable::ContextVariable;
+/// use oxiflow::mesh::{Mesh, UniformGrid1D};
+/// use nalgebra::DVector;
+///
+/// let mesh = Arc::new(UniformGrid1D::new(5, 0.0, 1.0).unwrap());
+/// let var  = ContextVariable::External { name: Cow::Borrowed("total_mass") };
+/// let calc = TrapezoidalIntegral::new(mesh, var);
+///
+/// // u = 1  →  ∫₀¹ 1 dx = 1.0
+/// let u = DVector::from_element(5, 1.0);
+/// let ctx = ComputeContext::new(0.0, 0.01);
+/// let val = calc.compute(&ContextValue::ScalarField(u), &ctx).unwrap();
+/// assert!((val.as_scalar().unwrap() - 1.0).abs() < 1e-10);
+/// ```
+pub struct TrapezoidalIntegral {
+    mesh: Arc<dyn Mesh>,
+    variable: ContextVariable,
+}
+
+impl TrapezoidalIntegral {
+    /// Creates a new trapezoidal integral calculator.
+    ///
+    /// # Arguments
+    ///
+    /// - `mesh` — shared mesh reference (INV-1 compliant).
+    /// - `variable` — the `ContextVariable` under which the integral is stored,
+    ///   typically `ContextVariable::External { name: "total_mass".into() }`.
+    pub fn new(mesh: Arc<dyn Mesh>, variable: ContextVariable) -> Self {
+        Self { mesh, variable }
+    }
+}
+
+impl std::fmt::Debug for TrapezoidalIntegral {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TrapezoidalIntegral")
+            .field("variable", &self.variable)
+            .field("mesh_n_dof", &self.mesh.n_dof())
+            .finish()
+    }
+}
+
+impl RequiresContext for TrapezoidalIntegral {
+    fn required_variables(&self) -> Vec<ContextVariable> {
+        vec![]
+    }
+
+    fn priority(&self) -> u32 {
+        100
+    }
+}
+
+impl ContextCalculator for TrapezoidalIntegral {
+    fn provides(&self) -> ContextVariable {
+        self.variable.clone()
+    }
+
+    fn compute(
+        &self,
+        state: &ContextValue,
+        _ctx: &ComputeContext,
+    ) -> Result<ContextValue, OxiflowError> {
+        if self.mesh.spatial_dimension() != 1 {
+            return Err(OxiflowError::PreconditionFailed {
+                context: "TrapezoidalIntegral",
+                message: format!(
+                    "only 1D meshes are supported at J2, got spatial_dimension = {}",
+                    self.mesh.spatial_dimension()
+                ),
+            });
+        }
+
+        let u = state.as_scalar_field()?;
+        let n = u.len();
+
+        if n < 2 {
+            return Err(OxiflowError::PreconditionFailed {
+                context: "TrapezoidalIntegral",
+                message: format!("field must have at least 2 nodes, got {n}"),
+            });
+        }
+
+        let mut integral = 0.0_f64;
+        for i in 0..n - 1 {
+            let x_i = self.mesh.coordinates(i)[0];
+            let x_next = self.mesh.coordinates(i + 1)[0];
+            let dx = x_next - x_i;
+            integral += (u[i] + u[i + 1]) * 0.5 * dx;
+        }
+
+        Ok(ContextValue::Scalar(integral))
+    }
+
+    fn name(&self) -> &str {
+        "trapezoidal_integral (built-in)"
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use nalgebra::DVector;
+
+    use super::*;
+    use crate::mesh::UniformGrid1D;
+
+    fn grid(n: usize) -> Arc<dyn Mesh> {
+        Arc::new(UniformGrid1D::new(n, 0.0, 1.0).unwrap())
+    }
+
+    fn var() -> ContextVariable {
+        ContextVariable::External {
+            name: Cow::Borrowed("mass"),
+        }
+    }
+
+    fn ctx() -> ComputeContext {
+        ComputeContext::new(0.0, 0.01)
+    }
+
+    // ── provides / priority ───────────────────────────────────────────────────
+
+    #[test]
+    fn provides_configured_variable() {
+        let v = var();
+        let calc = TrapezoidalIntegral::new(grid(5), v.clone());
+        assert_eq!(calc.provides(), v);
+    }
+
+    #[test]
+    fn priority_is_one_hundred() {
+        let calc = TrapezoidalIntegral::new(grid(5), var());
+        assert_eq!(calc.priority(), 100);
+    }
+
+    // ── constant field ────────────────────────────────────────────────────────
+
+    #[test]
+    fn integral_of_constant_field_equals_domain_length() {
+        // u = 1 on [0, 1]  →  ∫₀¹ 1 dx = 1.0
+        let n = 11;
+        let calc = TrapezoidalIntegral::new(grid(n), var());
+        let u = DVector::from_element(n, 1.0);
+        let val = calc.compute(&ContextValue::ScalarField(u), &ctx()).unwrap();
+        assert!((val.as_scalar().unwrap() - 1.0).abs() < 1e-10);
+    }
+
+    // ── linear field: exact for trapezoidal ───────────────────────────────────
+
+    #[test]
+    fn integral_of_linear_field_is_exact() {
+        // u = x on [0, 1]  →  ∫₀¹ x dx = 0.5  (trapezoidal is exact for linears)
+        let n = 5;
+        let mesh = grid(n);
+        let dx = mesh.characteristic_length();
+        let u: Vec<f64> = (0..n).map(|i| i as f64 * dx).collect();
+
+        let calc = TrapezoidalIntegral::new(mesh, var());
+        let val = calc
+            .compute(&ContextValue::ScalarField(DVector::from_vec(u)), &ctx())
+            .unwrap();
+        assert!((val.as_scalar().unwrap() - 0.5).abs() < 1e-10);
+    }
+
+    // ── quadratic field: trapezoidal error decays with n ─────────────────────
+
+    #[test]
+    fn integral_of_quadratic_converges_to_exact() {
+        // u = x²  →  ∫₀¹ x² dx = 1/3
+        // Trapezoidal error O(dx²) — use enough nodes for reasonable accuracy.
+        let n = 101;
+        let mesh = grid(n);
+        let dx = mesh.characteristic_length();
+        let u: Vec<f64> = (0..n).map(|i| (i as f64 * dx).powi(2)).collect();
+
+        let calc = TrapezoidalIntegral::new(mesh, var());
+        let val = calc
+            .compute(&ContextValue::ScalarField(DVector::from_vec(u)), &ctx())
+            .unwrap();
+        let exact = 1.0_f64 / 3.0;
+        assert!(
+            (val.as_scalar().unwrap() - exact).abs() < 1e-4,
+            "expected ≈ {exact}, got {}",
+            val.as_scalar().unwrap()
+        );
+    }
+
+    // ── errors ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn error_on_scalar_state() {
+        let calc = TrapezoidalIntegral::new(grid(5), var());
+        let result = calc.compute(&ContextValue::Scalar(1.0), &ctx());
+        assert!(matches!(result, Err(OxiflowError::TypeMismatch { .. })));
+    }
+
+    #[test]
+    fn error_on_single_node_field() {
+        let mesh = Arc::new(UniformGrid1D::new(2, 0.0, 1.0).unwrap());
+        let calc = TrapezoidalIntegral::new(mesh, var());
+        let result = calc.compute(
+            &ContextValue::ScalarField(DVector::from_vec(vec![1.0])),
+            &ctx(),
+        );
+        assert!(matches!(
+            result,
+            Err(OxiflowError::PreconditionFailed { .. })
+        ));
+    }
+}

--- a/src/context/calculators/mod.rs
+++ b/src/context/calculators/mod.rs
@@ -1,0 +1,76 @@
+//! # Module `context::calculators`
+//!
+//! Built-in [`ContextCalculator`] implementations for common PDE quantities.
+//!
+//! These calculators cover the most frequent context variables in
+//! transport–reaction–diffusion problems. Each implements [`ContextCalculator`]
+//! and can be registered directly in [`SolverConfiguration`].
+//!
+//! ## Available calculators
+//!
+//! | Type | Provides | Notes |
+//! |---|---|---|
+//! | [`TimeCalculator`] | `ContextVariable::Time` | Current simulation time |
+//! | [`TimeStepCalculator`] | `ContextVariable::TimeStep` | Current `dt` |
+//! | [`FDGradientCalculator`] | `ContextVariable::SpatialGradient` | FD gradient (fwd/ctr/bwd) |
+//! | [`FDLaplacianCalculator`] | `ContextVariable::External { name }` | FD Laplacian |
+//! | [`TrapezoidalIntegral`] | `ContextVariable::External { name }` | Spatial quadrature |
+//! | [`ExternalTabulated`] | `ContextVariable::External { name }` | Tabulated f(t) interpolation |
+//!
+//! ## Mesh ownership
+//!
+//! Spatial calculators ([`FDGradientCalculator`], [`FDLaplacianCalculator`],
+//! [`TrapezoidalIntegral`]) hold an [`Arc<dyn Mesh>`] internally. This is an
+//! implementation detail consistent with INV-1 (DD-007): the mesh never appears
+//! in the public `ContextCalculator` API. At v0.5.0, `Arc<dyn Mesh>` will be
+//! replaced by a concrete [`DiscreteOperator`] (INV-2, DD-012), with zero change
+//! to the `ContextCalculator` trait signature.
+//!
+//! [`ContextCalculator`]: crate::context::calculator::ContextCalculator
+//! [`SolverConfiguration`]: crate::solver::config::SolverConfiguration
+//! [`Arc<dyn Mesh>`]: std::sync::Arc
+//! [`DiscreteOperator`]: crate::operators
+
+pub mod integral;
+pub mod spatial;
+pub mod tabulated;
+pub mod time;
+
+// ── Re-exports ────────────────────────────────────────────────────────────────
+
+pub use integral::TrapezoidalIntegral;
+pub use spatial::{FDGradientCalculator, FDLaplacianCalculator};
+pub use tabulated::{ExternalTabulated, Interpolation};
+pub use time::{TimeCalculator, TimeStepCalculator};
+
+// ── FDScheme ──────────────────────────────────────────────────────────────────
+
+/// Finite-difference stencil for first-order spatial derivatives.
+///
+/// Used by [`FDGradientCalculator`]. At interior nodes all three schemes are
+/// fully applicable; at boundary nodes the calculator falls back to the nearest
+/// available one-sided stencil automatically.
+///
+/// | Variant | Stencil | Order | Boundary fallback |
+/// |---|---|---|---|
+/// | `Forward` | `(u[i+1] − u[i]) / dx` | 1st | `Backward` at last node |
+/// | `Backward` | `(u[i] − u[i−1]) / dx` | 1st | `Forward` at first node |
+/// | `Central` | `(u[i+1] − u[i−1]) / (2 dx)` | 2nd | One-sided at boundaries |
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::context::calculators::FDScheme;
+///
+/// let scheme = FDScheme::Central;
+/// ```
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FDScheme {
+    /// Forward difference: `(u[i+1] − u[i]) / dx` — 1st-order accurate.
+    Forward,
+    /// Backward difference: `(u[i] − u[i−1]) / dx` — 1st-order accurate.
+    Backward,
+    /// Central difference: `(u[i+1] − u[i−1]) / (2 dx)` — 2nd-order accurate.
+    Central,
+}

--- a/src/context/calculators/spatial.rs
+++ b/src/context/calculators/spatial.rs
@@ -1,0 +1,539 @@
+//! # Module `context::calculators::spatial`
+//!
+//! Finite-difference spatial calculators: gradient and Laplacian.
+//!
+//! Both calculators hold an `Arc<dyn Mesh>` internally (INV-1, DD-007).
+//! At v0.5.0, this will be replaced by a concrete `DiscreteOperator`
+//! (INV-2, DD-012) with no change to the `ContextCalculator` trait.
+
+use std::sync::Arc;
+
+use nalgebra::DVector;
+
+use crate::context::calculator::ContextCalculator;
+use crate::context::calculators::FDScheme;
+use crate::context::compute::ComputeContext;
+use crate::context::error::OxiflowError;
+use crate::context::value::ContextValue;
+use crate::context::variable::ContextVariable;
+use crate::mesh::Mesh;
+use crate::model::traits::RequiresContext;
+
+// ── FDGradientCalculator ──────────────────────────────────────────────────────
+
+/// Computes the finite-difference spatial gradient of the primary field.
+///
+/// Provides `ContextVariable::SpatialGradient { dimension, component }` as a
+/// `ContextValue::ScalarField` — one gradient value per mesh node.
+///
+/// The mesh is held as `Arc<dyn Mesh>` internally (INV-1). At J5 (v0.5.0),
+/// this implementation detail will be replaced by a `DiscreteOperator` (INV-2).
+///
+/// # Boundary treatment
+///
+/// | Scheme | Interior | Left boundary (i = 0) | Right boundary (i = n−1) |
+/// |---|---|---|---|
+/// | `Forward` | `(u[i+1] − u[i]) / dx` | same | `(u[n−1] − u[n−2]) / dx` |
+/// | `Backward` | `(u[i] − u[i−1]) / dx` | `(u[1] − u[0]) / dx` | same |
+/// | `Central` | `(u[i+1] − u[i−1]) / 2dx` | `(u[1] − u[0]) / dx` | `(u[n−1] − u[n−2]) / dx` |
+///
+/// # Examples
+///
+/// ```rust
+/// use std::sync::Arc;
+/// use oxiflow::context::calculator::ContextCalculator;
+/// use oxiflow::context::calculators::{FDGradientCalculator, FDScheme};
+/// use oxiflow::context::compute::ComputeContext;
+/// use oxiflow::context::value::ContextValue;
+/// use oxiflow::context::variable::ContextVariable;
+/// use oxiflow::mesh::{Mesh, UniformGrid1D};
+/// use nalgebra::DVector;
+///
+/// let mesh = Arc::new(UniformGrid1D::new(5, 0.0, 1.0).unwrap());
+/// let calc = FDGradientCalculator::new(mesh, 0, None, FDScheme::Central);
+///
+/// // Linear field u = x  →  ∂u/∂x = 1 everywhere
+/// let u = DVector::from_vec(vec![0.0, 0.25, 0.5, 0.75, 1.0]);
+/// let ctx = ComputeContext::new(0.0, 0.01);
+/// let grad = calc.compute(&ContextValue::ScalarField(u), &ctx).unwrap();
+/// let field = grad.as_scalar_field().unwrap();
+/// for g in field.iter() {
+///     assert!((g - 1.0).abs() < 1e-10);
+/// }
+/// ```
+pub struct FDGradientCalculator {
+    mesh: Arc<dyn Mesh>,
+    dimension: usize,
+    component: Option<usize>,
+    scheme: FDScheme,
+}
+
+impl FDGradientCalculator {
+    /// Creates a new FD gradient calculator.
+    ///
+    /// # Arguments
+    ///
+    /// - `mesh` — shared mesh reference (INV-1 compliant).
+    /// - `dimension` — spatial dimension (0 → ∂u/∂x, 1 → ∂u/∂y, …).
+    /// - `component` — field component (`None` for mono-component, J1/J2 default).
+    /// - `scheme` — finite-difference stencil.
+    pub fn new(
+        mesh: Arc<dyn Mesh>,
+        dimension: usize,
+        component: Option<usize>,
+        scheme: FDScheme,
+    ) -> Self {
+        Self {
+            mesh,
+            dimension,
+            component,
+            scheme,
+        }
+    }
+}
+
+impl std::fmt::Debug for FDGradientCalculator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FDGradientCalculator")
+            .field("dimension", &self.dimension)
+            .field("component", &self.component)
+            .field("scheme", &self.scheme)
+            .field("mesh_n_dof", &self.mesh.n_dof())
+            .finish()
+    }
+}
+
+impl RequiresContext for FDGradientCalculator {
+    fn required_variables(&self) -> Vec<ContextVariable> {
+        vec![]
+    }
+
+    // Runs after time built-ins (priority 0) but before user-defined calculators.
+    fn priority(&self) -> u32 {
+        10
+    }
+}
+
+impl ContextCalculator for FDGradientCalculator {
+    fn provides(&self) -> ContextVariable {
+        ContextVariable::SpatialGradient {
+            dimension: self.dimension,
+            component: self.component,
+        }
+    }
+
+    fn compute(
+        &self,
+        state: &ContextValue,
+        _ctx: &ComputeContext,
+    ) -> Result<ContextValue, OxiflowError> {
+        let u = state.as_scalar_field()?;
+        let n = u.len();
+
+        if n < 2 {
+            return Err(OxiflowError::PreconditionFailed {
+                context: "FDGradientCalculator",
+                message: format!("field must have at least 2 nodes, got {n}"),
+            });
+        }
+
+        let dx = self.mesh.characteristic_length();
+        let mut grad = DVector::zeros(n);
+
+        for i in 0..n {
+            grad[i] = match self.scheme {
+                FDScheme::Forward => {
+                    if i < n - 1 {
+                        (u[i + 1] - u[i]) / dx
+                    } else {
+                        // Right boundary fallback: backward
+                        (u[n - 1] - u[n - 2]) / dx
+                    }
+                }
+                FDScheme::Backward => {
+                    if i > 0 {
+                        (u[i] - u[i - 1]) / dx
+                    } else {
+                        // Left boundary fallback: forward
+                        (u[1] - u[0]) / dx
+                    }
+                }
+                FDScheme::Central => {
+                    if i == 0 {
+                        // Left boundary: 1st-order forward
+                        (u[1] - u[0]) / dx
+                    } else if i == n - 1 {
+                        // Right boundary: 1st-order backward
+                        (u[n - 1] - u[n - 2]) / dx
+                    } else {
+                        // Interior: 2nd-order central
+                        (u[i + 1] - u[i - 1]) / (2.0 * dx)
+                    }
+                }
+                // J5+: higher-order stencils will be added here.
+                #[allow(unreachable_patterns)]
+                _ => {
+                    return Err(OxiflowError::PreconditionFailed {
+                        context: "FDGradientCalculator",
+                        message: "unsupported FDScheme variant".to_string(),
+                    })
+                }
+            };
+        }
+
+        Ok(ContextValue::ScalarField(grad))
+    }
+
+    fn name(&self) -> &str {
+        "fd_gradient (built-in)"
+    }
+}
+
+// ── FDLaplacianCalculator ─────────────────────────────────────────────────────
+
+/// Computes the finite-difference Laplacian ∇²u of the primary field.
+///
+/// Provides a user-chosen `ContextVariable::External { name }` as a
+/// `ContextValue::ScalarField`. The Laplacian is a scalar nodal field of the
+/// same length as the primary field — no new `ContextVariable` variant is
+/// needed (DD-026 deferred).
+///
+/// # Stencil
+///
+/// Standard 3-point central: `(u[i−1] − 2u[i] + u[i+1]) / dx²`
+///
+/// Boundary treatment (1st-order one-sided):
+/// - `i = 0` → `(u[0] − 2u[1] + u[2]) / dx²`
+/// - `i = n−1` → `(u[n−3] − 2u[n−2] + u[n−1]) / dx²`
+///
+/// # Examples
+///
+/// ```rust
+/// use std::sync::Arc;
+/// use std::borrow::Cow;
+/// use oxiflow::context::calculator::ContextCalculator;
+/// use oxiflow::context::calculators::FDLaplacianCalculator;
+/// use oxiflow::context::compute::ComputeContext;
+/// use oxiflow::context::value::ContextValue;
+/// use oxiflow::context::variable::ContextVariable;
+/// use oxiflow::mesh::{Mesh, UniformGrid1D};
+/// use nalgebra::DVector;
+///
+/// let mesh = Arc::new(UniformGrid1D::new(5, 0.0, 1.0).unwrap());
+/// let var  = ContextVariable::External { name: Cow::Borrowed("laplacian") };
+/// let calc = FDLaplacianCalculator::new(mesh, var);
+///
+/// // Quadratic field u = x²  →  ∇²u = 2 everywhere (interior)
+/// let u = DVector::from_vec(vec![0.0, 0.0625, 0.25, 0.5625, 1.0]);
+/// let ctx = ComputeContext::new(0.0, 0.01);
+/// let lap = calc.compute(&ContextValue::ScalarField(u), &ctx).unwrap();
+/// let field = lap.as_scalar_field().unwrap();
+/// // Interior nodes: ∇²u ≈ 2.0
+/// assert!((field[2] - 2.0).abs() < 1e-6);
+/// ```
+pub struct FDLaplacianCalculator {
+    mesh: Arc<dyn Mesh>,
+    variable: ContextVariable,
+}
+
+impl FDLaplacianCalculator {
+    /// Creates a new FD Laplacian calculator.
+    ///
+    /// # Arguments
+    ///
+    /// - `mesh` — shared mesh reference (INV-1 compliant).
+    /// - `variable` — the `ContextVariable` this calculator provides, typically
+    ///   `ContextVariable::External { name: "laplacian".into() }`.
+    pub fn new(mesh: Arc<dyn Mesh>, variable: ContextVariable) -> Self {
+        Self { mesh, variable }
+    }
+}
+
+impl std::fmt::Debug for FDLaplacianCalculator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FDLaplacianCalculator")
+            .field("variable", &self.variable)
+            .field("mesh_n_dof", &self.mesh.n_dof())
+            .finish()
+    }
+}
+
+impl RequiresContext for FDLaplacianCalculator {
+    fn required_variables(&self) -> Vec<ContextVariable> {
+        vec![]
+    }
+
+    fn priority(&self) -> u32 {
+        10
+    }
+}
+
+impl ContextCalculator for FDLaplacianCalculator {
+    fn provides(&self) -> ContextVariable {
+        self.variable.clone()
+    }
+
+    fn compute(
+        &self,
+        state: &ContextValue,
+        _ctx: &ComputeContext,
+    ) -> Result<ContextValue, OxiflowError> {
+        let u = state.as_scalar_field()?;
+        let n = u.len();
+
+        if n < 3 {
+            return Err(OxiflowError::PreconditionFailed {
+                context: "FDLaplacianCalculator",
+                message: format!("field must have at least 3 nodes, got {n}"),
+            });
+        }
+
+        let dx = self.mesh.characteristic_length();
+        let dx2 = dx * dx;
+        let mut lap = DVector::zeros(n);
+
+        // Left boundary: one-sided stencil using nodes [0, 1, 2].
+        lap[0] = (u[0] - 2.0 * u[1] + u[2]) / dx2;
+
+        // Interior: standard 3-point central difference.
+        for i in 1..n - 1 {
+            lap[i] = (u[i - 1] - 2.0 * u[i] + u[i + 1]) / dx2;
+        }
+
+        // Right boundary: one-sided stencil using nodes [n-3, n-2, n-1].
+        lap[n - 1] = (u[n - 3] - 2.0 * u[n - 2] + u[n - 1]) / dx2;
+
+        Ok(ContextValue::ScalarField(lap))
+    }
+
+    fn name(&self) -> &str {
+        "fd_laplacian (built-in)"
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use super::*;
+    use crate::mesh::UniformGrid1D;
+
+    fn grid(n: usize) -> Arc<dyn Mesh> {
+        Arc::new(UniformGrid1D::new(n, 0.0, 1.0).unwrap())
+    }
+
+    fn ctx() -> ComputeContext {
+        ComputeContext::new(0.0, 0.01)
+    }
+
+    fn laplacian_var() -> ContextVariable {
+        ContextVariable::External {
+            name: Cow::Borrowed("laplacian"),
+        }
+    }
+
+    // ── FDGradientCalculator — provides / priority ────────────────────────────
+
+    #[test]
+    fn gradient_provides_spatial_gradient_variable() {
+        let calc = FDGradientCalculator::new(grid(5), 0, None, FDScheme::Central);
+        assert_eq!(
+            calc.provides(),
+            ContextVariable::SpatialGradient {
+                dimension: 0,
+                component: None
+            }
+        );
+    }
+
+    #[test]
+    fn gradient_priority_is_ten() {
+        let calc = FDGradientCalculator::new(grid(5), 0, None, FDScheme::Forward);
+        assert_eq!(calc.priority(), 10);
+    }
+
+    #[test]
+    fn gradient_has_no_required_variables() {
+        let calc = FDGradientCalculator::new(grid(5), 0, None, FDScheme::Forward);
+        assert!(calc.required_variables().is_empty());
+    }
+
+    // ── FDGradientCalculator — Central on linear field ────────────────────────
+
+    #[test]
+    fn central_gradient_of_linear_field_is_one() {
+        // u = x on [0, 1] with 5 nodes → ∂u/∂x = 1 everywhere
+        let n = 5;
+        let mesh = grid(n);
+        let dx = mesh.characteristic_length();
+        let u: Vec<f64> = (0..n).map(|i| i as f64 * dx).collect();
+
+        let calc = FDGradientCalculator::new(mesh, 0, None, FDScheme::Central);
+        let result = calc
+            .compute(&ContextValue::ScalarField(DVector::from_vec(u)), &ctx())
+            .unwrap();
+        let grad = result.as_scalar_field().unwrap();
+
+        for g in grad.iter() {
+            assert!((g - 1.0).abs() < 1e-10, "expected 1.0, got {g}");
+        }
+    }
+
+    // ── FDGradientCalculator — Forward ────────────────────────────────────────
+
+    #[test]
+    fn forward_gradient_interior_nodes_correct() {
+        let n = 5;
+        let mesh = grid(n);
+        let dx = mesh.characteristic_length();
+        // u = x²  →  ∂u/∂x at x_i ≈ (x_{i+1}² - x_i²) / dx  (forward, 1st order)
+        let u: Vec<f64> = (0..n).map(|i| (i as f64 * dx).powi(2)).collect();
+
+        let calc = FDGradientCalculator::new(mesh, 0, None, FDScheme::Forward);
+        let result = calc
+            .compute(&ContextValue::ScalarField(DVector::from_vec(u)), &ctx())
+            .unwrap();
+        let grad = result.as_scalar_field().unwrap();
+
+        // At i=0: (0.0625 - 0) / 0.25 = 0.25  (forward approx of 2x at x=0 → expected 0)
+        // Forward is 1st-order so we verify it returns a finite, non-NaN value.
+        assert!(grad.iter().all(|g| g.is_finite()));
+        // Boundary fallback: last node uses backward
+        assert!((grad[n - 1] - grad[n - 2]).abs() < 1.0);
+    }
+
+    // ── FDGradientCalculator — Backward ───────────────────────────────────────
+
+    #[test]
+    fn backward_gradient_fallback_at_left_boundary() {
+        let n = 5;
+        let mesh = grid(n);
+        let dx = mesh.characteristic_length();
+        let u: Vec<f64> = (0..n).map(|i| i as f64 * dx).collect(); // u = x
+
+        let calc = FDGradientCalculator::new(mesh, 0, None, FDScheme::Backward);
+        let result = calc
+            .compute(&ContextValue::ScalarField(DVector::from_vec(u)), &ctx())
+            .unwrap();
+        let grad = result.as_scalar_field().unwrap();
+
+        // Left boundary fallback → forward → (u[1] - u[0]) / dx = 1.0
+        assert!((grad[0] - 1.0).abs() < 1e-10);
+    }
+
+    // ── FDGradientCalculator — error on small field ───────────────────────────
+
+    #[test]
+    fn gradient_error_on_single_node_field() {
+        let mesh = Arc::new(UniformGrid1D::new(2, 0.0, 1.0).unwrap());
+        let calc = FDGradientCalculator::new(mesh, 0, None, FDScheme::Central);
+        let result = calc.compute(
+            &ContextValue::ScalarField(DVector::from_vec(vec![1.0])),
+            &ctx(),
+        );
+        assert!(matches!(
+            result,
+            Err(OxiflowError::PreconditionFailed { .. })
+        ));
+    }
+
+    // ── FDGradientCalculator — type mismatch ──────────────────────────────────
+
+    #[test]
+    fn gradient_error_on_scalar_state() {
+        let calc = FDGradientCalculator::new(grid(5), 0, None, FDScheme::Central);
+        let result = calc.compute(&ContextValue::Scalar(1.0), &ctx());
+        assert!(matches!(result, Err(OxiflowError::TypeMismatch { .. })));
+    }
+
+    // ── FDLaplacianCalculator — provides / priority ───────────────────────────
+
+    #[test]
+    fn laplacian_provides_configured_variable() {
+        let var = laplacian_var();
+        let calc = FDLaplacianCalculator::new(grid(5), var.clone());
+        assert_eq!(calc.provides(), var);
+    }
+
+    #[test]
+    fn laplacian_priority_is_ten() {
+        let calc = FDLaplacianCalculator::new(grid(5), laplacian_var());
+        assert_eq!(calc.priority(), 10);
+    }
+
+    // ── FDLaplacianCalculator — quadratic field ───────────────────────────────
+
+    #[test]
+    fn laplacian_of_quadratic_field_is_two_at_interior() {
+        // u = x²  →  ∇²u = d²u/dx² = 2 everywhere
+        let n = 7;
+        let mesh = grid(n);
+        let dx = mesh.characteristic_length();
+        let u: Vec<f64> = (0..n).map(|i| (i as f64 * dx).powi(2)).collect();
+
+        let calc = FDLaplacianCalculator::new(mesh, laplacian_var());
+        let result = calc
+            .compute(&ContextValue::ScalarField(DVector::from_vec(u)), &ctx())
+            .unwrap();
+        let lap = result.as_scalar_field().unwrap();
+
+        // Interior nodes: exact for quadratic field
+        for i in 1..n - 1 {
+            assert!(
+                (lap[i] - 2.0).abs() < 1e-8,
+                "node {i}: expected 2.0, got {}",
+                lap[i]
+            );
+        }
+    }
+
+    #[test]
+    fn laplacian_of_linear_field_is_zero_at_interior() {
+        // u = x  →  ∇²u = 0 everywhere
+        let n = 7;
+        let mesh = grid(n);
+        let dx = mesh.characteristic_length();
+        let u: Vec<f64> = (0..n).map(|i| i as f64 * dx).collect();
+
+        let calc = FDLaplacianCalculator::new(mesh, laplacian_var());
+        let result = calc
+            .compute(&ContextValue::ScalarField(DVector::from_vec(u)), &ctx())
+            .unwrap();
+        let lap = result.as_scalar_field().unwrap();
+
+        for i in 1..n - 1 {
+            assert!(
+                lap[i].abs() < 1e-10,
+                "node {i}: expected 0.0, got {}",
+                lap[i]
+            );
+        }
+    }
+
+    // ── FDLaplacianCalculator — error on small field ──────────────────────────
+
+    #[test]
+    fn laplacian_error_on_two_node_field() {
+        let mesh = Arc::new(UniformGrid1D::new(2, 0.0, 1.0).unwrap());
+        let calc = FDLaplacianCalculator::new(mesh, laplacian_var());
+        let result = calc.compute(
+            &ContextValue::ScalarField(DVector::from_vec(vec![0.0, 1.0])),
+            &ctx(),
+        );
+        assert!(matches!(
+            result,
+            Err(OxiflowError::PreconditionFailed { .. })
+        ));
+    }
+
+    // ── FDLaplacianCalculator — type mismatch ─────────────────────────────────
+
+    #[test]
+    fn laplacian_error_on_scalar_state() {
+        let calc = FDLaplacianCalculator::new(grid(5), laplacian_var());
+        let result = calc.compute(&ContextValue::Scalar(1.0), &ctx());
+        assert!(matches!(result, Err(OxiflowError::TypeMismatch { .. })));
+    }
+}

--- a/src/context/calculators/tabulated.rs
+++ b/src/context/calculators/tabulated.rs
@@ -1,0 +1,318 @@
+//! # Module `context::calculators::tabulated`
+//!
+//! Tabulated time-dependent data calculator with interpolation.
+
+use crate::context::calculator::ContextCalculator;
+use crate::context::compute::ComputeContext;
+use crate::context::error::OxiflowError;
+use crate::context::value::ContextValue;
+use crate::context::variable::ContextVariable;
+use crate::model::traits::RequiresContext;
+
+// ── Interpolation ─────────────────────────────────────────────────────────────
+
+/// Interpolation strategy for [`ExternalTabulated`].
+///
+/// # Variants
+///
+/// - `Linear` — piecewise linear (1st-order accurate). Exact for linear f(t).
+///
+/// # Reserved
+///
+/// `PiecewiseCubic` (natural cubic spline, 4th-order accurate) is planned for
+/// J5 (v0.7.0) and requires the `spline` feature flag.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Interpolation {
+    /// Piecewise linear interpolation: `f(t) = f_i + (f_{i+1} − f_i) · (t − t_i) / (t_{i+1} − t_i)`.
+    Linear,
+    // PiecewiseCubic — RESERVED J5 (v0.7.0), requires feature `spline`.
+}
+
+// ── ExternalTabulated ─────────────────────────────────────────────────────────
+
+/// Provides a time-dependent scalar from tabulated (t, value) data.
+///
+/// Data points must be sorted by ascending `t`. The calculator interpolates at
+/// `ctx.time()` using the chosen [`Interpolation`] strategy.
+///
+/// Outside the data range the calculator clamps to the nearest endpoint value
+/// rather than extrapolating, and emits an `ExternalData` error if `data` is
+/// empty or has only one point (interpolation is undefined).
+///
+/// # Examples
+///
+/// ```rust
+/// use std::borrow::Cow;
+/// use oxiflow::context::calculator::ContextCalculator;
+/// use oxiflow::context::calculators::{ExternalTabulated, Interpolation};
+/// use oxiflow::context::compute::ComputeContext;
+/// use oxiflow::context::value::ContextValue;
+/// use oxiflow::context::variable::ContextVariable;
+///
+/// let var = ContextVariable::External { name: Cow::Borrowed("feed_conc") };
+/// let data = vec![(0.0, 1.0), (1.0, 2.0), (2.0, 1.5)];
+/// let calc = ExternalTabulated::new(var, data, Interpolation::Linear).unwrap();
+///
+/// // Interpolate at t = 0.5  →  1.0 + (2.0 − 1.0) × 0.5 = 1.5
+/// let ctx = ComputeContext::new(0.5, 0.01);
+/// let val = calc.compute(&ContextValue::Scalar(0.0), &ctx).unwrap();
+/// assert!((val.as_scalar().unwrap() - 1.5).abs() < 1e-10);
+/// ```
+#[derive(Debug)]
+pub struct ExternalTabulated {
+    variable: ContextVariable,
+    /// (t, value) pairs, sorted by t ascending.
+    data: Vec<(f64, f64)>,
+    interpolation: Interpolation,
+}
+
+impl ExternalTabulated {
+    /// Creates a new tabulated external calculator.
+    ///
+    /// # Arguments
+    ///
+    /// - `variable` — the `ContextVariable` this calculator provides.
+    /// - `data` — `(t, value)` pairs; must be sorted by ascending `t` and
+    ///   contain at least 2 points.
+    /// - `interpolation` — interpolation strategy.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(OxiflowError::ExternalData)` if `data` has fewer than 2 points
+    /// or is not sorted by ascending `t`.
+    pub fn new(
+        variable: ContextVariable,
+        data: Vec<(f64, f64)>,
+        interpolation: Interpolation,
+    ) -> Result<Self, OxiflowError> {
+        if data.len() < 2 {
+            return Err(OxiflowError::ExternalData(format!(
+                "ExternalTabulated requires at least 2 data points, got {}",
+                data.len()
+            )));
+        }
+
+        // Verify ascending t order.
+        for w in data.windows(2) {
+            if w[0].0 >= w[1].0 {
+                return Err(OxiflowError::ExternalData(format!(
+                    "ExternalTabulated data must be sorted by ascending t: \
+                     t[i]={} >= t[i+1]={}",
+                    w[0].0, w[1].0
+                )));
+            }
+        }
+
+        Ok(Self {
+            variable,
+            data,
+            interpolation,
+        })
+    }
+
+    /// Interpolates the tabulated data at time `t`.
+    ///
+    /// Clamps to endpoint values outside the data range.
+    fn interpolate(&self, t: f64) -> f64 {
+        let (t_min, v_min) = self.data[0];
+        let (t_max, v_max) = *self.data.last().unwrap();
+
+        // Clamp outside range.
+        if t <= t_min {
+            return v_min;
+        }
+        if t >= t_max {
+            return v_max;
+        }
+
+        // Binary search for the bracketing interval.
+        let idx = self
+            .data
+            .partition_point(|(ti, _)| *ti <= t)
+            .saturating_sub(1);
+
+        let (t0, v0) = self.data[idx];
+        let (t1, v1) = self.data[idx + 1];
+
+        match self.interpolation {
+            Interpolation::Linear => v0 + (v1 - v0) * (t - t0) / (t1 - t0),
+            // J5+: PiecewiseCubic will be added here.
+            #[allow(unreachable_patterns)]
+            _ => v0, // unreachable at J2
+        }
+    }
+}
+
+impl RequiresContext for ExternalTabulated {
+    fn required_variables(&self) -> Vec<ContextVariable> {
+        vec![]
+    }
+
+    // External data runs before derived quantities (priority 100) but after
+    // time built-ins (priority 0).
+    fn priority(&self) -> u32 {
+        50
+    }
+}
+
+impl ContextCalculator for ExternalTabulated {
+    fn provides(&self) -> ContextVariable {
+        self.variable.clone()
+    }
+
+    fn compute(
+        &self,
+        _state: &ContextValue,
+        ctx: &ComputeContext,
+    ) -> Result<ContextValue, OxiflowError> {
+        let value = self.interpolate(ctx.time());
+        Ok(ContextValue::Scalar(value))
+    }
+
+    fn name(&self) -> &str {
+        "external_tabulated (built-in)"
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use super::*;
+
+    fn var() -> ContextVariable {
+        ContextVariable::External {
+            name: Cow::Borrowed("feed"),
+        }
+    }
+
+    fn linear_data() -> Vec<(f64, f64)> {
+        vec![(0.0, 0.0), (1.0, 1.0), (2.0, 2.0)]
+    }
+
+    fn calc(data: Vec<(f64, f64)>) -> ExternalTabulated {
+        ExternalTabulated::new(var(), data, Interpolation::Linear).unwrap()
+    }
+
+    fn ctx(t: f64) -> ComputeContext {
+        ComputeContext::new(t, 0.01)
+    }
+
+    // ── constructor ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn new_succeeds_with_valid_data() {
+        assert!(ExternalTabulated::new(var(), linear_data(), Interpolation::Linear).is_ok());
+    }
+
+    #[test]
+    fn new_fails_with_single_point() {
+        let result = ExternalTabulated::new(var(), vec![(0.0, 1.0)], Interpolation::Linear);
+        assert!(matches!(result, Err(OxiflowError::ExternalData(_))));
+    }
+
+    #[test]
+    fn new_fails_with_empty_data() {
+        let result = ExternalTabulated::new(var(), vec![], Interpolation::Linear);
+        assert!(matches!(result, Err(OxiflowError::ExternalData(_))));
+    }
+
+    #[test]
+    fn new_fails_when_not_sorted() {
+        let result =
+            ExternalTabulated::new(var(), vec![(1.0, 1.0), (0.0, 0.0)], Interpolation::Linear);
+        assert!(matches!(result, Err(OxiflowError::ExternalData(_))));
+    }
+
+    #[test]
+    fn new_fails_on_duplicate_t() {
+        let result = ExternalTabulated::new(
+            var(),
+            vec![(0.0, 0.0), (0.0, 1.0), (1.0, 2.0)],
+            Interpolation::Linear,
+        );
+        assert!(matches!(result, Err(OxiflowError::ExternalData(_))));
+    }
+
+    // ── provides / priority ───────────────────────────────────────────────────
+
+    #[test]
+    fn provides_configured_variable() {
+        let v = var();
+        let c = calc(linear_data());
+        assert_eq!(c.provides(), v);
+    }
+
+    #[test]
+    fn priority_is_fifty() {
+        assert_eq!(calc(linear_data()).priority(), 50);
+    }
+
+    // ── linear interpolation ──────────────────────────────────────────────────
+
+    #[test]
+    fn interpolates_at_midpoint() {
+        // data: (0,0), (1,1), (2,2)  →  at t=0.5: value = 0.5
+        let c = calc(linear_data());
+        let val = c.compute(&ContextValue::Scalar(0.0), &ctx(0.5)).unwrap();
+        assert!((val.as_scalar().unwrap() - 0.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn interpolates_exactly_at_knot() {
+        let c = calc(linear_data());
+        let val = c.compute(&ContextValue::Scalar(0.0), &ctx(1.0)).unwrap();
+        assert!((val.as_scalar().unwrap() - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn non_linear_interpolation_between_knots() {
+        // data: (0, 1.0), (1, 2.0), (2, 1.5)
+        let data = vec![(0.0, 1.0), (1.0, 2.0), (2.0, 1.5)];
+        let c = calc(data);
+        // t = 1.5 → between (1, 2.0) and (2, 1.5) → 2.0 + (1.5 - 2.0) * 0.5 = 1.75
+        let val = c.compute(&ContextValue::Scalar(0.0), &ctx(1.5)).unwrap();
+        assert!((val.as_scalar().unwrap() - 1.75).abs() < 1e-10);
+    }
+
+    // ── clamping ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn clamps_to_first_value_before_range() {
+        let c = calc(linear_data());
+        let val = c.compute(&ContextValue::Scalar(0.0), &ctx(-1.0)).unwrap();
+        assert_eq!(val.as_scalar().unwrap(), 0.0);
+    }
+
+    #[test]
+    fn clamps_to_last_value_after_range() {
+        let c = calc(linear_data());
+        let val = c.compute(&ContextValue::Scalar(0.0), &ctx(5.0)).unwrap();
+        assert_eq!(val.as_scalar().unwrap(), 2.0);
+    }
+
+    #[test]
+    fn clamps_exactly_at_lower_bound() {
+        let c = calc(linear_data());
+        let val = c.compute(&ContextValue::Scalar(0.0), &ctx(0.0)).unwrap();
+        assert_eq!(val.as_scalar().unwrap(), 0.0);
+    }
+
+    #[test]
+    fn clamps_exactly_at_upper_bound() {
+        let c = calc(linear_data());
+        let val = c.compute(&ContextValue::Scalar(0.0), &ctx(2.0)).unwrap();
+        assert_eq!(val.as_scalar().unwrap(), 2.0);
+    }
+
+    // ── object safety ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn is_object_safe() {
+        let c: Box<dyn ContextCalculator> = Box::new(calc(linear_data()));
+        assert_eq!(c.provides(), var());
+    }
+}

--- a/src/context/calculators/time.rs
+++ b/src/context/calculators/time.rs
@@ -1,0 +1,202 @@
+//! # Module `context::calculators::time`
+//!
+//! Built-in calculators for temporal context variables.
+//!
+//! [`TimeCalculator`] and [`TimeStepCalculator`] are injected by the solver
+//! before the user-defined calculator chain runs. They are registered here as
+//! public types so that downstream models can inspect or test the chain without
+//! coupling to solver internals.
+
+use crate::context::calculator::ContextCalculator;
+use crate::context::compute::ComputeContext;
+use crate::context::error::OxiflowError;
+use crate::context::value::ContextValue;
+use crate::context::variable::ContextVariable;
+use crate::model::traits::RequiresContext;
+
+// ── TimeCalculator ────────────────────────────────────────────────────────────
+
+/// Provides the current simulation time as `ContextVariable::Time`.
+///
+/// Priority 0 — runs first in every chain. No required variables.
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::context::calculator::ContextCalculator;
+/// use oxiflow::context::calculators::TimeCalculator;
+/// use oxiflow::context::compute::ComputeContext;
+/// use oxiflow::context::value::ContextValue;
+/// use oxiflow::context::variable::ContextVariable;
+///
+/// let calc = TimeCalculator;
+/// let ctx  = ComputeContext::new(3.14, 0.01);
+///
+/// assert_eq!(calc.provides(), ContextVariable::Time);
+/// let val = calc.compute(&ContextValue::Scalar(0.0), &ctx).unwrap();
+/// assert_eq!(val.as_scalar().unwrap(), 3.14);
+/// ```
+#[derive(Debug, Clone)]
+pub struct TimeCalculator;
+
+impl RequiresContext for TimeCalculator {
+    fn required_variables(&self) -> Vec<ContextVariable> {
+        vec![]
+    }
+
+    fn priority(&self) -> u32 {
+        0
+    }
+}
+
+impl ContextCalculator for TimeCalculator {
+    fn provides(&self) -> ContextVariable {
+        ContextVariable::Time
+    }
+
+    fn compute(
+        &self,
+        _state: &ContextValue,
+        ctx: &ComputeContext,
+    ) -> Result<ContextValue, OxiflowError> {
+        Ok(ContextValue::Scalar(ctx.time()))
+    }
+
+    fn name(&self) -> &str {
+        "time (built-in)"
+    }
+}
+
+// ── TimeStepCalculator ────────────────────────────────────────────────────────
+
+/// Provides the current time step as `ContextVariable::TimeStep`.
+///
+/// Priority 0 — runs first in every chain. No required variables.
+///
+/// # Examples
+///
+/// ```rust
+/// use oxiflow::context::calculator::ContextCalculator;
+/// use oxiflow::context::calculators::TimeStepCalculator;
+/// use oxiflow::context::compute::ComputeContext;
+/// use oxiflow::context::value::ContextValue;
+/// use oxiflow::context::variable::ContextVariable;
+///
+/// let calc = TimeStepCalculator;
+/// let ctx  = ComputeContext::new(0.0, 0.05);
+///
+/// assert_eq!(calc.provides(), ContextVariable::TimeStep);
+/// let val = calc.compute(&ContextValue::Scalar(0.0), &ctx).unwrap();
+/// assert_eq!(val.as_scalar().unwrap(), 0.05);
+/// ```
+#[derive(Debug, Clone)]
+pub struct TimeStepCalculator;
+
+impl RequiresContext for TimeStepCalculator {
+    fn required_variables(&self) -> Vec<ContextVariable> {
+        vec![]
+    }
+
+    fn priority(&self) -> u32 {
+        0
+    }
+}
+
+impl ContextCalculator for TimeStepCalculator {
+    fn provides(&self) -> ContextVariable {
+        ContextVariable::TimeStep
+    }
+
+    fn compute(
+        &self,
+        _state: &ContextValue,
+        ctx: &ComputeContext,
+    ) -> Result<ContextValue, OxiflowError> {
+        Ok(ContextValue::Scalar(ctx.time_step()))
+    }
+
+    fn name(&self) -> &str {
+        "time_step (built-in)"
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx(t: f64, dt: f64) -> ComputeContext {
+        ComputeContext::new(t, dt)
+    }
+
+    // ── TimeCalculator ────────────────────────────────────────────────────────
+
+    #[test]
+    fn time_calculator_provides_time() {
+        assert_eq!(TimeCalculator.provides(), ContextVariable::Time);
+    }
+
+    #[test]
+    fn time_calculator_returns_current_time() {
+        let result = TimeCalculator
+            .compute(&ContextValue::Scalar(0.0), &ctx(2.5, 0.01))
+            .unwrap();
+        assert_eq!(result.as_scalar().unwrap(), 2.5);
+    }
+
+    #[test]
+    fn time_calculator_priority_is_zero() {
+        assert_eq!(TimeCalculator.priority(), 0);
+    }
+
+    #[test]
+    fn time_calculator_has_no_required_variables() {
+        assert!(TimeCalculator.required_variables().is_empty());
+    }
+
+    #[test]
+    fn time_calculator_name() {
+        assert_eq!(TimeCalculator.name(), "time (built-in)");
+    }
+
+    // ── TimeStepCalculator ────────────────────────────────────────────────────
+
+    #[test]
+    fn timestep_calculator_provides_timestep() {
+        assert_eq!(TimeStepCalculator.provides(), ContextVariable::TimeStep);
+    }
+
+    #[test]
+    fn timestep_calculator_returns_current_dt() {
+        let result = TimeStepCalculator
+            .compute(&ContextValue::Scalar(0.0), &ctx(0.0, 0.05))
+            .unwrap();
+        assert_eq!(result.as_scalar().unwrap(), 0.05);
+    }
+
+    #[test]
+    fn timestep_calculator_priority_is_zero() {
+        assert_eq!(TimeStepCalculator.priority(), 0);
+    }
+
+    #[test]
+    fn timestep_calculator_has_no_required_variables() {
+        assert!(TimeStepCalculator.required_variables().is_empty());
+    }
+
+    #[test]
+    fn timestep_calculator_name() {
+        assert_eq!(TimeStepCalculator.name(), "time_step (built-in)");
+    }
+
+    // ── Object safety ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn both_are_object_safe() {
+        let calcs: Vec<Box<dyn ContextCalculator>> =
+            vec![Box::new(TimeCalculator), Box::new(TimeStepCalculator)];
+        assert_eq!(calcs[0].provides(), ContextVariable::Time);
+        assert_eq!(calcs[1].provides(), ContextVariable::TimeStep);
+    }
+}

--- a/src/context/compute.rs
+++ b/src/context/compute.rs
@@ -177,19 +177,19 @@ mod tests {
     fn ctx_with_all_variants() -> ComputeContext {
         let mut ctx = ComputeContext::new(2.0, 0.01);
         ctx.insert(
-            ContextVariable::External { name: "coeff" },
+            ContextVariable::External { name: "coeff".into() },
             ContextValue::Scalar(42.0),
         );
         ctx.insert(
-            ContextVariable::External { name: "flag" },
+            ContextVariable::External { name: "flag".into() },
             ContextValue::Boolean(true),
         );
         ctx.insert(
-            ContextVariable::External { name: "vel" },
+            ContextVariable::External { name: "vel".into() },
             ContextValue::Vector(DVector::from_vec(vec![1.0, 2.0, 3.0])),
         );
         ctx.insert(
-            ContextVariable::External { name: "tensor" },
+            ContextVariable::External { name: "tensor".into() },
             ContextValue::Matrix(DMatrix::from_element(2, 2, 5.0)),
         );
         ctx.insert(
@@ -200,7 +200,7 @@ mod tests {
             ContextValue::ScalarField(DVector::from_vec(vec![0.1, 0.2, 0.3])),
         );
         ctx.insert(
-            ContextVariable::External { name: "vfield" },
+            ContextVariable::External { name: "vfield".into() },
             ContextValue::VectorField(DMatrix::from_element(3, 2, 1.5)),
         );
         ctx
@@ -226,7 +226,7 @@ mod tests {
     fn scalar_returns_value_for_scalar_variable() {
         let ctx = ctx_with_all_variants();
         let v = ctx
-            .scalar(ContextVariable::External { name: "coeff" })
+            .scalar(ContextVariable::External { name: "coeff".into() })
             .unwrap();
         assert_eq!(v, 42.0);
     }
@@ -242,7 +242,7 @@ mod tests {
     fn scalar_returns_type_mismatch_for_non_scalar() {
         let ctx = ctx_with_all_variants();
         let err = ctx
-            .scalar(ContextVariable::External { name: "vel" })
+            .scalar(ContextVariable::External { name: "vel".into() })
             .unwrap_err();
         assert!(matches!(
             err,
@@ -259,7 +259,7 @@ mod tests {
     fn vector_returns_reference_for_vector_variable() {
         let ctx = ctx_with_all_variants();
         let v = ctx
-            .vector(ContextVariable::External { name: "vel" })
+            .vector(ContextVariable::External { name: "vel".into() })
             .unwrap();
         assert_eq!(v.len(), 3);
         assert_eq!(v[1], 2.0);
@@ -269,7 +269,7 @@ mod tests {
     fn vector_returns_missing_calculator_when_absent() {
         let ctx = ComputeContext::new(0.0, 0.01);
         let err = ctx
-            .vector(ContextVariable::External { name: "missing" })
+            .vector(ContextVariable::External { name: "missing".into() })
             .unwrap_err();
         assert!(matches!(err, OxiflowError::MissingCalculator(_)));
     }
@@ -278,7 +278,7 @@ mod tests {
     fn vector_returns_type_mismatch_for_non_vector() {
         let ctx = ctx_with_all_variants();
         let err = ctx
-            .vector(ContextVariable::External { name: "coeff" })
+            .vector(ContextVariable::External { name: "coeff".into() })
             .unwrap_err();
         assert!(matches!(
             err,
@@ -295,7 +295,7 @@ mod tests {
     fn matrix_returns_reference_for_matrix_variable() {
         let ctx = ctx_with_all_variants();
         let m = ctx
-            .matrix(ContextVariable::External { name: "tensor" })
+            .matrix(ContextVariable::External { name: "tensor".into() })
             .unwrap();
         assert_eq!(m.shape(), (2, 2));
         assert_eq!(m[(0, 0)], 5.0);
@@ -305,7 +305,7 @@ mod tests {
     fn matrix_returns_type_mismatch_for_non_matrix() {
         let ctx = ctx_with_all_variants();
         let err = ctx
-            .matrix(ContextVariable::External { name: "coeff" })
+            .matrix(ContextVariable::External { name: "coeff".into() })
             .unwrap_err();
         assert!(matches!(
             err,
@@ -361,7 +361,7 @@ mod tests {
     fn external_returns_raw_context_value() {
         let ctx = ctx_with_all_variants();
         let val = ctx
-            .external(ContextVariable::External { name: "flag" })
+            .external(ContextVariable::External { name: "flag".into() })
             .unwrap();
         assert!(matches!(val, ContextValue::Boolean(true)));
     }
@@ -370,7 +370,7 @@ mod tests {
     fn external_returns_missing_calculator_when_absent() {
         let ctx = ComputeContext::new(0.0, 0.01);
         let err = ctx
-            .external(ContextVariable::External { name: "absent" })
+            .external(ContextVariable::External { name: "absent".into() })
             .unwrap_err();
         assert!(matches!(err, OxiflowError::MissingCalculator(_)));
     }
@@ -380,7 +380,7 @@ mod tests {
         let ctx = ctx_with_all_variants();
         // VectorField via external()
         let val = ctx
-            .external(ContextVariable::External { name: "vfield" })
+            .external(ContextVariable::External { name: "vfield".into() })
             .unwrap();
         assert!(val.is_vector_field());
     }
@@ -409,7 +409,7 @@ mod tests {
     #[test]
     fn insert_overwrites_previous_value() {
         let mut ctx = ComputeContext::new(0.0, 0.01);
-        let var = ContextVariable::External { name: "x" };
+        let var = ContextVariable::External { name: "x".into() };
         ctx.insert(var.clone(), ContextValue::Scalar(1.0));
         ctx.insert(var.clone(), ContextValue::Scalar(2.0));
         assert_eq!(ctx.scalar(var).unwrap(), 2.0);

--- a/src/context/compute.rs
+++ b/src/context/compute.rs
@@ -177,11 +177,15 @@ mod tests {
     fn ctx_with_all_variants() -> ComputeContext {
         let mut ctx = ComputeContext::new(2.0, 0.01);
         ctx.insert(
-            ContextVariable::External { name: "coeff".into() },
+            ContextVariable::External {
+                name: "coeff".into(),
+            },
             ContextValue::Scalar(42.0),
         );
         ctx.insert(
-            ContextVariable::External { name: "flag".into() },
+            ContextVariable::External {
+                name: "flag".into(),
+            },
             ContextValue::Boolean(true),
         );
         ctx.insert(
@@ -189,7 +193,9 @@ mod tests {
             ContextValue::Vector(DVector::from_vec(vec![1.0, 2.0, 3.0])),
         );
         ctx.insert(
-            ContextVariable::External { name: "tensor".into() },
+            ContextVariable::External {
+                name: "tensor".into(),
+            },
             ContextValue::Matrix(DMatrix::from_element(2, 2, 5.0)),
         );
         ctx.insert(
@@ -200,7 +206,9 @@ mod tests {
             ContextValue::ScalarField(DVector::from_vec(vec![0.1, 0.2, 0.3])),
         );
         ctx.insert(
-            ContextVariable::External { name: "vfield".into() },
+            ContextVariable::External {
+                name: "vfield".into(),
+            },
             ContextValue::VectorField(DMatrix::from_element(3, 2, 1.5)),
         );
         ctx
@@ -226,7 +234,9 @@ mod tests {
     fn scalar_returns_value_for_scalar_variable() {
         let ctx = ctx_with_all_variants();
         let v = ctx
-            .scalar(ContextVariable::External { name: "coeff".into() })
+            .scalar(ContextVariable::External {
+                name: "coeff".into(),
+            })
             .unwrap();
         assert_eq!(v, 42.0);
     }
@@ -269,7 +279,9 @@ mod tests {
     fn vector_returns_missing_calculator_when_absent() {
         let ctx = ComputeContext::new(0.0, 0.01);
         let err = ctx
-            .vector(ContextVariable::External { name: "missing".into() })
+            .vector(ContextVariable::External {
+                name: "missing".into(),
+            })
             .unwrap_err();
         assert!(matches!(err, OxiflowError::MissingCalculator(_)));
     }
@@ -278,7 +290,9 @@ mod tests {
     fn vector_returns_type_mismatch_for_non_vector() {
         let ctx = ctx_with_all_variants();
         let err = ctx
-            .vector(ContextVariable::External { name: "coeff".into() })
+            .vector(ContextVariable::External {
+                name: "coeff".into(),
+            })
             .unwrap_err();
         assert!(matches!(
             err,
@@ -295,7 +309,9 @@ mod tests {
     fn matrix_returns_reference_for_matrix_variable() {
         let ctx = ctx_with_all_variants();
         let m = ctx
-            .matrix(ContextVariable::External { name: "tensor".into() })
+            .matrix(ContextVariable::External {
+                name: "tensor".into(),
+            })
             .unwrap();
         assert_eq!(m.shape(), (2, 2));
         assert_eq!(m[(0, 0)], 5.0);
@@ -305,7 +321,9 @@ mod tests {
     fn matrix_returns_type_mismatch_for_non_matrix() {
         let ctx = ctx_with_all_variants();
         let err = ctx
-            .matrix(ContextVariable::External { name: "coeff".into() })
+            .matrix(ContextVariable::External {
+                name: "coeff".into(),
+            })
             .unwrap_err();
         assert!(matches!(
             err,
@@ -361,7 +379,9 @@ mod tests {
     fn external_returns_raw_context_value() {
         let ctx = ctx_with_all_variants();
         let val = ctx
-            .external(ContextVariable::External { name: "flag".into() })
+            .external(ContextVariable::External {
+                name: "flag".into(),
+            })
             .unwrap();
         assert!(matches!(val, ContextValue::Boolean(true)));
     }
@@ -370,7 +390,9 @@ mod tests {
     fn external_returns_missing_calculator_when_absent() {
         let ctx = ComputeContext::new(0.0, 0.01);
         let err = ctx
-            .external(ContextVariable::External { name: "absent".into() })
+            .external(ContextVariable::External {
+                name: "absent".into(),
+            })
             .unwrap_err();
         assert!(matches!(err, OxiflowError::MissingCalculator(_)));
     }
@@ -380,7 +402,9 @@ mod tests {
         let ctx = ctx_with_all_variants();
         // VectorField via external()
         let val = ctx
-            .external(ContextVariable::External { name: "vfield".into() })
+            .external(ContextVariable::External {
+                name: "vfield".into(),
+            })
             .unwrap();
         assert!(val.is_vector_field());
     }

--- a/src/context/error.rs
+++ b/src/context/error.rs
@@ -21,6 +21,14 @@ use crate::context::variable::ContextVariable;
 /// The `source` field in `ComputationFailed` preserves the original error
 /// for error-chain display while keeping the variant matchable.
 ///
+/// # Serialisation
+///
+/// `OxiflowError` does not implement `serde::Serialize` / `serde::Deserialize`.
+/// The `ComputationFailed` variant holds a `Box<dyn std::error::Error + Send + Sync>`
+/// (a trait object), which cannot be serialised directly. Error context for
+/// post-mortem analysis is captured as a `String` in `SimulationSnapshot`
+/// (DD-025 Option B, v0.6.0).
+///
 /// # Examples
 ///
 /// ```rust
@@ -127,7 +135,7 @@ mod tests {
 
     #[test]
     fn circular_dependency_matches_variable() {
-        let err = OxiflowError::CircularDependency(ContextVariable::External { name: "flux" });
+        let err = OxiflowError::CircularDependency(ContextVariable::External { name: "flux".into() });
         assert!(matches!(err, OxiflowError::CircularDependency(_)));
     }
 

--- a/src/context/error.rs
+++ b/src/context/error.rs
@@ -135,7 +135,9 @@ mod tests {
 
     #[test]
     fn circular_dependency_matches_variable() {
-        let err = OxiflowError::CircularDependency(ContextVariable::External { name: "flux".into() });
+        let err = OxiflowError::CircularDependency(ContextVariable::External {
+            name: "flux".into(),
+        });
         assert!(matches!(err, OxiflowError::CircularDependency(_)));
     }
 

--- a/src/context/error.rs
+++ b/src/context/error.rs
@@ -73,6 +73,26 @@ pub enum OxiflowError {
     #[error("invalid domain: {0}")]
     InvalidDomain(String),
 
+    /// A required physical or numerical precondition was violated.
+    ///
+    /// Used when a computation cannot proceed due to an invalid parameter value
+    /// or an inconsistent input state. Distinct from [`ComputationFailed`] which
+    /// wraps an upstream error: `PreconditionFailed` is raised by the component
+    /// itself upon detecting a violated invariant.
+    ///
+    /// `context` identifies the component that raised the error (e.g.
+    /// `"DanckwertsInlet"`, `"UniformGrid1D"`). `message` describes the
+    /// violated condition and may include dynamic values.
+    ///
+    /// [`ComputationFailed`]: OxiflowError::ComputationFailed
+    #[error("precondition failed in {context}: {message}")]
+    PreconditionFailed {
+        /// Name of the component that detected the violation.
+        context: &'static str,
+        /// Human-readable description of the violated condition.
+        message: String,
+    },
+
     /// An external data source returned an error or is unavailable.
     #[error("external data error: {0}")]
     ExternalData(String),
@@ -206,6 +226,41 @@ mod tests {
     }
 
     #[test]
+    fn precondition_failed_is_matchable() {
+        let err = OxiflowError::PreconditionFailed {
+            context: "DanckwertsInlet",
+            message: "velocity must be non-zero".into(),
+        };
+        assert!(matches!(err, OxiflowError::PreconditionFailed { .. }));
+    }
+
+    #[test]
+    fn precondition_failed_display_contains_context_and_message() {
+        let err = OxiflowError::PreconditionFailed {
+            context: "DanckwertsInlet",
+            message: "velocity must be non-zero".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("DanckwertsInlet"));
+        assert!(msg.contains("velocity must be non-zero"));
+    }
+
+    #[test]
+    fn precondition_failed_context_is_static_str() {
+        let err = OxiflowError::PreconditionFailed {
+            context: "UniformGrid1D",
+            message: "n_points must be >= 2".into(),
+        };
+        assert!(matches!(
+            err,
+            OxiflowError::PreconditionFailed {
+                context: "UniformGrid1D",
+                ..
+            }
+        ));
+    }
+
+    #[test]
     fn all_variants_implement_debug() {
         let variants: Vec<Box<dyn std::fmt::Debug>> = vec![
             Box::new(OxiflowError::MissingCalculator(ContextVariable::Time)),
@@ -215,6 +270,10 @@ mod tests {
                 actual: "Boolean",
             }),
             Box::new(OxiflowError::InvalidDomain("test".into())),
+            Box::new(OxiflowError::PreconditionFailed {
+                context: "test",
+                message: "test condition".into(),
+            }),
             Box::new(OxiflowError::ExternalData("test".into())),
             Box::new(OxiflowError::SolverDivergence {
                 time: 0.0,

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -13,6 +13,7 @@
 //! - [`compute`]  — Type `ComputeContext` and trait `RequiresContext` (DD-005, DD-006)
 
 pub mod calculator;
+pub mod calculators;
 pub mod compute;
 pub mod error;
 pub mod value;

--- a/src/context/value.rs
+++ b/src/context/value.rs
@@ -65,8 +65,9 @@ use crate::context::error::OxiflowError;
 /// assert_eq!(t.as_scalar().unwrap(), 1.5);
 /// assert!(!field.as_scalar_field().unwrap().is_empty());
 /// ```
-#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ContextValue {
     // ── Pointwise algebraic objects ───────────────────────────────────────────
     /// Rank-0 scalar: time, step size, uniform coefficient.

--- a/src/context/variable.rs
+++ b/src/context/variable.rs
@@ -161,7 +161,9 @@ mod tests {
         let a = ContextVariable::External {
             name: "temperature".into(),
         };
-        let b = ContextVariable::External { name: "pressure".into() };
+        let b = ContextVariable::External {
+            name: "pressure".into(),
+        };
         assert_ne!(a, b);
     }
 
@@ -176,7 +178,9 @@ mod tests {
                 dimension: 2,
                 component: None,
             },
-            ContextVariable::External { name: "feed".into() },
+            ContextVariable::External {
+                name: "feed".into(),
+            },
         ];
         for v in &vars {
             assert_eq!(v.clone(), *v);
@@ -197,7 +201,12 @@ mod tests {
             },
             0.3,
         );
-        map.insert(ContextVariable::External { name: "T_amb".into() }, 298.15);
+        map.insert(
+            ContextVariable::External {
+                name: "T_amb".into(),
+            },
+            298.15,
+        );
 
         assert_eq!(map[&ContextVariable::Time], 1.5);
         assert_eq!(map[&ContextVariable::TimeStep], 0.01);
@@ -208,7 +217,12 @@ mod tests {
             }],
             0.3
         );
-        assert_eq!(map[&ContextVariable::External { name: "T_amb".into() }], 298.15);
+        assert_eq!(
+            map[&ContextVariable::External {
+                name: "T_amb".into()
+            }],
+            298.15
+        );
     }
 
     #[test]
@@ -268,7 +282,9 @@ mod tests {
 
     #[test]
     fn display_external() {
-        let v = ContextVariable::External { name: "T_amb".into() };
+        let v = ContextVariable::External {
+            name: "T_amb".into(),
+        };
         assert_eq!(format!("{}", v), "External(T_amb)");
     }
 

--- a/src/context/variable.rs
+++ b/src/context/variable.rs
@@ -13,6 +13,8 @@
 //! `SpatialGradient { dimension, component }` → `ContextValue::ScalarField`.
 //! Node-level access is the operator's responsibility (INV-2, J5).
 
+use std::borrow::Cow;
+
 /// Typed key identifying a context variable in the compute context.
 ///
 /// All variants implement `Hash + Eq` so that `ContextVariable` can serve as
@@ -27,7 +29,7 @@
 /// let t   = ContextVariable::Time;
 /// let dt  = ContextVariable::TimeStep;
 /// let gx  = ContextVariable::SpatialGradient { dimension: 0, component: None };
-/// let ext = ContextVariable::External { name: "ambient_temperature" };
+/// let ext = ContextVariable::External { name: "ambient_temperature".into() };
 ///
 /// assert_ne!(t, dt);
 /// assert_ne!(
@@ -35,8 +37,9 @@
 ///     ContextVariable::SpatialGradient { dimension: 1, component: None },
 /// );
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ContextVariable {
     /// Current simulation time `t`.
     Time,
@@ -68,7 +71,7 @@ pub enum ContextVariable {
     /// The `name` is a static string and participates in `Hash + Eq`.
     External {
         /// Unique name of the external variable.
-        name: &'static str,
+        name: Cow<'static, str>,
     },
 }
 
@@ -145,10 +148,10 @@ mod tests {
     #[test]
     fn external_same_name_equal() {
         let a = ContextVariable::External {
-            name: "temperature",
+            name: "temperature".into(),
         };
         let b = ContextVariable::External {
-            name: "temperature",
+            name: "temperature".into(),
         };
         assert_eq!(a, b);
     }
@@ -156,9 +159,9 @@ mod tests {
     #[test]
     fn external_different_name_not_equal() {
         let a = ContextVariable::External {
-            name: "temperature",
+            name: "temperature".into(),
         };
-        let b = ContextVariable::External { name: "pressure" };
+        let b = ContextVariable::External { name: "pressure".into() };
         assert_ne!(a, b);
     }
 
@@ -173,7 +176,7 @@ mod tests {
                 dimension: 2,
                 component: None,
             },
-            ContextVariable::External { name: "feed" },
+            ContextVariable::External { name: "feed".into() },
         ];
         for v in &vars {
             assert_eq!(v.clone(), *v);
@@ -194,7 +197,7 @@ mod tests {
             },
             0.3,
         );
-        map.insert(ContextVariable::External { name: "T_amb" }, 298.15);
+        map.insert(ContextVariable::External { name: "T_amb".into() }, 298.15);
 
         assert_eq!(map[&ContextVariable::Time], 1.5);
         assert_eq!(map[&ContextVariable::TimeStep], 0.01);
@@ -205,7 +208,7 @@ mod tests {
             }],
             0.3
         );
-        assert_eq!(map[&ContextVariable::External { name: "T_amb" }], 298.15);
+        assert_eq!(map[&ContextVariable::External { name: "T_amb".into() }], 298.15);
     }
 
     #[test]
@@ -265,7 +268,7 @@ mod tests {
 
     #[test]
     fn display_external() {
-        let v = ContextVariable::External { name: "T_amb" };
+        let v = ContextVariable::External { name: "T_amb".into() };
         assert_eq!(format!("{}", v), "External(T_amb)");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@
 //!
 //! 1. Context calculators populate [`context::ComputeContext`]
 //! 2. Boundary conditions are applied to the current state (J2)
-//! 3. [`model::PhysicalModel::compute`] computes `du/dt`
+//! 3. [`model::PhysicalModel::compute_physics`] computes `du/dt`
 //! 4. The integrator advances the state by `dt`
 //!
 //! ## Modules

--- a/src/model/traits.rs
+++ b/src/model/traits.rs
@@ -159,7 +159,7 @@ mod tests {
             ]
         }
         fn optional_variables(&self) -> Vec<ContextVariable> {
-            vec![ContextVariable::External { name: "T_amb" }]
+            vec![ContextVariable::External { name: "T_amb".into() }]
         }
         fn depends_on(&self) -> Vec<ContextVariable> {
             vec![ContextVariable::Time]

--- a/src/model/traits.rs
+++ b/src/model/traits.rs
@@ -159,7 +159,9 @@ mod tests {
             ]
         }
         fn optional_variables(&self) -> Vec<ContextVariable> {
-            vec![ContextVariable::External { name: "T_amb".into() }]
+            vec![ContextVariable::External {
+                name: "T_amb".into(),
+            }]
         }
         fn depends_on(&self) -> Vec<ContextVariable> {
             vec![ContextVariable::Time]

--- a/src/solver/chain.rs
+++ b/src/solver/chain.rs
@@ -173,15 +173,24 @@ mod tests {
 
     #[test]
     fn satisfied_requirement_succeeds() {
-        let requirements = vec![ContextVariable::External { name: "D_ax".into() }];
-        let calcs = vec![make_calc(ContextVariable::External { name: "D_ax".into() }, 100)];
+        let requirements = vec![ContextVariable::External {
+            name: "D_ax".into(),
+        }];
+        let calcs = vec![make_calc(
+            ContextVariable::External {
+                name: "D_ax".into(),
+            },
+            100,
+        )];
         let chain = build_calculator_chain(&requirements, &calcs).unwrap();
         assert_eq!(chain.len(), 1);
     }
 
     #[test]
     fn missing_calculator_returns_error() {
-        let requirements = vec![ContextVariable::External { name: "missing".into() }];
+        let requirements = vec![ContextVariable::External {
+            name: "missing".into(),
+        }];
         let err = build_calculator_chain(&requirements, &[]).unwrap_err();
         assert!(matches!(err, OxiflowError::MissingCalculator(_)));
     }
@@ -235,17 +244,31 @@ mod tests {
     #[test]
     fn stable_sort_preserves_registration_order_within_same_priority() {
         let calcs = vec![
-            make_calc(ContextVariable::External { name: "first".into() }, 100),
-            make_calc(ContextVariable::External { name: "second".into() }, 100),
+            make_calc(
+                ContextVariable::External {
+                    name: "first".into(),
+                },
+                100,
+            ),
+            make_calc(
+                ContextVariable::External {
+                    name: "second".into(),
+                },
+                100,
+            ),
         ];
         let chain = build_calculator_chain(&[], &calcs).unwrap();
         assert_eq!(
             chain[0].provides(),
-            ContextVariable::External { name: "first".into() }
+            ContextVariable::External {
+                name: "first".into()
+            }
         );
         assert_eq!(
             chain[1].provides(),
-            ContextVariable::External { name: "second".into() }
+            ContextVariable::External {
+                name: "second".into()
+            }
         );
     }
 
@@ -253,9 +276,16 @@ mod tests {
     fn mixed_builtin_and_user_requirements() {
         let requirements = vec![
             ContextVariable::Time,
-            ContextVariable::External { name: "D_ax".into() },
+            ContextVariable::External {
+                name: "D_ax".into(),
+            },
         ];
-        let calcs = vec![make_calc(ContextVariable::External { name: "D_ax".into() }, 100)];
+        let calcs = vec![make_calc(
+            ContextVariable::External {
+                name: "D_ax".into(),
+            },
+            100,
+        )];
         let chain = build_calculator_chain(&requirements, &calcs).unwrap();
         assert_eq!(chain.len(), 1);
     }

--- a/src/solver/chain.rs
+++ b/src/solver/chain.rs
@@ -173,15 +173,15 @@ mod tests {
 
     #[test]
     fn satisfied_requirement_succeeds() {
-        let requirements = vec![ContextVariable::External { name: "D_ax" }];
-        let calcs = vec![make_calc(ContextVariable::External { name: "D_ax" }, 100)];
+        let requirements = vec![ContextVariable::External { name: "D_ax".into() }];
+        let calcs = vec![make_calc(ContextVariable::External { name: "D_ax".into() }, 100)];
         let chain = build_calculator_chain(&requirements, &calcs).unwrap();
         assert_eq!(chain.len(), 1);
     }
 
     #[test]
     fn missing_calculator_returns_error() {
-        let requirements = vec![ContextVariable::External { name: "missing" }];
+        let requirements = vec![ContextVariable::External { name: "missing".into() }];
         let err = build_calculator_chain(&requirements, &[]).unwrap_err();
         assert!(matches!(err, OxiflowError::MissingCalculator(_)));
     }
@@ -199,7 +199,7 @@ mod tests {
 
     #[test]
     fn duplicate_calculator_for_same_variable_is_accepted() {
-        let var = ContextVariable::External { name: "v" };
+        let var = ContextVariable::External { name: "v".into() };
         let requirements = vec![var.clone()];
         let calcs = vec![make_calc(var.clone(), 100), make_calc(var.clone(), 50)];
         assert!(build_calculator_chain(&requirements, &calcs).is_ok());
@@ -208,10 +208,10 @@ mod tests {
     #[test]
     fn extra_calculators_beyond_requirements_are_included() {
         // Calculators for unrequired variables are still executed
-        let requirements = vec![ContextVariable::External { name: "a" }];
+        let requirements = vec![ContextVariable::External { name: "a".into() }];
         let calcs = vec![
-            make_calc(ContextVariable::External { name: "a" }, 100),
-            make_calc(ContextVariable::External { name: "b" }, 100),
+            make_calc(ContextVariable::External { name: "a".into() }, 100),
+            make_calc(ContextVariable::External { name: "b".into() }, 100),
         ];
         let chain = build_calculator_chain(&requirements, &calcs).unwrap();
         assert_eq!(chain.len(), 2);
@@ -222,9 +222,9 @@ mod tests {
     #[test]
     fn chain_sorted_by_ascending_priority() {
         let calcs = vec![
-            make_calc(ContextVariable::External { name: "c" }, 200),
-            make_calc(ContextVariable::External { name: "a" }, 50),
-            make_calc(ContextVariable::External { name: "b" }, 100),
+            make_calc(ContextVariable::External { name: "c".into() }, 200),
+            make_calc(ContextVariable::External { name: "a".into() }, 50),
+            make_calc(ContextVariable::External { name: "b".into() }, 100),
         ];
         let chain = build_calculator_chain(&[], &calcs).unwrap();
         assert_eq!(chain[0].priority(), 50);
@@ -235,17 +235,17 @@ mod tests {
     #[test]
     fn stable_sort_preserves_registration_order_within_same_priority() {
         let calcs = vec![
-            make_calc(ContextVariable::External { name: "first" }, 100),
-            make_calc(ContextVariable::External { name: "second" }, 100),
+            make_calc(ContextVariable::External { name: "first".into() }, 100),
+            make_calc(ContextVariable::External { name: "second".into() }, 100),
         ];
         let chain = build_calculator_chain(&[], &calcs).unwrap();
         assert_eq!(
             chain[0].provides(),
-            ContextVariable::External { name: "first" }
+            ContextVariable::External { name: "first".into() }
         );
         assert_eq!(
             chain[1].provides(),
-            ContextVariable::External { name: "second" }
+            ContextVariable::External { name: "second".into() }
         );
     }
 
@@ -253,9 +253,9 @@ mod tests {
     fn mixed_builtin_and_user_requirements() {
         let requirements = vec![
             ContextVariable::Time,
-            ContextVariable::External { name: "D_ax" },
+            ContextVariable::External { name: "D_ax".into() },
         ];
-        let calcs = vec![make_calc(ContextVariable::External { name: "D_ax" }, 100)];
+        let calcs = vec![make_calc(ContextVariable::External { name: "D_ax".into() }, 100)];
         let chain = build_calculator_chain(&requirements, &calcs).unwrap();
         assert_eq!(chain.len(), 1);
     }

--- a/src/solver/chain.rs
+++ b/src/solver/chain.rs
@@ -24,7 +24,7 @@
 //! if calculator C declares `depends_on: [X]`, an edge is drawn from every calculator
 //! providing X to C. Within each topological tier, calculators are ordered by
 //! ascending `priority()`. A cycle returns
-//! [`OxiflowError::CircularDependency`](crate::context::error::OxiflowError::CircularDependency).
+//! [`OxiflowError::CircularDependency`].
 //!
 //! ## Built-in variables
 //!

--- a/src/solver/chain.rs
+++ b/src/solver/chain.rs
@@ -1,29 +1,37 @@
 //! # Module `solver::chain`
 //!
-//! Calculator chain — validation and priority-based ordering (issue #33).
+//! Calculator chain — validation and ordered execution (issues #33, #36, DD-009).
 //!
 //! ## Responsibility
 //!
 //! `build_calculator_chain` verifies that every context variable required by the
 //! scenario has a corresponding calculator in `SolverConfiguration`, then returns
-//! the calculators sorted by ascending priority for execution.
+//! the calculators in a correct execution order.
 //!
-//! ## Ordering strategy (J1)
+//! ## Ordering strategy (DD-009)
 //!
-//! At J1, ordering is by `priority()` (ascending). Calculators with lower
-//! priority numbers run first — reserved ranges:
-//! - **0–49**: system variables (Time, TimeStep) — injected directly by the solver
+//! A hybrid two-path algorithm is selected at chain-build time:
+//!
+//! **Priority path (fast path)** — no calculator declares a non-empty `depends_on()`.
+//! Calculators are sorted by ascending `priority()` (stable sort, O(n log n)).
+//! A total order by priority cannot contain a cycle. Priority ranges:
+//! - **0–49**: system variables (`Time`, `TimeStep`) — injected directly by the solver
 //! - **50–99**: external data providers
 //! - **100+**: derived quantities (default)
 //!
-//! Full topological ordering via Kahn's algorithm is reserved for J2 (DD-009),
-//! when calculators may declare `depends_on()` dependencies on each other.
+//! **Topological path (Kahn)** — at least one calculator declares a non-empty
+//! `depends_on()`. A directed acyclic graph is built from the declared dependencies:
+//! if calculator C declares `depends_on: [X]`, an edge is drawn from every calculator
+//! providing X to C. Within each topological tier, calculators are ordered by
+//! ascending `priority()`. A cycle returns
+//! [`OxiflowError::CircularDependency`](crate::context::error::OxiflowError::CircularDependency).
 //!
 //! ## Built-in variables
 //!
 //! `Time` and `TimeStep` are always available in `ComputeContext` — the solver
 //! injects them directly via `ComputeContext::new(t, dt)` before running the
-//! chain. No calculator is needed for these variables.
+//! chain. Built-in variables declared in `depends_on()` are ignored when building
+//! the dependency graph.
 
 use crate::context::calculator::ContextCalculator;
 use crate::context::error::OxiflowError;
@@ -33,7 +41,8 @@ use crate::context::variable::ContextVariable;
 ///
 /// `Time` and `TimeStep` are injected via `ComputeContext::new(t, dt)` before
 /// the calculator chain runs. Declaring them as requirements is valid; checking
-/// them against the calculator list would be a false negative.
+/// them against the calculator list would be a false negative. Declaring them in
+/// `depends_on()` is valid and ignored when building the dependency graph.
 const BUILTIN_VARIABLES: &[ContextVariable] = &[ContextVariable::Time, ContextVariable::TimeStep];
 
 /// Validates requirements against provided calculators and returns an
@@ -43,20 +52,27 @@ const BUILTIN_VARIABLES: &[ContextVariable] = &[ContextVariable::Time, ContextVa
 ///
 /// Every variable in `requirements` must be either:
 /// - a built-in variable (`Time`, `TimeStep`), or
-/// - covered by exactly one calculator via `provides()`.
+/// - covered by at least one calculator via `provides()`.
 ///
 /// A variable covered by multiple calculators is accepted — the last one
-/// in priority order wins (consistent with `ComputeContext::insert` overwrite).
+/// to execute wins (consistent with `ComputeContext::insert` overwrite).
 ///
-/// # Ordering (J1)
+/// # Ordering (DD-009)
 ///
-/// Calculators are sorted by ascending `priority()`. Within the same priority,
-/// original registration order is preserved (stable sort).
+/// If no calculator declares a non-empty `depends_on()`, calculators are sorted
+/// by ascending `priority()` (stable sort — registration order preserved within
+/// equal priorities).
+///
+/// If at least one calculator declares a non-empty `depends_on()`, Kahn's
+/// algorithm is applied on the full dependency graph. Within each topological
+/// tier, calculators are sorted by ascending `priority()`. Built-in variables
+/// in `depends_on()` declarations are ignored when building the graph.
 ///
 /// # Errors
 ///
-/// Returns `OxiflowError::MissingCalculator` for the first uncovered
-/// non-builtin required variable.
+/// - [`OxiflowError::MissingCalculator`] — first uncovered non-builtin requirement.
+/// - [`OxiflowError::CircularDependency`] — cycle detected in the dependency graph
+///   (Kahn path only).
 ///
 /// # Examples
 ///
@@ -91,7 +107,7 @@ pub fn build_calculator_chain<'a>(
     requirements: &[ContextVariable],
     calculators: &'a [Box<dyn ContextCalculator>],
 ) -> Result<Vec<&'a dyn ContextCalculator>, OxiflowError> {
-    // Check every requirement is covered
+    // Validate: every non-builtin requirement must have a provider.
     for req in requirements {
         if is_builtin(req) {
             continue;
@@ -102,11 +118,91 @@ pub fn build_calculator_chain<'a>(
         }
     }
 
-    // Sort by priority (stable — preserves registration order within same priority)
+    // Select ordering path based on whether any calculator declares dependencies.
+    let has_deps = calculators.iter().any(|c| !c.depends_on().is_empty());
+    if has_deps {
+        build_kahn_chain(calculators)
+    } else {
+        build_priority_chain(calculators)
+    }
+}
+
+/// Fast path — no `depends_on()` declared. Stable sort by ascending priority.
+fn build_priority_chain(
+    calculators: &[Box<dyn ContextCalculator>],
+) -> Result<Vec<&dyn ContextCalculator>, OxiflowError> {
     let mut chain: Vec<&dyn ContextCalculator> = calculators.iter().map(|c| c.as_ref()).collect();
     chain.sort_by_key(|c| c.priority());
-
     Ok(chain)
+}
+
+/// Kahn path — topological sort with priority as tiebreaker within each tier.
+///
+/// Edges: for each calculator C declaring `depends_on: [X]`, draw an edge from
+/// every calculator providing X to C. Built-in variables are excluded from the
+/// graph. A cycle returns `CircularDependency` naming the first `depends_on`
+/// variable of the first blocked calculator found.
+fn build_kahn_chain(
+    calculators: &[Box<dyn ContextCalculator>],
+) -> Result<Vec<&dyn ContextCalculator>, OxiflowError> {
+    let n = calculators.len();
+
+    // Build adjacency list and in-degree table.
+    // successors[j] = indices of calculators that must run after j.
+    let mut successors: Vec<Vec<usize>> = vec![vec![]; n];
+    let mut in_degree: Vec<usize> = vec![0; n];
+
+    for (i, calc) in calculators.iter().enumerate() {
+        for dep_var in calc.depends_on() {
+            if is_builtin(&dep_var) {
+                continue;
+            }
+            for (j, provider) in calculators.iter().enumerate() {
+                if provider.provides() == dep_var {
+                    successors[j].push(i);
+                    in_degree[i] += 1;
+                }
+            }
+        }
+    }
+
+    // Initial queue: calculators with no unresolved predecessors, by priority.
+    let mut queue: Vec<usize> = (0..n).filter(|&i| in_degree[i] == 0).collect();
+    queue.sort_by_key(|&i| calculators[i].priority());
+
+    let mut result: Vec<&dyn ContextCalculator> = Vec::with_capacity(n);
+
+    while !queue.is_empty() {
+        // Emit the first element (lowest priority in current tier).
+        let i = queue.remove(0);
+        result.push(calculators[i].as_ref());
+
+        // Decrement in-degree of successors; collect newly unblocked nodes.
+        let mut newly_free: Vec<usize> = Vec::new();
+        for &j in &successors[i] {
+            in_degree[j] -= 1;
+            if in_degree[j] == 0 {
+                newly_free.push(j);
+            }
+        }
+
+        // Merge newly unblocked nodes into the queue, maintaining priority order.
+        queue.extend(newly_free);
+        queue.sort_by_key(|&i| calculators[i].priority());
+    }
+
+    // If not all calculators were emitted, a cycle exists.
+    if result.len() < n {
+        let blocked = (0..n).find(|&i| in_degree[i] > 0).unwrap();
+        let var = calculators[blocked]
+            .depends_on()
+            .into_iter()
+            .find(|v| !is_builtin(v))
+            .unwrap_or_else(|| calculators[blocked].provides());
+        return Err(OxiflowError::CircularDependency(var));
+    }
+
+    Ok(result)
 }
 
 fn is_builtin(var: &ContextVariable) -> bool {
@@ -124,10 +220,12 @@ mod tests {
 
     // ── Fixtures ──────────────────────────────────────────────────────────────
 
+    /// Calculator with configurable provides, priority, and depends_on.
     #[derive(Debug)]
     struct NamedCalc {
         provides: ContextVariable,
         priority: u32,
+        depends_on: Vec<ContextVariable>,
     }
 
     impl RequiresContext for NamedCalc {
@@ -136,6 +234,9 @@ mod tests {
         }
         fn priority(&self) -> u32 {
             self.priority
+        }
+        fn depends_on(&self) -> Vec<ContextVariable> {
+            self.depends_on.clone()
         }
     }
 
@@ -153,7 +254,27 @@ mod tests {
     }
 
     fn make_calc(provides: ContextVariable, priority: u32) -> Box<dyn ContextCalculator> {
-        Box::new(NamedCalc { provides, priority })
+        Box::new(NamedCalc {
+            provides,
+            priority,
+            depends_on: vec![],
+        })
+    }
+
+    fn make_deps_calc(
+        provides: ContextVariable,
+        priority: u32,
+        depends_on: Vec<ContextVariable>,
+    ) -> Box<dyn ContextCalculator> {
+        Box::new(NamedCalc {
+            provides,
+            priority,
+            depends_on,
+        })
+    }
+
+    fn var(name: &'static str) -> ContextVariable {
+        ContextVariable::External { name: name.into() }
     }
 
     // ── Validation ────────────────────────────────────────────────────────────
@@ -173,67 +294,53 @@ mod tests {
 
     #[test]
     fn satisfied_requirement_succeeds() {
-        let requirements = vec![ContextVariable::External {
-            name: "D_ax".into(),
-        }];
-        let calcs = vec![make_calc(
-            ContextVariable::External {
-                name: "D_ax".into(),
-            },
-            100,
-        )];
+        let requirements = vec![var("D_ax")];
+        let calcs = vec![make_calc(var("D_ax"), 100)];
         let chain = build_calculator_chain(&requirements, &calcs).unwrap();
         assert_eq!(chain.len(), 1);
     }
 
     #[test]
     fn missing_calculator_returns_error() {
-        let requirements = vec![ContextVariable::External {
-            name: "missing".into(),
-        }];
+        let requirements = vec![var("missing")];
         let err = build_calculator_chain(&requirements, &[]).unwrap_err();
         assert!(matches!(err, OxiflowError::MissingCalculator(_)));
     }
 
     #[test]
     fn missing_calculator_error_names_the_variable() {
-        let var = ContextVariable::SpatialGradient {
+        let v = ContextVariable::SpatialGradient {
             dimension: 0,
             component: None,
         };
-        let requirements = vec![var.clone()];
+        let requirements = vec![v.clone()];
         let err = build_calculator_chain(&requirements, &[]).unwrap_err();
-        assert!(matches!(err, OxiflowError::MissingCalculator(v) if v == var));
+        assert!(matches!(err, OxiflowError::MissingCalculator(x) if x == v));
     }
 
     #[test]
     fn duplicate_calculator_for_same_variable_is_accepted() {
-        let var = ContextVariable::External { name: "v".into() };
-        let requirements = vec![var.clone()];
-        let calcs = vec![make_calc(var.clone(), 100), make_calc(var.clone(), 50)];
+        let requirements = vec![var("v")];
+        let calcs = vec![make_calc(var("v"), 100), make_calc(var("v"), 50)];
         assert!(build_calculator_chain(&requirements, &calcs).is_ok());
     }
 
     #[test]
     fn extra_calculators_beyond_requirements_are_included() {
-        // Calculators for unrequired variables are still executed
-        let requirements = vec![ContextVariable::External { name: "a".into() }];
-        let calcs = vec![
-            make_calc(ContextVariable::External { name: "a".into() }, 100),
-            make_calc(ContextVariable::External { name: "b".into() }, 100),
-        ];
+        let requirements = vec![var("a")];
+        let calcs = vec![make_calc(var("a"), 100), make_calc(var("b"), 100)];
         let chain = build_calculator_chain(&requirements, &calcs).unwrap();
         assert_eq!(chain.len(), 2);
     }
 
-    // ── Ordering ──────────────────────────────────────────────────────────────
+    // ── Priority path (fast path) ─────────────────────────────────────────────
 
     #[test]
     fn chain_sorted_by_ascending_priority() {
         let calcs = vec![
-            make_calc(ContextVariable::External { name: "c".into() }, 200),
-            make_calc(ContextVariable::External { name: "a".into() }, 50),
-            make_calc(ContextVariable::External { name: "b".into() }, 100),
+            make_calc(var("c"), 200),
+            make_calc(var("a"), 50),
+            make_calc(var("b"), 100),
         ];
         let chain = build_calculator_chain(&[], &calcs).unwrap();
         assert_eq!(chain[0].priority(), 50);
@@ -243,50 +350,153 @@ mod tests {
 
     #[test]
     fn stable_sort_preserves_registration_order_within_same_priority() {
-        let calcs = vec![
-            make_calc(
-                ContextVariable::External {
-                    name: "first".into(),
-                },
-                100,
-            ),
-            make_calc(
-                ContextVariable::External {
-                    name: "second".into(),
-                },
-                100,
-            ),
-        ];
+        let calcs = vec![make_calc(var("first"), 100), make_calc(var("second"), 100)];
         let chain = build_calculator_chain(&[], &calcs).unwrap();
-        assert_eq!(
-            chain[0].provides(),
-            ContextVariable::External {
-                name: "first".into()
-            }
-        );
-        assert_eq!(
-            chain[1].provides(),
-            ContextVariable::External {
-                name: "second".into()
-            }
-        );
+        assert_eq!(chain[0].provides(), var("first"));
+        assert_eq!(chain[1].provides(), var("second"));
     }
 
     #[test]
     fn mixed_builtin_and_user_requirements() {
-        let requirements = vec![
-            ContextVariable::Time,
-            ContextVariable::External {
-                name: "D_ax".into(),
-            },
-        ];
-        let calcs = vec![make_calc(
-            ContextVariable::External {
-                name: "D_ax".into(),
-            },
-            100,
-        )];
+        let requirements = vec![ContextVariable::Time, var("D_ax")];
+        let calcs = vec![make_calc(var("D_ax"), 100)];
         let chain = build_calculator_chain(&requirements, &calcs).unwrap();
         assert_eq!(chain.len(), 1);
+    }
+
+    // ── Kahn path ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn kahn_simple_chain() {
+        // A provides X, B depends on X and provides Y, C depends on Y.
+        // Expected order: A, B, C.
+        let calcs = vec![
+            make_deps_calc(var("Y"), 100, vec![var("X")]), // B — registered first
+            make_deps_calc(var("Z"), 100, vec![var("Y")]), // C
+            make_calc(var("X"), 100),                      // A — no deps
+        ];
+        let chain = build_calculator_chain(&[], &calcs).unwrap();
+        assert_eq!(chain[0].provides(), var("X"));
+        assert_eq!(chain[1].provides(), var("Y"));
+        assert_eq!(chain[2].provides(), var("Z"));
+    }
+
+    #[test]
+    fn kahn_diamond() {
+        // A provides X; B depends on X, provides Y; C depends on X, provides Z;
+        // D depends on Y and Z, provides W.
+        // Expected: A first, D last, B and C in between.
+        let calcs = vec![
+            make_deps_calc(var("W"), 100, vec![var("Y"), var("Z")]), // D
+            make_deps_calc(var("Y"), 100, vec![var("X")]),           // B
+            make_deps_calc(var("Z"), 100, vec![var("X")]),           // C
+            make_calc(var("X"), 100),                                // A
+        ];
+        let chain = build_calculator_chain(&[], &calcs).unwrap();
+        assert_eq!(chain[0].provides(), var("X"));
+        assert_eq!(chain[3].provides(), var("W"));
+        // B and C are in the middle (order between them is by priority — equal here).
+        let middle: Vec<ContextVariable> = chain[1..3].iter().map(|c| c.provides()).collect();
+        assert!(middle.contains(&var("Y")));
+        assert!(middle.contains(&var("Z")));
+    }
+
+    #[test]
+    fn kahn_priority_tiebreaker_within_tier() {
+        // B and C are independent (both depend on X). priority(C) < priority(B).
+        // Expected within their tier: C before B.
+        let calcs = vec![
+            make_deps_calc(var("B_out"), 200, vec![var("X")]),
+            make_deps_calc(var("C_out"), 50, vec![var("X")]),
+            make_calc(var("X"), 10),
+        ];
+        let chain = build_calculator_chain(&[], &calcs).unwrap();
+        assert_eq!(chain[0].provides(), var("X"));
+        assert_eq!(chain[1].provides(), var("C_out"));
+        assert_eq!(chain[2].provides(), var("B_out"));
+    }
+
+    #[test]
+    fn kahn_multiple_providers_all_precede_dependent() {
+        // A and B both provide X; C depends on X.
+        // Both A and B must appear before C.
+        let calcs = vec![
+            make_deps_calc(var("Z"), 100, vec![var("X")]), // C
+            make_calc(var("X"), 60),                       // B
+            make_calc(var("X"), 50),                       // A (lower priority)
+        ];
+        let chain = build_calculator_chain(&[], &calcs).unwrap();
+        let c_pos = chain.iter().position(|c| c.provides() == var("Z")).unwrap();
+        let a_pos = chain
+            .iter()
+            .position(|c| c.priority() == 50 && c.provides() == var("X"))
+            .unwrap();
+        let b_pos = chain
+            .iter()
+            .position(|c| c.priority() == 60 && c.provides() == var("X"))
+            .unwrap();
+        assert!(a_pos < c_pos);
+        assert!(b_pos < c_pos);
+    }
+
+    #[test]
+    fn kahn_builtin_in_depends_on_is_ignored() {
+        // Declaring Time in depends_on must not create a graph edge or a cycle.
+        let calcs = vec![make_deps_calc(
+            var("flux"),
+            100,
+            vec![ContextVariable::Time],
+        )];
+        let chain = build_calculator_chain(&[], &calcs).unwrap();
+        assert_eq!(chain.len(), 1);
+        assert_eq!(chain[0].provides(), var("flux"));
+    }
+
+    #[test]
+    fn kahn_cycle_two_nodes_returns_error() {
+        // A depends on B's output, B depends on A's output.
+        let calcs = vec![
+            make_deps_calc(var("A_out"), 100, vec![var("B_out")]),
+            make_deps_calc(var("B_out"), 100, vec![var("A_out")]),
+        ];
+        let err = build_calculator_chain(&[], &calcs).unwrap_err();
+        assert!(matches!(err, OxiflowError::CircularDependency(_)));
+    }
+
+    #[test]
+    fn kahn_cycle_three_nodes_returns_error() {
+        // A → B → C → A
+        let calcs = vec![
+            make_deps_calc(var("A_out"), 100, vec![var("C_out")]),
+            make_deps_calc(var("B_out"), 100, vec![var("A_out")]),
+            make_deps_calc(var("C_out"), 100, vec![var("B_out")]),
+        ];
+        let err = build_calculator_chain(&[], &calcs).unwrap_err();
+        assert!(matches!(err, OxiflowError::CircularDependency(_)));
+    }
+
+    #[test]
+    fn kahn_mixed_with_and_without_deps() {
+        // Calculators without depends_on coexist with one that has deps.
+        // Independent ones (no deps) run by priority; the dependent one after its provider.
+        let calcs = vec![
+            make_calc(var("alpha"), 200),
+            make_deps_calc(var("beta"), 100, vec![var("alpha")]),
+            make_calc(var("gamma"), 50),
+        ];
+        let chain = build_calculator_chain(&[], &calcs).unwrap();
+        // gamma (priority 50) and alpha (priority 200) have no deps on each other.
+        // beta depends on alpha → alpha must precede beta.
+        let alpha_pos = chain
+            .iter()
+            .position(|c| c.provides() == var("alpha"))
+            .unwrap();
+        let beta_pos = chain
+            .iter()
+            .position(|c| c.provides() == var("beta"))
+            .unwrap();
+        assert!(alpha_pos < beta_pos);
+        // gamma has no deps → should appear first (priority 50 < 200).
+        assert_eq!(chain[0].provides(), var("gamma"));
     }
 }

--- a/src/solver/config.rs
+++ b/src/solver/config.rs
@@ -26,8 +26,9 @@ use crate::context::calculator::ContextCalculator;
 /// let fixed = StepControl::Fixed { dt: 0.01 };
 /// assert_eq!(fixed.dt_initial(), 0.01);
 /// ```
-#[derive(Debug, Clone)]
 #[non_exhaustive]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum StepControl {
     /// Fixed time step — J1.
     ///
@@ -94,8 +95,9 @@ impl StepControl {
 /// let method = IntegratorKind::Euler;
 /// assert!(method.is_explicit());
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum IntegratorKind {
     /// Forward Euler — explicit, 1st order — J1.
     Euler,
@@ -128,8 +130,9 @@ impl IntegratorKind {
 /// assert_eq!(time.t_end, 600.0);
 /// assert_eq!(time.n_steps_estimate(), 6000);
 /// ```
-#[derive(Debug, Clone)]
 #[non_exhaustive]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TimeConfiguration {
     /// End time of the simulation.
     pub t_end: f64,
@@ -182,6 +185,13 @@ impl TimeConfiguration {
 /// Groups the integration method, temporal parameters, and context calculators.
 /// `DiscreteOperator` (INV-2, J4b) is **not** a configuration field — it is
 /// an implementation detail inside spatial `ContextCalculator`s.
+///
+/// # Serialisation
+///
+/// `SolverConfiguration` does not implement `serde::Serialize` / `serde::Deserialize`.
+/// The `calculators` field holds `Vec<Box<dyn ContextCalculator>>` (trait objects),
+/// which cannot be serialised directly. The serialisable subset of configuration
+/// is captured in `SimulationSnapshot` (DD-025 Option B, v0.6.0).
 ///
 /// # Examples
 ///

--- a/src/solver/methods/euler.rs
+++ b/src/solver/methods/euler.rs
@@ -381,7 +381,7 @@ mod tests {
         struct NeedsExternal;
         impl RequiresContext for NeedsExternal {
             fn required_variables(&self) -> Vec<ContextVariable> {
-                vec![ContextVariable::External { name: "missing" }]
+                vec![ContextVariable::External { name: "missing".into() }]
             }
         }
         impl PhysicalModel for NeedsExternal {

--- a/src/solver/methods/euler.rs
+++ b/src/solver/methods/euler.rs
@@ -381,7 +381,9 @@ mod tests {
         struct NeedsExternal;
         impl RequiresContext for NeedsExternal {
             fn required_variables(&self) -> Vec<ContextVariable> {
-                vec![ContextVariable::External { name: "missing".into() }]
+                vec![ContextVariable::External {
+                    name: "missing".into(),
+                }]
             }
         }
         impl PhysicalModel for NeedsExternal {

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -55,6 +55,7 @@ use crate::context::error::OxiflowError;
 /// ```
 #[non_exhaustive]
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SimulationResult {
     /// Saved field states at each recorded time.
     pub states: Vec<crate::context::value::ContextValue>,

--- a/src/solver/scenario.rs
+++ b/src/solver/scenario.rs
@@ -10,6 +10,7 @@
 //! without verbosity. At J3, additional domains and coupling operators are added
 //! without any API change (DD-020).
 
+use crate::boundary::BoundaryCondition;
 use crate::context::error::OxiflowError;
 use crate::context::variable::ContextVariable;
 use crate::mesh::Mesh;
@@ -71,14 +72,15 @@ impl From<&str> for DomainId {
 
 /// Single physical domain: model + mesh + boundary conditions.
 ///
-/// At J1, `boundary_conditions` is always empty. At J2, BCs are added via
-/// `Scenario::with_bcs()` without touching this struct definition.
+/// `boundary_conditions` is empty at J1. At J2, BCs are added via the
+/// `Domain::with_boundary_conditions` builder.
 ///
 /// # Serialisation
 ///
 /// `Domain` does not implement `serde::Serialize` / `serde::Deserialize`.
-/// It holds `Box<dyn PhysicalModel>` and `Box<dyn Mesh>` (trait objects),
-/// which cannot be serialised directly. See `SimulationSnapshot` (DD-025 Option B).
+/// It holds `Box<dyn PhysicalModel>`, `Box<dyn Mesh>`, and
+/// `Box<dyn BoundaryCondition>` (trait objects), which cannot be serialised
+/// directly. See `SimulationSnapshot` (DD-025 Option B).
 #[non_exhaustive]
 pub struct Domain {
     /// Unique identifier for this domain.
@@ -87,11 +89,15 @@ pub struct Domain {
     pub model: Box<dyn PhysicalModel>,
     /// Spatial mesh — INV-1.
     pub mesh: Box<dyn Mesh>,
-    // boundary_conditions: Vec<Box<dyn BoundaryCondition>>  — RESERVED J2 (DD-008)
+    /// Boundary conditions applied after context calculation, before physics.
+    pub boundary_conditions: Vec<Box<dyn BoundaryCondition>>,
 }
 
 impl Domain {
     /// Creates a new domain with the given id, model, and mesh.
+    ///
+    /// `boundary_conditions` is initialised to an empty list. Use
+    /// `with_boundary_conditions` to attach BCs.
     pub fn new(
         id: impl Into<DomainId>,
         model: Box<dyn PhysicalModel>,
@@ -101,7 +107,23 @@ impl Domain {
             id: id.into(),
             model,
             mesh,
+            boundary_conditions: vec![],
         }
+    }
+
+    /// Attaches boundary conditions to this domain.
+    ///
+    /// Replaces any previously set boundary conditions.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let domain = Domain::new("column", model, mesh)
+    ///     .with_boundary_conditions(vec![Box::new(inlet_bc), Box::new(outlet_bc)]);
+    /// ```
+    pub fn with_boundary_conditions(mut self, bcs: Vec<Box<dyn BoundaryCondition>>) -> Self {
+        self.boundary_conditions = bcs;
+        self
     }
 }
 
@@ -248,11 +270,13 @@ impl Scenario {
             .collect();
 
         // J2: extend with BC requirements
-        // self.domains.iter().for_each(|d| {
-        //     d.boundary_conditions.iter().for_each(|bc| {
-        //         requirements.extend(bc.required_variables());
-        //     });
-        // });
+        self.domains.iter().for_each(|d| {
+            requirements.extend(
+                d.boundary_conditions
+                    .iter()
+                    .flat_map(|bc| bc.required_variables()),
+            );
+        });
 
         // J3: extend with coupling operator requirements
         // self.couplings.iter().for_each(|c| {
@@ -483,5 +507,73 @@ mod tests {
     fn validate_ok_for_valid_scenario() {
         let s = Scenario::single(Box::new(NeedsTime), make_mesh());
         assert!(s.validate().is_ok());
+    }
+
+    // ── BoundaryCondition integration ─────────────────────────────────────────
+
+    use crate::boundary::BoundaryCondition;
+    use crate::context::compute::ComputeContext as Ctx;
+
+    #[derive(Debug)]
+    struct TimeDependentBC;
+
+    impl RequiresContext for TimeDependentBC {
+        fn required_variables(&self) -> Vec<ContextVariable> {
+            vec![ContextVariable::Time]
+        }
+    }
+
+    impl BoundaryCondition for TimeDependentBC {
+        fn apply(
+            &self,
+            _state: &mut DVector<f64>,
+            _ctx: &Ctx,
+            _mesh: &dyn Mesh,
+        ) -> Result<(), OxiflowError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn domain_with_boundary_conditions_stores_bcs() {
+        let bc: Box<dyn BoundaryCondition> = Box::new(TimeDependentBC);
+        let domain =
+            Domain::new("col", Box::new(NeedsTime), make_mesh()).with_boundary_conditions(vec![bc]);
+        assert_eq!(domain.boundary_conditions.len(), 1);
+    }
+
+    #[test]
+    fn domain_new_has_empty_bcs() {
+        let domain = Domain::new("col", Box::new(NeedsTime), make_mesh());
+        assert!(domain.boundary_conditions.is_empty());
+    }
+
+    #[test]
+    fn context_requirements_includes_bc_variables() {
+        let bc: Box<dyn BoundaryCondition> = Box::new(TimeDependentBC);
+        let domain = Domain::new("col", Box::new(NeedsGradient), make_mesh())
+            .with_boundary_conditions(vec![bc]);
+        let scenario = Scenario::multi(vec![domain]).unwrap();
+        let reqs = scenario.context_requirements();
+        // NeedsGradient requires SpatialGradient; TimeDependentBC requires Time.
+        assert!(reqs.contains(&ContextVariable::Time));
+        assert!(reqs.contains(&ContextVariable::SpatialGradient {
+            dimension: 0,
+            component: None
+        }));
+    }
+
+    #[test]
+    fn context_requirements_deduplicates_bc_and_model_variables() {
+        // Both model and BC require Time — must appear only once.
+        let bc: Box<dyn BoundaryCondition> = Box::new(TimeDependentBC);
+        let domain =
+            Domain::new("col", Box::new(NeedsTime), make_mesh()).with_boundary_conditions(vec![bc]);
+        let scenario = Scenario::multi(vec![domain]).unwrap();
+        let reqs = scenario.context_requirements();
+        assert_eq!(
+            reqs.iter().filter(|v| **v == ContextVariable::Time).count(),
+            1
+        );
     }
 }

--- a/src/solver/scenario.rs
+++ b/src/solver/scenario.rs
@@ -34,6 +34,7 @@ use crate::model::traits::PhysicalModel;
 /// assert_eq!(default_id.as_str(), "default");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DomainId(String);
 
 impl DomainId {
@@ -72,6 +73,12 @@ impl From<&str> for DomainId {
 ///
 /// At J1, `boundary_conditions` is always empty. At J2, BCs are added via
 /// `Scenario::with_bcs()` without touching this struct definition.
+///
+/// # Serialisation
+///
+/// `Domain` does not implement `serde::Serialize` / `serde::Deserialize`.
+/// It holds `Box<dyn PhysicalModel>` and `Box<dyn Mesh>` (trait objects),
+/// which cannot be serialised directly. See `SimulationSnapshot` (DD-025 Option B).
 #[non_exhaustive]
 pub struct Domain {
     /// Unique identifier for this domain.
@@ -109,6 +116,14 @@ impl Domain {
 ///
 /// `Scenario` is declarative — it contains no solving logic. The `Solver`
 /// receives it and validates it via `context_requirements()` before solving.
+///
+/// # Serialisation
+///
+/// `Scenario` does not implement `serde::Serialize` / `serde::Deserialize`.
+/// It contains `Vec<Domain>`, which holds trait objects (`Box<dyn PhysicalModel>`,
+/// `Box<dyn Mesh>`). Restoring a simulation from a snapshot requires user code
+/// to reconstruct `Scenario` from its own configuration and inject the physical
+/// state from `SimulationSnapshot` (DD-025 Option B, v0.6.0).
 ///
 /// # Examples
 ///

--- a/src/solver/scenario.rs
+++ b/src/solver/scenario.rs
@@ -524,6 +524,9 @@ mod tests {
     }
 
     impl BoundaryCondition for TimeDependentBC {
+        fn boundary_type(&self) -> crate::boundary::BoundaryType {
+            crate::boundary::BoundaryType::Dirichlet
+        }
         fn apply(
             &self,
             _state: &mut DVector<f64>,


### PR DESCRIPTION
## Summary

Closes milestone **v0.2.0 — Complete Context**.

## What changed

### Design decisions
- **DD-008** #8 — `BoundaryCondition: RequiresContext + Debug` supertrait; `Domain` carries its own BCs
- **DD-009** #9 — Hybrid topological ordering for the calculator chain (Kahn + priority fallback)
- **DD-025** #66 — Serialisation strategy: `cfg_attr(serde)` on value types; `SimulationSnapshot` deferred to v0.6.0

### New modules
- `src/boundary/mod.rs` — `BoundaryCondition` trait, `BoundaryType`, `BoundaryLocation`
- `src/boundary/danckwerts.rs` — `DanckwertsInlet` (Robin), `DanckwertsOutlet` (Neumann)
- `src/solver/chain.rs` — `build_calculator_chain()`: fast path (priority) + Kahn path (topology)
- `src/context/calculators/` — built-in suite: `TimeCalculator`, `TimeStepCalculator`, `FDGradientCalculator`, `FDLaplacianCalculator`, `TrapezoidalIntegral`, `ExternalTabulated`

### Updated
- `src/context/error.rs` — `OxiflowError::PreconditionFailed`
- `src/solver/scenario.rs` — `Domain::boundary_conditions`, `Scenario::context_requirements()` aggregates BCs
- `src/context/variable.rs`, `value.rs`, `solver/config.rs`, `solver/mod.rs`, `solver/scenario.rs` — `cfg_attr(serde)` annotations
- `Cargo.toml` — version `0.2.0`

### Tests
- `tests/solver_pipeline_chromatography.rs` — first integration test; validates full pipeline end-to-end

## Invariants

INV-1 respected: `Arc<dyn Mesh>` held privately in spatial calculators; `Debug` implemented manually.  
INV-2 anticipated: spatial calculators will receive a `DiscreteOperator` at v0.5.0, no signature change required.

## Checklist

- [x] `cargo test` (lib + integration) passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo doc --no-deps` builds without warnings
- [x] Version bumped to `0.2.0` in `Cargo.toml`
- [ ] Release drafter published manually after merge
- [x] Milestone v0.2.0 closed on GitHub