### PR TITLE
Release v0.6.0 — Sparse Linear Algebra & Persistence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,28 @@ jobs:
       - name: cargo clippy — default features
         run: cargo clippy -- -D warnings
 
-      # J5 (v0.7) — activate when features are declared in Cargo.toml
+      # DD-043 (#50) — sparse linear algebra backend (faer). No system
+      # dependency needed, but requires rustc 1.84+ (faer 0.24's own MSRV,
+      # above this crate's own rust-version = "1.80") — @stable is expected
+      # to satisfy this; revisit if it ever regresses below 1.84.
+      - name: cargo clippy — feature sparse
+        run: cargo clippy --features sparse -- -D warnings
+
+      # DD-027 (#75, migrated to hdf5-metno per #79) — needs libhdf5's C
+      # headers, discovered via pkg-config. No code uses this feature yet
+      # (ExternalTabulated not implemented) — this only guards against the
+      # dependency itself becoming unbuildable.
+      - name: Install system dependencies (HDF5)
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y --no-install-recommends libhdf5-dev pkg-config
+
+      - name: cargo clippy — feature hdf5
+        run: cargo clippy --features hdf5 -- -D warnings
+
+      # J5 (v0.7) — activate when consumed for real:
+      # parallel/serde are already declared in Cargo.toml but not yet
+      # exercised by any real threshold-triggered or serialized code path.
       # - name: cargo clippy — feature parallel
       #   run: cargo clippy --features parallel -- -D warnings
       # - name: cargo clippy — feature serde
@@ -80,7 +101,20 @@ jobs:
       - name: cargo test — default features
         run: cargo test
 
-      # J5 (v0.7) — activate when features are declared in Cargo.toml
+      # DD-043 (#50) — see the clippy job for the rustc 1.84+ note.
+      - name: cargo test — feature sparse
+        run: cargo test --features sparse
+
+      # DD-027 (#75, migrated to hdf5-metno per #79).
+      - name: Install system dependencies (HDF5)
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y --no-install-recommends libhdf5-dev pkg-config
+
+      - name: cargo test — feature hdf5
+        run: cargo test --features hdf5
+
+      # J5 (v0.7) — activate when consumed for real (see the clippy job).
       # - name: cargo test — feature parallel
       #   run: cargo test --features parallel
       # - name: cargo test — feature serde

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Cache Cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: fmt
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Cache Cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -86,10 +86,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: fmt
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Cache Cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -132,10 +132,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Cache Cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -50,7 +50,32 @@ jobs:
           cargo llvm-cov --all-targets \
             --lcov --output-path lcov-default.info
 
-      # ── Run 2 : all features ──────────────────────────────────────────────
+      # ── Run 2 : sparse feature (faer) — DD-013, DD-043 (#50) ───────────────
+      # Code réel depuis ce sprint (solver::sparse, banded jacobian,
+      # BackwardEuler/CrankNicolson dispatch) — contrairement à `hdf5`
+      # ci-dessous, ce run couvre du comportement effectif.
+      - name: Coverage — sparse feature
+        run: |
+          cargo llvm-cov --all-targets --features sparse \
+            --lcov --output-path lcov-sparse.info
+
+      # ── Run 3 : hdf5 feature — DD-027 (#75), migré vers hdf5-metno (#79) ───
+      # Pas encore activé : aucun code n'utilise cette feature
+      # (`ExternalTabulated` non implémenté) — un run de couverture n'aurait
+      # aucune ligne réelle à mesurer. À activer avec l'implémentation
+      # réelle, en réutilisant l'installation système ci-dessous.
+      #
+      # - name: Install system dependencies (HDF5)
+      #   run: |
+      #     sudo apt-get update -q
+      #     sudo apt-get install -y --no-install-recommends libhdf5-dev pkg-config
+      #
+      # - name: Coverage — hdf5 feature
+      #   run: |
+      #     cargo llvm-cov --all-targets --features hdf5 \
+      #       --lcov --output-path lcov-hdf5.info
+
+      # ── Run 4 : all features ──────────────────────────────────────────────
       # À activer dès qu'au moins un feature optionnel est déclaré dans
       # Cargo.toml (parallel, serde, hdf5...).
       #
@@ -59,7 +84,7 @@ jobs:
       #     cargo llvm-cov --all-targets --all-features \
       #       --lcov --output-path lcov-all.info
 
-      # ── Run 3 : parallel feature only ─────────────────────────────────────
+      # ── Run 5 : parallel feature only ─────────────────────────────────────
       # À activer quand Cargo.toml contient : [features] parallel = [...]
       #
       # - name: Coverage — parallel feature
@@ -67,7 +92,7 @@ jobs:
       #     cargo llvm-cov --all-targets --features parallel \
       #       --lcov --output-path lcov-parallel.info
 
-      # ── Run 4 : serde feature only ────────────────────────────────────────
+      # ── Run 6 : serde feature only ────────────────────────────────────────
       - name: Coverage — serde feature
         run: |
           cargo llvm-cov --all-targets --features serde \
@@ -86,6 +111,6 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
         with:
-          files: lcov-default.info,lcov-serde.info
+          files: lcov-default.info,lcov-sparse.info,lcov-serde.info
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0   # full history required for Codecov branch tracking
 
@@ -109,7 +109,7 @@ jobs:
 
       # ── Upload to Codecov ─────────────────────────────────────────────────
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           files: lcov-default.info,lcov-sparse.info,lcov-serde.info
           fail_ci_if_error: true

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -11,7 +11,7 @@ jobs:
     name: Push mirror
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0   # full history required
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -32,7 +32,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter-semver.yml
           # Publish the draft when a vX.Y.Z tag is pushed; update otherwise.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ oxiflow adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `SimulationSnapshot`, `SnapshotFormat`, `write_snapshot()`/`read_snapshot()`
+  (JSON/bincode) — `src/solver/snapshot.rs` (DD-025 Option B / DD-029, #71)
+- `Solver::on_divergence()` — default no-op hook, called automatically before
+  `OxiflowError::SolverDivergence` is returned (#71)
+- `OxiflowError::Persistence` — snapshot I/O/(de)serialisation failures
+
+### Changed
+
+- `SimulationResult` now derives `Clone`
+
 ## [0.5.0] — 2026-07-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,13 @@ oxiflow adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - `SimulationSnapshot`, `SnapshotFormat`, `write_snapshot()`/`read_snapshot()`
-  (JSON/bincode) — `src/solver/snapshot.rs` (DD-025 Option B / DD-029, #71)
+  (JSON/bincode) — `src/solver/snapshot.rs` (#66 Option B / #77, #71)
 - `Solver::on_divergence()` — default no-op hook, called automatically before
   `OxiflowError::SolverDivergence` is returned (#71)
 - `OxiflowError::Persistence` — snapshot I/O/(de)serialisation failures
 - `ExternalTabulated::from_hdf5()` — loads tabulated data from an HDF5 file
     (one group per variable, `t`/`value` datasets), feature-gated `hdf5`
-    (DD-027, #105)
+    (#75, #105)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ oxiflow adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `Solver::on_divergence()` — default no-op hook, called automatically before
   `OxiflowError::SolverDivergence` is returned (#71)
 - `OxiflowError::Persistence` — snapshot I/O/(de)serialisation failures
+- `ExternalTabulated::from_hdf5()` — loads tabulated data from an HDF5 file
+    (one group per variable, `t`/`value` datasets), feature-gated `hdf5`
+    (DD-027, #105)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,16 @@ oxiflow adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- `SimulationSnapshot`, `SnapshotFormat`, `write_snapshot()`/`read_snapshot()`
-  (JSON/bincode) — `src/solver/snapshot.rs` (#66 Option B / #77, #71)
+- `SimulationSnapshot`, `SnapshotFormat`, `write_snapshot()`/`read_snapshot()` (JSON/bincode) — `src/solver/snapshot.rs`
+  (#66 Option B / #77, #71)
 - `Solver::on_divergence()` — default no-op hook, called automatically before
   `OxiflowError::SolverDivergence` is returned (#71)
 - `OxiflowError::Persistence` — snapshot I/O/(de)serialisation failures
-- `ExternalTabulated::from_hdf5()` — loads tabulated data from an HDF5 file
-    (one group per variable, `t`/`value` datasets), feature-gated `hdf5`
-    (#75, #105)
+- `ExternalTabulated::from_hdf5()` — loads tabulated data from an HDF5 file (one group per variable, `t`/`value`
+  datasets), feature-gated `hdf5` (#75, #105)
+- `SimulationResult::write_vtk()` — XML `.vtu` export for ParaView/VisIt,   feature-gated `vtk` (#75, #78)
+- `IntegratorSpec` — external config DTO for `BackwardEulerSolver` +
+  `TryFrom<IntegratorSpec> for Box<dyn Solver>`, feature-gated `sparse` (#75 amendment 1, #104)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,47 @@ oxiflow adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-07-21
+
+### Highlights
+
+Sparse linear algebra and persistence: a `faer`-backed sparse solver path for
+implicit integrators (`BackwardEulerSolver`, `CrankNicolsonSolver`), a
+crash/checkpoint snapshot mechanism, HDF5-backed loading of experimental
+tabulated data, XML VTK export for ParaView/VisIt, and the first
+config-driven integrator selection DTO (`IntegratorSpec`).
+
 ### Added
 
-- `SimulationSnapshot`, `SnapshotFormat`, `write_snapshot()`/`read_snapshot()` (JSON/bincode) — `src/solver/snapshot.rs`
-  (#66 Option B / #77, #71)
+- `faer`-backed sparse linear solver path (`SparseLinearSolver`,
+  `FaerSparseSolver`) for `BackwardEulerSolver`/`CrankNicolsonSolver`,
+  feature-gated `sparse` (DD-013, DD-043, #50)
+- `SimulationSnapshot`, `SnapshotFormat`, `write_snapshot()`/`read_snapshot()`
+  (JSON/bincode) — `src/solver/snapshot.rs` (DD-025 Option B / DD-029, #71)
 - `Solver::on_divergence()` — default no-op hook, called automatically before
   `OxiflowError::SolverDivergence` is returned (#71)
-- `OxiflowError::Persistence` — snapshot I/O/(de)serialisation failures
-- `ExternalTabulated::from_hdf5()` — loads tabulated data from an HDF5 file (one group per variable, `t`/`value`
-  datasets), feature-gated `hdf5` (#75, #105)
-- `SimulationResult::write_vtk()` — XML `.vtu` export for ParaView/VisIt,   feature-gated `vtk` (#75, #78)
+- `OxiflowError::Persistence` — snapshot/HDF5/VTK I/O and (de)serialisation
+  failures
+- `ExternalTabulated::from_hdf5()` — loads tabulated data from an HDF5 file,
+  feature-gated `hdf5` (DD-027, #105)
+- `SimulationResult::write_vtk()` — XML `.vtu` export for ParaView/VisIt,
+  feature-gated `vtk` (DD-027, #78)
 - `IntegratorSpec` — external config DTO for `BackwardEulerSolver` +
-  `TryFrom<IntegratorSpec> for Box<dyn Solver>`, feature-gated `sparse` (#75 amendment 1, #104)
+  `TryFrom<IntegratorSpec> for Box<dyn Solver>`, feature-gated `sparse`
+  (DD-027 amendment 1, #104)
 
 ### Changed
 
 - `SimulationResult` now derives `Clone`
+- `hdf5` feature migrated from the unmaintained `hdf5` crate (0.8, aldanor)
+  to the actively-maintained `hdf5-metno` fork (chore, #79)
+
+### Design Decisions
+
+- DD-027 — Results export: VTK as interop pivot, HDF5 for bulk datasets (#75)
+- DD-027 amendment 1 — config-driven WHAT/HOW construction from JSON/YAML
+- DD-029 — Generalised `SimulationSnapshot`: normal checkpoint/resume (#77)
+- DD-043 — `SparseLinearSolver`: sibling trait to `DiscreteOperator` (faer)
 
 ## [0.5.0] — 2026-07-17
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,20 @@ hdf5  = { package = "hdf5-metno", version = "0.10", optional = true }
 # dépendances transitives avec un MSRV bien supérieur à celui de ce crate,
 # sans bénéfice ici.
 faer  = { version = "0.24", optional = true, default-features = false, features = ["std", "sparse-linalg"] }
+# feature `serde`    — sérialisation JSON de `SimulationSnapshot` (DD-025 Option
+# B / DD-029, issue #71) — `write_snapshot()` au format lisible pour le debug.
+# Passée de dev-dependency (fixtures de test uniquement) à dépendance de
+# production optionnelle : `write_snapshot()` en a besoin dans le crate publié,
+# pas seulement dans ses tests. Pinnée `1.3` (pas `2.x`/`3.x`) : ces versions
+# récentes déclarent `rust-version = "1.85.0"`, au-dessus du MSRV de ce crate
+# (`1.80`) — vérifié sur l'index crates.io avant ajout, pas supposé.
+serde_json = { version = "1", optional = true }
+# feature `serde`    — sérialisation bincode de `SimulationSnapshot` (DD-025
+# Option B / DD-029, issue #71) — format binaire natif recommandé pour
+# `checkpoint()`/`on_divergence()` (fidélité + performance). Même contrainte de
+# MSRV que `serde_json` ci-dessus : `bincode 1.3` (API `serialize`/
+# `deserialize` classique), pas `2.x`/`3.x` (`rust-version = "1.85.0"`).
+bincode = { version = "1.3", optional = true }
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Features
@@ -71,8 +85,10 @@ default  = []
 parallel = ["dep:rayon"]
 
 # Sérialisation des types publics via serde — DD-025 (issue #66, décision ;
-# issue #67, implémentation Option A).
-serde    = ["dep:serde", "nalgebra/serde-serialize"]
+# issue #67, implémentation Option A). Entraîne `serde_json`/`bincode` pour
+# `write_snapshot()` (DD-025 Option B / DD-029, issue #71) : JSON lisible pour
+# le debug, bincode natif pour `checkpoint()`/`on_divergence()`.
+serde    = ["dep:serde", "nalgebra/serde-serialize", "dep:serde_json", "dep:bincode"]
 
 # Support HDF5 pour les données expérimentales volumineuses — DD-027
 # (issue #75). Dépendance migrée vers `hdf5-metno` (chore #79) — voir le
@@ -91,9 +107,6 @@ sparse   = ["dep:faer"]
 # Benchmarks — suite prévue à v0.7.0/J5 (issue #53, encore ouverte : le
 # harness ci-dessous n'est pas encore activé, seul le crate est déclaré).
 criterion = { version = "0.8", features = ["html_reports"] }
-# Fixtures de test (JSON de référence) — pas de DD/issue dédiée, usage
-# interne aux tests uniquement.
-serde_json = { version = "1" }
 
 # [[bench]]
 # name    = "oxiflow_benchmarks"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,18 +19,44 @@ categories  = ["science", "algorithms"]
 # ──────────────────────────────────────────────────────────────────────────────
 
 [dependencies]
-# Algèbre linéaire — vecteurs, matrices, champs / Linear algebra — vectors, matrices, fields
+# Algèbre linéaire dense — vecteurs, matrices, champs. DD-013 (issue #13) :
+# nalgebra retenu plutôt qu'une implémentation maison (option A).
 nalgebra  = "0.33"
-# Gestion des erreurs typées / Typed error handling (DD-004)
+# Gestion des erreurs typées — DD-004 (issue #4) : enum `OxiflowError` via
+# thiserror plutôt que des erreurs `String` (option A).
 thiserror = "2"
 
 # Optionnelles / Optional
-# feature `parallel` — parallélisme opt-in via Rayon (DD-014, J5)
+# feature `parallel` — parallélisme opt-in via Rayon. DD-014 (issue #14,
+# décision ; issue #51, implémentation) : feature opt-in + seuil configurable
+# (option A) plutôt qu'activation systématique (option B) ou threading manuel
+# (option C).
 rayon = { version = "1", optional = true }
-# feature `serde`    — sérialisation des types publics (J6)
+# feature `serde`    — sérialisation des types publics. DD-025 (issue #66,
+# décision ; issue #67, implémentation Option A) : `cfg_attr` sur les types
+# valeur dès v0.1.0, `SimulationSnapshot` (Option B, issue #71) à v0.6.0.
 serde = { version = "1", features = ["derive"], optional = true }
-# feature `hdf5`     — large experimental dataset I/O (planned J3+)
-hdf5  = { version = "0.8", optional = true }
+# feature `hdf5`     — données expérimentales volumineuses (`ExternalTabulated`).
+# DD-027 (issue #75) : HDF5 conservé pour ce seul usage (VTK devient le pivot
+# des résultats — feature `vtk`, pas encore ajoutée ici).
+# Migré vers `hdf5-metno` (chore #79) via l'alias `package` de Cargo : le nom
+# local reste `hdf5`, donc aucun site d'appel (`use hdf5::...`) n'a besoin
+# d'être modifié — seule cette ligne change. `hdf5 = "0.8"` (wrapper aldanor)
+# est explicitement décrit par DD-027 comme non maintenu et ne compilant plus
+# contre les toolchains Rust récentes ; `hdf5-metno` est le fork activement
+# maintenu (Institut météorologique norvégien), même auteur original en
+# co-mainteneur.
+hdf5  = { package = "hdf5-metno", version = "0.10", optional = true }
+# feature `sparse`   — solveur linéaire creux pour les intégrateurs implicites
+# sur grandes grilles. DD-013 (issue #13, décision faer pour le volet creux) ;
+# DD-043 (issue #50, v0.6.0) : trait frère de LinearSolver, pas une extension
+# (voir solver::sparse). `default-features = false` : seul `sparse-linalg`
+# (LU sur faer::sparse::SparseColMat) est nécessaire — les features par défaut
+# de faer tirent aussi `npy` (I/O .npy, inutilisé ici) et son propre `rayon`
+# interne (distinct de la feature `parallel` de ce crate), qui entraînent des
+# dépendances transitives avec un MSRV bien supérieur à celui de ce crate,
+# sans bénéfice ici.
+faer  = { version = "0.24", optional = true, default-features = false, features = ["std", "sparse-linalg"] }
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Features
@@ -39,12 +65,13 @@ hdf5  = { version = "0.8", optional = true }
 [features]
 default  = []
 
-# Parallélisme opt-in via Rayon — activé uniquement au-delà du seuil configurable
-# Opt-in parallelism via Rayon — activated only beyond the configurable threshold
+# Parallélisme opt-in via Rayon — DD-014 (issue #14, décision ; issue #51,
+# implémentation) : activé uniquement au-delà d'un seuil configurable
+# (`set_parallel_threshold`), jamais par défaut.
 parallel = ["dep:rayon"]
 
-# Sérialisation des types publics via serde
-# Public types serialization via serde
+# Sérialisation des types publics via serde — DD-025 (issue #66, décision ;
+# issue #67, implémentation Option A).
 serde    = ["dep:serde", "nalgebra/serde-serialize"]
 
 # Support HDF5 pour les données expérimentales volumineuses
@@ -56,11 +83,13 @@ hdf5     = ["dep:hdf5"]
 # ──────────────────────────────────────────────────────────────────────────────
 
 [dev-dependencies]
+# Benchmarks — suite prévue à v0.7.0/J5 (issue #53, encore ouverte : le
+# harness ci-dessous n'est pas encore activé, seul le crate est déclaré).
 criterion = { version = "0.8", features = ["html_reports"] }
+# Fixtures de test (JSON de référence) — pas de DD/issue dédiée, usage
+# interne aux tests uniquement.
 serde_json = { version = "1" }
 
-# Benchmarks Criterion — activés à J5 (v0.7) lorsque benches/ sera créé
-# Criterion benchmarks — activated at J5 (v0.7) when benches/ is created
 # [[bench]]
 # name    = "oxiflow_benchmarks"
 # harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,10 @@ serde = { version = "1", features = ["derive"], optional = true }
 # maintenu (Institut météorologique norvégien), même auteur original en
 # co-mainteneur.
 hdf5  = { package = "hdf5-metno", version = "0.10", optional = true }
+# feature `vtk`      — export XML (.vtu) de SimulationResult::write_vtk()
+# (DD-027, issue #78). Pure Rust, aucune dépendance système (contrairement à
+# `hdf5`) — voir DD-027 : choisi comme pivot d'interop pour ParaView/VisIt.
+vtkio = { version = "0.6", optional = true }
 # feature `sparse`   — solveur linéaire creux pour les intégrateurs implicites
 # sur grandes grilles. DD-013 (issue #13, décision faer pour le volet creux) ;
 # DD-043 (issue #50, v0.6.0) : trait frère de LinearSolver, pas une extension
@@ -94,6 +98,7 @@ serde    = ["dep:serde", "nalgebra/serde-serialize", "dep:serde_json", "dep:binc
 # (issue #75). Dépendance migrée vers `hdf5-metno` (chore #79) — voir le
 # commentaire sur la dépendance ci-dessus.
 hdf5     = ["dep:hdf5"]
+vtk      = ["dep:vtkio"]
 
 # Solveur linéaire creux (faer) — DD-013 (issue #13) / DD-043 (issue #50,
 # v0.6.0). Trait frère de LinearSolver (solver::sparse), pas une extension.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,9 +74,14 @@ parallel = ["dep:rayon"]
 # issue #67, implémentation Option A).
 serde    = ["dep:serde", "nalgebra/serde-serialize"]
 
-# Support HDF5 pour les données expérimentales volumineuses
-# HDF5 support for large experimental datasets
+# Support HDF5 pour les données expérimentales volumineuses — DD-027
+# (issue #75). Dépendance migrée vers `hdf5-metno` (chore #79) — voir le
+# commentaire sur la dépendance ci-dessus.
 hdf5     = ["dep:hdf5"]
+
+# Solveur linéaire creux (faer) — DD-013 (issue #13) / DD-043 (issue #50,
+# v0.6.0). Trait frère de LinearSolver (solver::sparse), pas une extension.
+sparse   = ["dep:faer"]
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Dépendances de développement / Development dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "oxiflow"
-version     = "0.5.0"
+version     = "0.6.0"
 edition     = "2021"
 rust-version = "1.80"
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,10 +4,9 @@ This document is the architectural reference for oxiflow. It covers the design p
 milestone specifications, design invariants, ecosystem strategy, and decision log that guide
 all implementation work from v0.1 to v3.0.
 
-> **Current version:** v0.4.0 — Integrators (closed)
-> **Active development:** v0.5.0 — Discretisation (J5) — DiscreteOperator (DD-012/#46), FD (#47),
-> FV (#48), WENO/limiters (#49), FluxDivergenceOperator & DiscretizedModel (DD-039/DD-038)
-> **Document version:** 2.2 — July 2026
+> **Current version:** v0.6.0 — Sparse Algebra & Persistence (closed)
+> **Active development:** v0.7.0 — Nonlinear Time Integration (J7), not yet started
+> **Document version:** 2.3 — July 2026
 
 ---
 
@@ -88,8 +87,8 @@ boilerplate.
 | J2 — Complete Context | v0.2.0 | ✅ Achieved | Requiring BCs · topological ordering · built-in calculators |
 | J3 — Multi-Component | v0.3.0 | ✅ Achieved | PhysicalQuantity · MultiDomainState · CouplingOperator (INV-3) |
 | J4a — Integrators | v0.4.0 | ✅ Achieved | Euler, RK4, DoPri45, Backward Euler, Crank-Nicolson, BDF2, IMEX |
-| J5 — Discretisation | v0.5.0 | 🔄 In progress | DiscreteOperator (INV-2) · FD/FV · WENO3/5 |
-| J6 — Sparse Algebra & Persistence | v0.6.0 | ⏳ Planned | faer-sparse · VTK/HDF5 export · SimulationSnapshot |
+| J5 — Discretisation | v0.5.0 | ✅ Achieved | DiscreteOperator (INV-2) · FD/FV · WENO3/5 |
+| J6 — Sparse Algebra & Persistence | v0.6.0 | ✅ Achieved | faer-sparse · VTK/HDF5 export · SimulationSnapshot |
 | J7 — Nonlinear Time Integration | v0.7.0 | ⏳ Planned | Newton and related methods for implicit integrators |
 | J8 — Computational Optimisation | v0.8.0 | ⏳ Planned | Profiling, algorithmic/memory optimisation, GPU (`wgpu`) |
 | J9 — Parallelism & Benchmarking | v0.9.0 | ⏳ Planned | Rayon · dirty-flag cache · Criterion benchmarks |
@@ -281,8 +280,15 @@ delivered.
 
 Sparse `faer-sparse` linear solver for implicit systems (#50, DD-013 phase 2). Results export:
 VTK (`vtkio`) as the interop pivot for `SimulationResult` (#78, DD-027), HDF5 (`hdf5-metno`,
-dependency migration #79) for bulk datasets. `SimulationSnapshot` generalised beyond crash
-recovery to normal checkpoint/resume (DD-029, extends #71, #77).
+dependency migration #79) for bulk datasets, including HDF5-backed loading for
+`ExternalTabulated` (#105, split from #75). `SimulationSnapshot` generalised beyond crash
+recovery to normal checkpoint/resume (DD-029, extends #71, #77) — no `Solver::checkpoint()`
+method; callers construct the snapshot directly, see `snapshot.rs` module docs.
+
+DD-027 amendment 1 adds the first config-driven HOW-axis DTO, `IntegratorSpec` (#104) —
+`TryFrom<IntegratorSpec> for Box<dyn Solver>`, `BackwardEuler` variant only for this
+increment (the sparse dispatch path, #50). Remaining integrators and the WHAT axis
+(`ModelConfig`/`MeshConfig`/`BoundaryConditionConfig`) are follow-up, not part of J6.
 
 This is also the milestone at which the private `FluxDivergenceCalculator` (DD-038, J5) becomes
 a candidate for registration in the `ContextCalculator` pipeline, if generic flux-field export
@@ -558,8 +564,8 @@ replaces the old M+N scheme, which had drifted from the real due dates.
 | J2 | v0.2.0 | Closed (2026-05) | Requiring BCs · topology · built-in calculators |
 | J3 | v0.3.0 | Closed (2026-06) | PhysicalQuantity · CouplingOperator (INV-3) · proto lahar–lake |
 | J4a | v0.4.0 | Closed (2026-06) | Temporal integrators, IMEX included |
-| J5 | v0.5.0 | 2026-08-06 | DiscreteOperator (INV-2) · FD/FV · WENO3/5 |
-| J6 | v0.6.0 | 2026-09-16 | faer-sparse · VTK/HDF5 export · SimulationSnapshot |
+| J5 | v0.5.0 | Closed (2026-07-17) | DiscreteOperator (INV-2) · FD/FV · WENO3/5 |
+| J6 | v0.6.0 | Closed (2026-07-21) | faer-sparse · VTK/HDF5 export · SimulationSnapshot · IntegratorSpec |
 | J7 | v0.7.0 | 2026-10-07 | Nonlinear time integration (Newton) |
 | J8 | v0.8.0 | 2026-11-18 | Computational optimisation, GPU readiness |
 | J9 | v0.9.0 | 2026-12-30 | Rayon · dirty-flag cache · Criterion benchmarks |

--- a/DEVELOPPEMENT.md
+++ b/DEVELOPPEMENT.md
@@ -4,10 +4,9 @@ Ce document est la référence architecturale d'oxiflow. Il couvre les principes
 les spécifications de jalons, les invariants de conception, la stratégie d'écosystème et le
 journal de décisions qui guident l'ensemble du travail d'implémentation de v0.1 à v3.0.
 
-> **Version actuelle :** v0.4.0 — Integrators (clos)
-> **Développement actif :** v0.5.0 — Discretisation (J5) — DiscreteOperator (DD-012/#46), FD (#47),
-> FV (#48), WENO/limiteurs (#49), FluxDivergenceOperator & DiscretizedModel (DD-039/DD-038)
-> **Version du document :** 2.2 — Juillet 2026
+> **Version actuelle :** v0.6.0 — Algèbre creuse & persistance (clos)
+> **Développement actif :** v0.7.0 — Intégration temporelle non linéaire (J7), pas encore démarré
+> **Version du document :** 2.3 — Juillet 2026
 
 ---
 
@@ -90,8 +89,8 @@ scientifiques spécifiques avec un minimum de code de plomberie.
 | J2 — Contexte complet | v0.2.0 | ✅ Acquis | BCs requirantes · ordonnancement topologique · calculateurs built-in |
 | J3 — Multi-composants | v0.3.0 | ✅ Acquis | PhysicalQuantity · MultiDomainState · CouplingOperator (INV-3) |
 | J4a — Intégrateurs | v0.4.0 | ✅ Acquis | Euler, RK4, DoPri45, Euler implicite, Crank-Nicolson, BDF2, IMEX |
-| J5 — Discrétisation | v0.5.0 | 🔄 en cours | DiscreteOperator (INV-2) · FD/FV · WENO3/5 |
-| J6 — Algèbre creuse & persistance | v0.6.0 | ⏳ Planifié | faer-sparse · export VTK/HDF5 · SimulationSnapshot |
+| J5 — Discrétisation | v0.5.0 | ✅ Atteint | DiscreteOperator (INV-2) · FD/FV · WENO3/5 |
+| J6 — Algèbre creuse & persistance | v0.6.0 | ✅ Atteint | faer-sparse · export VTK/HDF5 · SimulationSnapshot |
 | J7 — Intégration temporelle non linéaire | v0.7.0 | ⏳ Planifié | Newton et méthodes apparentées pour intégrateurs implicites |
 | J8 — Optimisation computationnelle | v0.8.0 | ⏳ Planifié | Profilage, optimisation algorithmique/mémoire, GPU (`wgpu`) |
 | J9 — Parallélisme & benchmarking | v0.9.0 | ⏳ Planifié | Rayon · cache dirty-flag · benchmarks Criterion |
@@ -285,9 +284,17 @@ livrée.
 
 Solveur linéaire creux `faer-sparse` pour les systèmes implicites (#50, DD-013 phase 2).
 Export des résultats : VTK (`vtkio`) comme pivot interop pour `SimulationResult` (#78,
-DD-027), HDF5 (`hdf5-metno`, migration de dépendance #79) pour les données volumineuses.
+DD-027), HDF5 (`hdf5-metno`, migration de dépendance #79) pour les données volumineuses,
+incluant le chargement HDF5 pour `ExternalTabulated` (#105, scindée de #75).
 `SimulationSnapshot` généralisé au-delà de la reprise sur crash vers un checkpoint/reprise
-normal (DD-029, étend #71, #77).
+normal (DD-029, étend #71, #77) — pas de méthode `Solver::checkpoint()` : l'appelant
+construit le snapshot directement, voir la documentation de module de `snapshot.rs`.
+
+L'amendement 1 de DD-027 ajoute le premier DTO de configuration côté HOW,
+`IntegratorSpec` (#104) — `TryFrom<IntegratorSpec> for Box<dyn Solver>`, seule la
+variante `BackwardEuler` pour cet incrément (le chemin de dispatch creux, #50). Les
+autres intégrateurs et l'axe WHAT (`ModelConfig`/`MeshConfig`/`BoundaryConditionConfig`)
+restent à faire, hors périmètre de J6.
 
 C'est également au moment de cette étape que le calculateur privé `FluxDivergenceCalculator`
 (DD-038, J5) est candidat à un branchement dans le pipeline de `ContextCalculator`, si l'export
@@ -566,8 +573,8 @@ relatifs — remplace l'ancien schéma M+N, devenu incohérent avec les échéan
 | J2 | v0.2.0 | Clos (2026-05) | BCs requirantes · topologie · calculateurs built-in |
 | J3 | v0.3.0 | Clos (2026-06) | PhysicalQuantity · CouplingOperator (INV-3) · proto lahar–lac |
 | J4a | v0.4.0 | Clos (2026-06) | Intégrateurs temporels, IMEX inclus |
-| J5 | v0.5.0 | 2026-08-06 | DiscreteOperator (INV-2) · FD/FV · WENO3/5 |
-| J6 | v0.6.0 | 2026-09-16 | faer-sparse · export VTK/HDF5 · SimulationSnapshot |
+| J5 | v0.5.0 | Clos (2026-07-17) | DiscreteOperator (INV-2) · FD/FV · WENO3/5 |
+| J6 | v0.6.0 | Clos (2026-07-21) | faer-sparse · export VTK/HDF5 · SimulationSnapshot · IntegratorSpec |
 | J7 | v0.7.0 | 2026-10-07 | Intégration temporelle non linéaire (Newton) |
 | J8 | v0.8.0 | 2026-11-18 | Optimisation computationnelle, GPU-readiness |
 | J9 | v0.9.0 | 2026-12-30 | Rayon · cache dirty-flag · benchmarks Criterion |

--- a/README.fr.md
+++ b/README.fr.md
@@ -65,7 +65,7 @@ object-safe précisément dans ce but.
 
 ```toml
 [dependencies]
-oxiflow = "0.3"
+oxiflow = "0.6"
 # oxiflow-chrom = "3.0"    # framework chromatographie (disponible dès v3.0)
 ```
 
@@ -149,18 +149,21 @@ assurent la compatibilité des frameworks tiers entre les versions du moteur :
 
 ## État de Développement
 
-| Jalon                  | Version  | Statut      | Thème                                                            |
-|------------------------|----------|-------------|------------------------------------------------------------------|
-| J0 — Fondations        | v0.0.5   | ✅ Publié    | Placeholder · CI · structure projet                              |
-| J1 — Architecture cœur | v0.1.0   | ✅ Publié    | ContextValue · OxiflowError · Mesh (INV-1)                       |
-| J2 — Contexte complet  | v0.2.0   | ✅ Publié    | BCs requirantes · ordonnancement topologique · calculateurs      |
-| J3 — Multi-composants  | v0.3.0   | ✅ Publié    | PhysicalQuantity · MultiDomainState · CouplingOperator (INV-3)   |
-| J4a — Intégrateurs     | v0.4.0   | ✅ Publié    | Euler, RK4, DoPri45, Euler implicite, Crank–Nicolson, BDF2, IMEX |
-| J4b — Discrétisation   | v0.5.0   | ✅ Publié    | DiscreteOperator (INV-2) · FD/FV · WENO3/5 · limiteurs de flux + sélection adaptative |
-| J5 — Performance       | v0.6.0   | ⏳ Planifié  | Rayon · cache dirty-flag · benchmarks Criterion                  |
-| J6 — Écosystème v1.0   | v1.0.0   | ⏳ Planifié  | 7 exemples · audit FEM · API stable                              |
-| J7 — FEM               | v2.0.0   | 🔭 Horizon  | Maillages non structurés · ALE · INV-4 plugin-safe               |
-| J8 — Frameworks        | v3.0.0   | 🔭 Horizon  | oxiflow-chrom · oxiflow-geo · CLI `oxiflow run`                  |
+| Jalon                                    | Version | Statut     | Thème                                                                                                              |
+|------------------------------------------|--------|------------|--------------------------------------------------------------------------------------------------------------------|
+| J0 — Fondations                          | v0.0.5 | ✅ Publié   | Placeholder · CI · structure projet                                                                                |
+| J1 — Architecture cœur                   | v0.1.0 | ✅ Publié   | ContextValue · OxiflowError · Mesh (INV-1)                                                                         |
+| J2 — Contexte complet                    | v0.2.0 | ✅ Publié   | BCs requirantes · ordonnancement topologique · calculateurs                                                        |
+| J3 — Multi-composants                    | v0.3.0 | ✅ Publié   | PhysicalQuantity · MultiDomainState · CouplingOperator (INV-3)                                                     |
+| J4a — Intégrateurs                       | v0.4.0 | ✅ Publié   | Euler, RK4, DoPri45, Euler implicite, Crank–Nicolson, BDF2, IMEX                                                   |
+| J5 — Discrétisation                      | v0.5.0 | ✅ Publié   | DiscreteOperator (INV-2) · FD/FV · WENO3/5 · limiteurs de flux + sélection adaptative                              |
+| J6 — Algèbre creuse & persistance        | v0.6.0 | ✅ Publié   | solveur creux faer · SimulationSnapshot (checkpoint/on_divergence) · chargement HDF5 · export VTK · IntegratorSpec |
+| J7 — Intégration temporelle non linéaire | v0.7.0 | ⏳ Planifié | Itération de Newton complète pour les intégrateurs implicites                                                      |
+| J8 — Optimisation des calculs            | v0.8.0 | ⏳ Planifié | Profilage · optimisation algorithmique/mémoire · GPU-readiness (DD-026)                                            |
+| J9 — Parallélisme & Benchmarking         | v0.9.0 | ⏳ Planifié | Rayon · cache dirty-flag · benchmarks Criterion                                                                    |
+| J10 — Écosystème v1.0                    | v1.0.0 | ⏳ Planifié | 7 exemples · audit FEM · API stable                                                                                |
+| J20 — FEM                                | v2.0.0 | 🔭 Horizon | Maillages non structurés · ALE · INV-4 plugin-safe                                                                 |
+| J30 — Frameworks                         | v3.0.0 | 🔭 Horizon | oxiflow-chrom · oxiflow-geo · CLI `oxiflow run`                                                                    |
 
 Les sous-invariants INV-GPU-1 à INV-GPU-5 (DD-026) gouvernent la GPU-readiness des
 structures de données numériques dès v0.3.0 — pas de code GPU pour l'instant, mais tous
@@ -172,13 +175,15 @@ Voir [DEVELOPPEMENT.md](DEVELOPPEMENT.md) pour la spécification architecturale 
 
 ## Feature Flags
 
-| Flag       | Description                                           | Disponible dès |
-|------------|-------------------------------------------------------|----------------|
-| *(défaut)* | Moteur cœur, exécution séquentielle                   | v0.2           |
-| `parallel` | Parallélisme Rayon pour les calculateurs indépendants | v0.6           |
-| `serde`    | Sérialisation des états et scénarios                  | v0.6           |
-| `hdf5`     | Import/export HDF5 pour données tabulées externes     | v0.6           |
-| `gpu`      | Accélération GPU via `wgpu` (Vulkan/Metal/DX12)       | post-v0.5.0 (planifié) |
+| Flag       | Description                                                | Disponible dès  |
+|------------|------------------------------------------------------------|-----------------|
+| *(défaut)* | Moteur cœur, exécution séquentielle                        | v0.2            |
+| `serde`    | Sérialisation des états et scénarios                       | v0.6            |
+| `hdf5`     | Import/export HDF5 pour données tabulées externes          | v0.6            |
+| `vtk`      | Export VTK (`.vtu`) de `SimulationResult`                  | v0.6            |
+| `sparse`   | Solveur linéaire creux `faer` pour intégrateurs implicites | v0.6            |
+| `parallel` | Parallélisme Rayon pour les calculateurs indépendants      | v0.9 (planifié) |
+| `gpu`      | Accélération GPU via `wgpu` (Vulkan/Metal/DX12)            | v0.8 (planifié) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ plugin API — the engine exposes stable, object-safe extension points for exact
 
 ```toml
 [dependencies]
-oxiflow = "0.3"
+oxiflow = "0.6"
 # oxiflow-chrom = "3.0"    # chromatography framework (available from v3.0)
 ```
 
@@ -154,11 +154,14 @@ third-party frameworks remain compatible across engine versions:
 | J2 — Complete Context  | v0.2.0   | ✅ Published  | Requiring BCs · topological ordering · calculators |
 | J3 — Multi-Component   | v0.3.0   | ✅ Published  | PhysicalQuantity · MultiDomainState · CouplingOperator (INV-3) |
 | J4a — Integrators      | v0.4.0   | ✅ Published  | Euler, RK4, DoPri45, Backward Euler, Crank–Nicolson, BDF2, IMEX |
-| J4b — Discretisation   | v0.5.0   | ✅ Published  | DiscreteOperator (INV-2) · FD/FV · WENO3/5 · flux limiters + adaptive selection |
-| J5 — Performance       | v0.6.0   | ⏳ Planned    | Rayon · dirty-flag cache · Criterion benchmarks |
-| J6 — Ecosystem v1.0    | v1.0.0   | ⏳ Planned    | 7 examples · FEM audit · stable API             |
-| J7 — FEM               | v2.0.0   | 🔭 Horizon   | Unstructured meshes · ALE · INV-4 plugin-safe   |
-| J8 — Frameworks        | v3.0.0   | 🔭 Horizon   | oxiflow-chrom · oxiflow-geo · CLI `oxiflow run` |
+| J5 — Discretisation    | v0.5.0   | ✅ Published  | DiscreteOperator (INV-2) · FD/FV · WENO3/5 · flux limiters + adaptive selection |
+| J6 — Sparse Algebra & Persistence | v0.6.0 | ✅ Published | faer sparse solver · SimulationSnapshot (checkpoint/on_divergence) · HDF5 loading · VTK export · IntegratorSpec |
+| J7 — Nonlinear Time Integration | v0.7.0 | ⏳ Planned | Full Newton iteration for implicit integrators |
+| J8 — Computational Optimisation | v0.8.0 | ⏳ Planned | Profiling · algorithmic/memory optimisation · GPU-readiness (DD-026) |
+| J9 — Parallelism & Benchmarking | v0.9.0 | ⏳ Planned | Rayon · dirty-flag cache · Criterion benchmarks |
+| J10 — Ecosystem v1.0   | v1.0.0   | ⏳ Planned    | 7 examples · FEM audit · stable API             |
+| J20 — FEM              | v2.0.0   | 🔭 Horizon   | Unstructured meshes · ALE · INV-4 plugin-safe   |
+| J30 — Frameworks       | v3.0.0   | 🔭 Horizon   | oxiflow-chrom · oxiflow-geo · CLI `oxiflow run` |
 
 The INV-GPU-1 to INV-GPU-5 sub-invariants (DD-026) govern GPU-readiness of numerical
 data structures from v0.3.0 — no GPU code yet, but all types are designed to admit a
@@ -173,10 +176,12 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for the full architectural specification.
 | Flag        | Description                                    | Available from |
 |-------------|------------------------------------------------|----------------|
 | *(default)* | Engine core, serial execution                  | v0.2           |
-| `parallel`  | Rayon parallelism for independent calculators  | v0.6           |
 | `serde`     | Serialisation of states and scenarios          | v0.6           |
 | `hdf5`      | HDF5 import/export for tabulated external data | v0.6           |
-| `gpu`       | GPU acceleration via `wgpu` (Vulkan/Metal/DX12) | post-v0.5.0 (planned) |
+| `vtk`       | VTK (`.vtu`) export of `SimulationResult`      | v0.6           |
+| `sparse`    | `faer` sparse linear solver for implicit integrators | v0.6     |
+| `parallel`  | Rayon parallelism for independent calculators  | v0.9 (planned) |
+| `gpu`       | GPU acceleration via `wgpu` (Vulkan/Metal/DX12) | v0.8 (planned) |
 
 ---
 

--- a/src/context/calculators/tabulated.rs
+++ b/src/context/calculators/tabulated.rs
@@ -68,6 +68,77 @@ pub struct ExternalTabulated {
 }
 
 impl ExternalTabulated {
+    /// Loads tabulated data from an HDF5 file (DD-027, issue #105).
+    ///
+    /// `variable` must be [`ContextVariable::External`] — its `name` is used
+    /// as the HDF5 group to read from. The group must contain two 1D `f64`
+    /// datasets, `t` and `value`, of equal length. Delegates to [`Self::new`]
+    /// for validation (≥ 2 points, strictly ascending `t`) — no duplicated
+    /// logic.
+    ///
+    /// Requires the `hdf5` feature.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(OxiflowError::ExternalData)` if `variable` is not
+    /// `ContextVariable::External`. Returns `Err(OxiflowError::Persistence)`
+    /// if the file/group/dataset cannot be opened or read, or if `t` and
+    /// `value` have different lengths. Returns `Err(OxiflowError::ExternalData)`
+    /// (via [`Self::new`]) if the loaded data has fewer than 2 points or is
+    /// not sorted by ascending `t`.
+    #[cfg(feature = "hdf5")]
+    pub fn from_hdf5(
+        path: &std::path::Path,
+        variable: ContextVariable,
+        interpolation: Interpolation,
+    ) -> Result<Self, OxiflowError> {
+        let group_name = match &variable {
+            ContextVariable::External { name } => name.as_ref(),
+            _ => {
+                return Err(OxiflowError::ExternalData(
+                    "ExternalTabulated::from_hdf5 requires a ContextVariable::External \
+                     (its `name` is used as the HDF5 group to read)"
+                        .to_string(),
+                ));
+            }
+        };
+
+        let file = hdf5::File::open(path)
+            .map_err(|e| OxiflowError::Persistence(format!("cannot open {path:?}: {e}")))?;
+        let group = file.group(group_name).map_err(|e| {
+            OxiflowError::Persistence(format!("no group {group_name:?} in {path:?}: {e}"))
+        })?;
+
+        let read_column = |name: &str| -> Result<Vec<f64>, OxiflowError> {
+            let ds = group.dataset(name).map_err(|e| {
+                OxiflowError::Persistence(format!(
+                    "no dataset {name:?} in group {group_name:?} ({path:?}): {e}"
+                ))
+            })?;
+            let arr = ds.read_1d::<f64>().map_err(|e| {
+                OxiflowError::Persistence(format!(
+                    "cannot read dataset {name:?} in group {group_name:?} ({path:?}): {e}"
+                ))
+            })?;
+            Ok(arr.iter().copied().collect())
+        };
+
+        let t = read_column("t")?;
+        let value = read_column("value")?;
+
+        if t.len() != value.len() {
+            return Err(OxiflowError::Persistence(format!(
+                "group {group_name:?} ({path:?}): 't' has {} points, 'value' has {} — \
+                 must match",
+                t.len(),
+                value.len()
+            )));
+        }
+
+        let data: Vec<(f64, f64)> = t.into_iter().zip(value).collect();
+        Self::new(variable, data, interpolation)
+    }
+
     /// Creates a new tabulated external calculator.
     ///
     /// # Arguments
@@ -314,5 +385,65 @@ mod tests {
     fn is_object_safe() {
         let c: Box<dyn ContextCalculator> = Box::new(calc(linear_data()));
         assert_eq!(c.provides(), var());
+    }
+
+    // ── from_hdf5 ─────────────────────────────────────────────────────────────
+
+    #[cfg(feature = "hdf5")]
+    #[test]
+    fn from_hdf5_round_trip() {
+        let path = std::env::temp_dir().join("oxiflow_test_from_hdf5_round_trip.h5");
+
+        // Write a fixture matching the schema from_hdf5 expects: one group
+        // named after the variable, two 1D f64 datasets "t"/"value".
+        {
+            let file = hdf5::File::create(&path).unwrap();
+            let group = file.create_group("feed_conc").unwrap();
+            group
+                .new_dataset::<f64>()
+                .shape(3)
+                .create("t")
+                .unwrap()
+                .write_raw(&[0.0, 1.0, 2.0])
+                .unwrap();
+            group
+                .new_dataset::<f64>()
+                .shape(3)
+                .create("value")
+                .unwrap()
+                .write_raw(&[1.0, 2.0, 1.5])
+                .unwrap();
+        }
+
+        let variable = ContextVariable::External {
+            name: "feed_conc".into(),
+        };
+        let calc = ExternalTabulated::from_hdf5(&path, variable, Interpolation::Linear).unwrap();
+
+        // Same fixture as the module-level rustdoc example (t=0.5 -> 1.5).
+        let val = calc.compute(&ContextValue::Scalar(0.0), &ctx(0.5)).unwrap();
+        assert!((val.as_scalar().unwrap() - 1.5).abs() < 1e-10);
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[cfg(feature = "hdf5")]
+    #[test]
+    fn from_hdf5_rejects_non_external_variable() {
+        let path = std::env::temp_dir().join("oxiflow_test_from_hdf5_wrong_variant.h5");
+        let result =
+            ExternalTabulated::from_hdf5(&path, ContextVariable::Time, Interpolation::Linear);
+        assert!(matches!(result, Err(OxiflowError::ExternalData(_))));
+    }
+
+    #[cfg(feature = "hdf5")]
+    #[test]
+    fn from_hdf5_missing_file_is_persistence_error() {
+        let path = std::path::PathBuf::from("/nonexistent/path/data.h5");
+        let variable = ContextVariable::External {
+            name: "feed_conc".into(),
+        };
+        let result = ExternalTabulated::from_hdf5(&path, variable, Interpolation::Linear);
+        assert!(matches!(result, Err(OxiflowError::Persistence(_))));
     }
 }

--- a/src/context/error.rs
+++ b/src/context/error.rs
@@ -100,6 +100,12 @@ pub enum OxiflowError {
     /// The solver produced a non-finite state and cannot continue.
     #[error("solver divergence at t={time:.4e}: {reason}")]
     SolverDivergence { time: f64, reason: String },
+
+    /// A `SimulationSnapshot` read/write operation failed — file I/O or
+    /// (de)serialisation (JSON or bincode). See
+    /// [`crate::solver::snapshot`] (DD-025 Option B / DD-029, issue #71).
+    #[error("snapshot persistence error: {0}")]
+    Persistence(String),
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/src/model/discretized.rs
+++ b/src/model/discretized.rs
@@ -190,6 +190,11 @@ mod tests {
             let n = field.as_scalar_field()?.len();
             Ok(ContextValue::ScalarField(DVector::from_element(n, self.0)))
         }
+
+        fn stencil_radius(&self) -> usize {
+            // Constant output, no neighbor access at all.
+            0
+        }
     }
 
     fn fixture(value: f64) -> DiscretizedModel<ConstantFlux> {

--- a/src/operators/adaptive.rs
+++ b/src/operators/adaptive.rs
@@ -183,6 +183,12 @@ impl FluxDivergenceOperator for AdaptiveFlux {
         };
         Ok(ContextValue::ScalarField(div))
     }
+
+    fn stencil_radius(&self) -> usize {
+        // Same footprint as WENO3 (see module doc) — delegate rather than
+        // repeat the literal, so the two can never drift apart.
+        self.weno.stencil_radius()
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/src/operators/fv.rs
+++ b/src/operators/fv.rs
@@ -245,6 +245,11 @@ impl FluxDivergenceOperator for FVCenteredFlux {
         };
         Ok(ContextValue::ScalarField(div))
     }
+
+    fn stencil_radius(&self) -> usize {
+        // Two-point face flux — one neighbor on each side.
+        1
+    }
 }
 
 // ── FVUpwindFlux ──────────────────────────────────────────────────────────────
@@ -311,6 +316,11 @@ impl FluxDivergenceOperator for FVUpwindFlux {
             )?,
         };
         Ok(ContextValue::ScalarField(div))
+    }
+
+    fn stencil_radius(&self) -> usize {
+        // Two-point face flux — one neighbor on each side.
+        1
     }
 }
 

--- a/src/operators/limiters.rs
+++ b/src/operators/limiters.rs
@@ -255,6 +255,11 @@ impl FluxDivergenceOperator for LimitedFlux {
         };
         Ok(ContextValue::ScalarField(div))
     }
+
+    fn stencil_radius(&self) -> usize {
+        // Same stencil footprint as WENO3 — see the module doc.
+        2
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -123,6 +123,22 @@ pub trait FluxDivergenceOperator: RequiresContext + Send + Sync {
         mesh: &Self::MeshType,
         ctx: &ComputeContext,
     ) -> Result<ContextValue, OxiflowError>;
+
+    /// Half-width of the stencil this scheme reads on each side of a cell —
+    /// a property of the numerical scheme itself (HOW), never of the
+    /// physical model it backs (DD-043, amendment 1). No default: every
+    /// implementation must state its own value explicitly, the same
+    /// posture as [`crate::model::traits::RequiresContext::required_variables`].
+    ///
+    /// Read directly by the caller on the concrete `Op` — before it is ever
+    /// boxed into a `Box<dyn PhysicalModel>` — and handed explicitly to a
+    /// solver's own configuration (e.g.
+    /// `BackwardEulerSolver::with_jacobian_bandwidth(scheme.stencil_radius())`,
+    /// v0.6.0/#50). Never read back from a `PhysicalModel`: bandwidth is a
+    /// solver-side assertion (HOW), not a model declaration (WHAT) — see
+    /// DD-043, amendment 1, for the rejected alternative
+    /// (`PhysicalModel::jacobian_bandwidth`) and why it was rejected.
+    fn stencil_radius(&self) -> usize;
 }
 
 // ── FluxBoundary ──────────────────────────────────────────────────────────────

--- a/src/operators/weno.rs
+++ b/src/operators/weno.rs
@@ -329,6 +329,12 @@ impl FluxDivergenceOperator for WENO3 {
         };
         Ok(ContextValue::ScalarField(div))
     }
+
+    fn stencil_radius(&self) -> usize {
+        // Widest reach across both upwind directions and all three boundary
+        // treatments is 2 cells (see the GhostCell margins above).
+        2
+    }
 }
 
 // ── WENO5 operator ────────────────────────────────────────────────────────────
@@ -422,6 +428,12 @@ impl FluxDivergenceOperator for WENO5 {
             }
         };
         Ok(ContextValue::ScalarField(div))
+    }
+
+    fn stencil_radius(&self) -> usize {
+        // Widest reach across both upwind directions and all three boundary
+        // treatments is 3 cells (see the GhostCell margins above).
+        3
     }
 }
 

--- a/src/solver/linear.rs
+++ b/src/solver/linear.rs
@@ -6,14 +6,20 @@
 //! `A * x = b` knows nothing about `t`, `dt`, or any `Domain` — it is a
 //! generic service, not a temporal-integration concern. The implicit
 //! integrators ([`crate::solver::methods::implicit`]) are its first
-//! consumer, but DD-013 already anticipates a second one unrelated to time
-//! integration: sparse FEM systems at v2.0/J7, via a `faer` backend
-//! implementing this same trait.
+//! consumer. DD-013 also anticipates further consumers unrelated to time
+//! integration — sparse FEM systems at v2.0/J7 among them — but any sparse
+//! backend is a sibling trait (see below), never a second implementation
+//! of `LinearSolver` itself.
 //!
 //! [`NalgebraDenseSolver`] (dense LU) is the default for the small systems
 //! implicit integrators produce at J4a. The sparse `faer` backend arrives
-//! at v0.5.0 (DD-013, second phase) as an additional implementation of
-//! this same trait — no change needed here when it does.
+//! at v0.6.0 (DD-013 second phase, DD-043) as **`SparseLinearSolver`**
+//! (`solver::sparse`) — a sibling trait, not another implementation of
+//! `LinearSolver` itself: `faer`'s sparse matrix type is structurally
+//! incompatible with `DMatrix` without a conversion that would erase the
+//! memory benefit sparsity is meant to provide (DD-043). `LinearSolver` and
+//! `NalgebraDenseSolver` are unaffected by that addition — no change needed
+//! here when it lands.
 
 use nalgebra::{DMatrix, DVector};
 

--- a/src/solver/methods/backward_euler.rs
+++ b/src/solver/methods/backward_euler.rs
@@ -170,7 +170,15 @@ impl SteppableSolver for BackwardEulerSolver {
                 self.sparse_threshold,
                 self.jacobian_bandwidth,
             ),
-            None => theta_method_step(domain, chain, state, t, dt, 1.0, self.linear_solver.as_ref()),
+            None => theta_method_step(
+                domain,
+                chain,
+                state,
+                t,
+                dt,
+                1.0,
+                self.linear_solver.as_ref(),
+            ),
         }
     }
 }

--- a/src/solver/methods/backward_euler.rs
+++ b/src/solver/methods/backward_euler.rs
@@ -31,8 +31,12 @@ use crate::context::value::ContextValue;
 use crate::context::ContextCalculator;
 use crate::solver::linear::{LinearSolver, NalgebraDenseSolver};
 use crate::solver::methods::implicit::theta_method_step;
+#[cfg(feature = "sparse")]
+use crate::solver::methods::implicit::theta_method_step_adaptive;
 use crate::solver::methods::SteppableSolver;
 use crate::solver::scenario::{Domain, Scenario};
+#[cfg(feature = "sparse")]
+use crate::solver::sparse::SparseLinearSolver;
 use crate::solver::{SimulationResult, Solver, SolverConfiguration};
 
 /// Backward Euler solver — implicit, 1st order.
@@ -43,17 +47,43 @@ use crate::solver::{SimulationResult, Solver, SolverConfiguration};
 /// use oxiflow::solver::methods::backward_euler::BackwardEulerSolver;
 ///
 /// let solver = BackwardEulerSolver::new();
-/// // Or, once a sparse backend lands (v0.5.0, DD-013):
-/// // let solver = BackwardEulerSolver::new().with_linear_solver(Box::new(FaerSparseSolver));
+/// // Sparse backend (v0.6.0, DD-013 second phase, DD-043) — dense path
+/// // stays untouched unless all three are configured explicitly:
+/// // let solver = BackwardEulerSolver::new()
+/// //     .with_jacobian_bandwidth(scheme.stencil_radius())
+/// //     .with_sparse_solver(Box::new(FaerSparseSolver))
+/// //     .with_sparse_threshold(100); // default
 /// ```
 pub struct BackwardEulerSolver {
     linear_solver: Box<dyn LinearSolver>,
+    /// Sparse backend (DD-043) — `None` by default: the dense path
+    /// ([`theta_method_step`]) is unconditionally used unless this is
+    /// explicitly configured via [`Self::with_sparse_solver`].
+    #[cfg(feature = "sparse")]
+    sparse_solver: Option<Box<dyn SparseLinearSolver>>,
+    /// System size above which the sparse path is used, once a
+    /// `sparse_solver` and a `jacobian_bandwidth` are both configured.
+    /// Ignored (no effect) if `sparse_solver` is `None`.
+    #[cfg(feature = "sparse")]
+    sparse_threshold: usize,
+    /// Half-bandwidth of the Jacobian — a HOW-side assertion supplied by
+    /// the caller (e.g. `scheme.stencil_radius()`, DD-039), never read
+    /// from `Domain`/`PhysicalModel` (DD-043, amendment 1). `None` by
+    /// default: no assumption about locality, dense path only.
+    #[cfg(feature = "sparse")]
+    jacobian_bandwidth: Option<usize>,
 }
 
 impl Default for BackwardEulerSolver {
     fn default() -> Self {
         Self {
             linear_solver: Box::new(NalgebraDenseSolver),
+            #[cfg(feature = "sparse")]
+            sparse_solver: None,
+            #[cfg(feature = "sparse")]
+            sparse_threshold: 100,
+            #[cfg(feature = "sparse")]
+            jacobian_bandwidth: None,
         }
     }
 }
@@ -69,6 +99,32 @@ impl BackwardEulerSolver {
         self.linear_solver = linear_solver;
         self
     }
+
+    /// Configures the sparse backend (DD-043). Has no effect on its own —
+    /// the sparse path also requires [`Self::with_jacobian_bandwidth`] and
+    /// a system larger than [`Self::with_sparse_threshold`] (default 100)
+    /// at solve time; otherwise the dense path is used unchanged.
+    #[cfg(feature = "sparse")]
+    pub fn with_sparse_solver(mut self, sparse_solver: Box<dyn SparseLinearSolver>) -> Self {
+        self.sparse_solver = Some(sparse_solver);
+        self
+    }
+
+    /// System size above which the sparse path is used (default 100) —
+    /// see [`Self::with_sparse_solver`].
+    #[cfg(feature = "sparse")]
+    pub fn with_sparse_threshold(mut self, sparse_threshold: usize) -> Self {
+        self.sparse_threshold = sparse_threshold;
+        self
+    }
+
+    /// Declares the Jacobian's half-bandwidth (e.g.
+    /// `scheme.stencil_radius()`, DD-039) — see [`Self::with_sparse_solver`].
+    #[cfg(feature = "sparse")]
+    pub fn with_jacobian_bandwidth(mut self, jacobian_bandwidth: usize) -> Self {
+        self.jacobian_bandwidth = Some(jacobian_bandwidth);
+        self
+    }
 }
 
 impl Solver for BackwardEulerSolver {
@@ -81,6 +137,45 @@ impl Solver for BackwardEulerSolver {
     }
 }
 
+#[cfg(feature = "sparse")]
+impl SteppableSolver for BackwardEulerSolver {
+    fn step(
+        &self,
+        domain: &Domain,
+        chain: &[&dyn ContextCalculator],
+        state: &mut ContextValue,
+        _history: &[ContextValue],
+        t: f64,
+        dt: f64,
+    ) -> Result<ContextValue, OxiflowError> {
+        // history_depth() defaults to 0 -- Backward Euler is a one-step
+        // method, `_history` is always empty here and intentionally unused.
+        //
+        // Dispatch is gated on `sparse_solver` alone: with no solver
+        // configured there is nothing to hand `theta_method_step_adaptive`,
+        // so the dense path is taken directly rather than going through it
+        // with a `None` bandwidth (equivalent result, one fewer branch to
+        // reason about). The `n > sparse_threshold && bandwidth.is_some()`
+        // condition is `theta_method_step_adaptive`'s own responsibility.
+        match &self.sparse_solver {
+            Some(sparse_solver) => theta_method_step_adaptive(
+                domain,
+                chain,
+                state,
+                t,
+                dt,
+                1.0,
+                self.linear_solver.as_ref(),
+                sparse_solver.as_ref(),
+                self.sparse_threshold,
+                self.jacobian_bandwidth,
+            ),
+            None => theta_method_step(domain, chain, state, t, dt, 1.0, self.linear_solver.as_ref()),
+        }
+    }
+}
+
+#[cfg(not(feature = "sparse"))]
 impl SteppableSolver for BackwardEulerSolver {
     fn step(
         &self,

--- a/src/solver/methods/crank_nicolson.rs
+++ b/src/solver/methods/crank_nicolson.rs
@@ -31,19 +31,38 @@ use crate::context::value::ContextValue;
 use crate::context::ContextCalculator;
 use crate::solver::linear::{LinearSolver, NalgebraDenseSolver};
 use crate::solver::methods::implicit::theta_method_step;
+#[cfg(feature = "sparse")]
+use crate::solver::methods::implicit::theta_method_step_adaptive;
 use crate::solver::methods::SteppableSolver;
 use crate::solver::scenario::{Domain, Scenario};
+#[cfg(feature = "sparse")]
+use crate::solver::sparse::SparseLinearSolver;
 use crate::solver::{SimulationResult, Solver, SolverConfiguration};
 
 /// Crank-Nicolson solver — semi-implicit, 2nd order.
 pub struct CrankNicolsonSolver {
     linear_solver: Box<dyn LinearSolver>,
+    /// Sparse backend (DD-043) — see
+    /// [`BackwardEulerSolver`](super::backward_euler::BackwardEulerSolver)'s
+    /// fields for the full rationale, identical here.
+    #[cfg(feature = "sparse")]
+    sparse_solver: Option<Box<dyn SparseLinearSolver>>,
+    #[cfg(feature = "sparse")]
+    sparse_threshold: usize,
+    #[cfg(feature = "sparse")]
+    jacobian_bandwidth: Option<usize>,
 }
 
 impl Default for CrankNicolsonSolver {
     fn default() -> Self {
         Self {
             linear_solver: Box::new(NalgebraDenseSolver),
+            #[cfg(feature = "sparse")]
+            sparse_solver: None,
+            #[cfg(feature = "sparse")]
+            sparse_threshold: 100,
+            #[cfg(feature = "sparse")]
+            jacobian_bandwidth: None,
         }
     }
 }
@@ -59,6 +78,29 @@ impl CrankNicolsonSolver {
         self.linear_solver = linear_solver;
         self
     }
+
+    /// Configures the sparse backend (DD-043) — see
+    /// [`BackwardEulerSolver::with_sparse_solver`](super::backward_euler::BackwardEulerSolver::with_sparse_solver).
+    #[cfg(feature = "sparse")]
+    pub fn with_sparse_solver(mut self, sparse_solver: Box<dyn SparseLinearSolver>) -> Self {
+        self.sparse_solver = Some(sparse_solver);
+        self
+    }
+
+    /// System size above which the sparse path is used (default 100).
+    #[cfg(feature = "sparse")]
+    pub fn with_sparse_threshold(mut self, sparse_threshold: usize) -> Self {
+        self.sparse_threshold = sparse_threshold;
+        self
+    }
+
+    /// Declares the Jacobian's half-bandwidth (e.g.
+    /// `scheme.stencil_radius()`, DD-039).
+    #[cfg(feature = "sparse")]
+    pub fn with_jacobian_bandwidth(mut self, jacobian_bandwidth: usize) -> Self {
+        self.jacobian_bandwidth = Some(jacobian_bandwidth);
+        self
+    }
 }
 
 impl Solver for CrankNicolsonSolver {
@@ -71,6 +113,41 @@ impl Solver for CrankNicolsonSolver {
     }
 }
 
+#[cfg(feature = "sparse")]
+impl SteppableSolver for CrankNicolsonSolver {
+    fn step(
+        &self,
+        domain: &Domain,
+        chain: &[&dyn ContextCalculator],
+        state: &mut ContextValue,
+        _history: &[ContextValue],
+        t: f64,
+        dt: f64,
+    ) -> Result<ContextValue, OxiflowError> {
+        // history_depth() defaults to 0 -- Crank-Nicolson is a one-step
+        // method, `_history` is always empty here and intentionally unused.
+        //
+        // See BackwardEulerSolver::step for why dispatch is gated on
+        // `sparse_solver` alone.
+        match &self.sparse_solver {
+            Some(sparse_solver) => theta_method_step_adaptive(
+                domain,
+                chain,
+                state,
+                t,
+                dt,
+                0.5,
+                self.linear_solver.as_ref(),
+                sparse_solver.as_ref(),
+                self.sparse_threshold,
+                self.jacobian_bandwidth,
+            ),
+            None => theta_method_step(domain, chain, state, t, dt, 0.5, self.linear_solver.as_ref()),
+        }
+    }
+}
+
+#[cfg(not(feature = "sparse"))]
 impl SteppableSolver for CrankNicolsonSolver {
     fn step(
         &self,

--- a/src/solver/methods/crank_nicolson.rs
+++ b/src/solver/methods/crank_nicolson.rs
@@ -142,7 +142,15 @@ impl SteppableSolver for CrankNicolsonSolver {
                 self.sparse_threshold,
                 self.jacobian_bandwidth,
             ),
-            None => theta_method_step(domain, chain, state, t, dt, 0.5, self.linear_solver.as_ref()),
+            None => theta_method_step(
+                domain,
+                chain,
+                state,
+                t,
+                dt,
+                0.5,
+                self.linear_solver.as_ref(),
+            ),
         }
     }
 }

--- a/src/solver/methods/dopri45.rs
+++ b/src/solver/methods/dopri45.rs
@@ -213,7 +213,23 @@ impl Solver for DoPri45Solver {
                     accepted_steps += 1;
                     accepted_since_save += 1;
 
-                    check_finite(&u, t)?;
+                    if let Err(e) = check_finite(&u, t) {
+                        self.on_divergence(&crate::solver::snapshot::SimulationSnapshot {
+                            time_config: config.time.clone(),
+                            integrator: config.integrator.clone(),
+                            state: u.clone(),
+                            t,
+                            n_steps: accepted_steps,
+                            error: Some(e.to_string()),
+                            partial: Some(SimulationResult {
+                                states: states.clone(),
+                                times: times.clone(),
+                                n_steps: accepted_steps,
+                                metadata: HashMap::new(),
+                            }),
+                        });
+                        return Err(e);
+                    }
 
                     dt = controller.next_dt(local_dt, error_norm);
 
@@ -232,14 +248,26 @@ impl Solver for DoPri45Solver {
                 if rejections_this_step >= MAX_REJECTIONS_PER_STEP
                     || suggested <= controller.dt_min()
                 {
-                    return Err(OxiflowError::SolverDivergence {
-                        time: t,
-                        reason: format!(
-                            "step rejected {rejections_this_step} times in a row; cannot \
-                             satisfy rtol/atol even at dt_min={}",
-                            controller.dt_min()
-                        ),
+                    let reason = format!(
+                        "step rejected {rejections_this_step} times in a row; cannot \
+                         satisfy rtol/atol even at dt_min={}",
+                        controller.dt_min()
+                    );
+                    self.on_divergence(&crate::solver::snapshot::SimulationSnapshot {
+                        time_config: config.time.clone(),
+                        integrator: config.integrator.clone(),
+                        state: u.clone(),
+                        t,
+                        n_steps: accepted_steps,
+                        error: Some(reason.clone()),
+                        partial: Some(SimulationResult {
+                            states: states.clone(),
+                            times: times.clone(),
+                            n_steps: accepted_steps,
+                            metadata: HashMap::new(),
+                        }),
                     });
+                    return Err(OxiflowError::SolverDivergence { time: t, reason });
                 }
 
                 local_dt = suggested;

--- a/src/solver/methods/implicit.rs
+++ b/src/solver/methods/implicit.rs
@@ -154,6 +154,23 @@ pub(crate) fn theta_method_step(
 // why `PhysicalModel::jacobian_bandwidth` was rejected: bandwidth is a
 // property of the numerical scheme (HOW), not of the physical model (WHAT).
 
+/// A single Jacobian entry: `(row, col, value)` — one nonzero of `∂f/∂u`
+/// within the band, as produced by [`banded_jacobian_entries`]. Not yet a
+/// `faer` triplet: callers convert only when they actually need the
+/// sparse matrix type (see [`banded_finite_difference_jacobian`] and
+/// [`theta_method_step_adaptive`]), rather than paying that conversion
+/// cost inside the assembly loop itself.
+#[cfg(feature = "sparse")]
+type SparseEntry = (usize, usize, f64);
+
+/// Return type of [`banded_jacobian_entries`]: the system size `n`, and
+/// the raw list of [`SparseEntry`] within the declared band. Each
+/// `(row, col)` pair appears at most once — every column belongs to
+/// exactly one CPR color, so no two colors can ever produce the same
+/// entry.
+#[cfg(feature = "sparse")]
+type BandedJacobianResult = Result<(usize, Vec<SparseEntry>), OxiflowError>;
+
 /// Assembles the nonzero entries of $\partial f/\partial u$ within a band of
 /// half-width `bandwidth` around the diagonal, via Curtis-Powell-Reid (CPR)
 /// graph coloring: for a genuinely banded Jacobian, columns more than
@@ -175,7 +192,7 @@ pub(crate) fn banded_jacobian_entries(
     t: f64,
     dt: f64,
     bandwidth: usize,
-) -> Result<(usize, Vec<(usize, usize, f64)>), OxiflowError> {
+) -> BandedJacobianResult {
     let base_field = state.as_scalar_field()?.clone();
     let n = base_field.len();
 
@@ -222,6 +239,10 @@ pub(crate) fn banded_jacobian_entries(
 ///
 /// Kept separate from [`banded_jacobian_entries`] for dense/sparse parity
 /// testing against [`finite_difference_jacobian`] — see the test module.
+// TODO(v0.6.0): wire in once BackwardEulerSolver/CrankNicolsonSolver
+// select the banded path in practice (DD-043) — currently only exercised
+// by the dense/sparse parity test.
+#[allow(dead_code)]
 #[cfg(feature = "sparse")]
 pub(crate) fn banded_finite_difference_jacobian(
     domain: &Domain,

--- a/src/solver/methods/implicit.rs
+++ b/src/solver/methods/implicit.rs
@@ -50,6 +50,8 @@ use crate::context::value::ContextValue;
 use crate::context::ContextCalculator;
 use crate::solver::linear::LinearSolver;
 use crate::solver::scenario::Domain;
+#[cfg(feature = "sparse")]
+use crate::solver::sparse::SparseLinearSolver;
 
 /// Finite-difference step size for [`finite_difference_jacobian`].
 ///
@@ -141,6 +143,179 @@ pub(crate) fn theta_method_step(
 
     let u_next: DVector<f64> = u_n_field + delta_u;
     Ok(ContextValue::ScalarField(u_next))
+}
+
+// ── Sparse / banded path (DD-013 second phase, DD-043) ─────────────────────────
+//
+// `#[cfg(feature = "sparse")]` only. Bandwidth is always an explicit
+// parameter here, supplied by the caller (the solver's own HOW-side
+// configuration, e.g. `BackwardEulerSolver::with_jacobian_bandwidth`) — it
+// is never read from `Domain`/`PhysicalModel`. See DD-043, amendment 1, for
+// why `PhysicalModel::jacobian_bandwidth` was rejected: bandwidth is a
+// property of the numerical scheme (HOW), not of the physical model (WHAT).
+
+/// Assembles the nonzero entries of $\partial f/\partial u$ within a band of
+/// half-width `bandwidth` around the diagonal, via Curtis-Powell-Reid (CPR)
+/// graph coloring: for a genuinely banded Jacobian, columns more than
+/// `2*bandwidth + 1` apart never share a nonzero row, so all columns of the
+/// same color can be perturbed **simultaneously** in a single
+/// [`evaluate_derivative`] call — `2*bandwidth + 1` evaluations total,
+/// instead of [`finite_difference_jacobian`]'s `n`.
+///
+/// Returns `(n, triplets)` — raw `(row, col, value)` entries, not yet a
+/// `faer` sparse matrix, so callers computing the *system* matrix
+/// (`I - theta*dt*J`, see [`theta_method_step_adaptive`]) can fold the
+/// identity in before building the sparse type once, rather than building
+/// the raw Jacobian in sparse form only to rebuild it again.
+#[cfg(feature = "sparse")]
+pub(crate) fn banded_jacobian_entries(
+    domain: &Domain,
+    chain: &[&dyn ContextCalculator],
+    state: &ContextValue,
+    t: f64,
+    dt: f64,
+    bandwidth: usize,
+) -> Result<(usize, Vec<(usize, usize, f64)>), OxiflowError> {
+    let base_field = state.as_scalar_field()?.clone();
+    let n = base_field.len();
+
+    let mut base_state = state.clone();
+    let f0 = evaluate_derivative(domain, chain, &mut base_state, t, dt)?;
+    let f0_field = f0.as_scalar_field()?.clone();
+
+    let n_colors = 2 * bandwidth + 1;
+    let mut triplets = Vec::new();
+
+    for color in 0..n_colors {
+        let columns: Vec<usize> = (color..n).step_by(n_colors).collect();
+        if columns.is_empty() {
+            continue;
+        }
+
+        let mut perturbed_field = base_field.clone();
+        for &j in &columns {
+            perturbed_field[j] += FD_EPSILON;
+        }
+        let mut perturbed_state = ContextValue::ScalarField(perturbed_field);
+
+        let f_c = evaluate_derivative(domain, chain, &mut perturbed_state, t, dt)?;
+        let f_c_field = f_c.as_scalar_field()?;
+
+        // Columns of the same color are spaced `n_colors > 2*bandwidth`
+        // apart, so their bands ([j-bandwidth, j+bandwidth]) never
+        // overlap — each perturbed row's response is attributable to
+        // exactly one column, no disambiguation needed.
+        for &j in &columns {
+            let lo = j.saturating_sub(bandwidth);
+            let hi = (j + bandwidth + 1).min(n);
+            for i in lo..hi {
+                let deriv = (f_c_field[i] - f0_field[i]) / FD_EPSILON;
+                triplets.push((i, j, deriv));
+            }
+        }
+    }
+
+    Ok((n, triplets))
+}
+
+/// [`banded_jacobian_entries`], assembled into a `faer` sparse matrix.
+///
+/// Kept separate from [`banded_jacobian_entries`] for dense/sparse parity
+/// testing against [`finite_difference_jacobian`] — see the test module.
+#[cfg(feature = "sparse")]
+pub(crate) fn banded_finite_difference_jacobian(
+    domain: &Domain,
+    chain: &[&dyn ContextCalculator],
+    state: &ContextValue,
+    t: f64,
+    dt: f64,
+    bandwidth: usize,
+) -> Result<faer::sparse::SparseColMat<usize, f64>, OxiflowError> {
+    let (n, triplets) = banded_jacobian_entries(domain, chain, state, t, dt, bandwidth)?;
+
+    let faer_triplets: Vec<faer::sparse::Triplet<usize, usize, f64>> = triplets
+        .into_iter()
+        .map(|(i, j, v)| faer::sparse::Triplet::new(i, j, v))
+        .collect();
+
+    faer::sparse::SparseColMat::try_new_from_triplets(n, n, &faer_triplets).map_err(|e| {
+        OxiflowError::PreconditionFailed {
+            context: "banded_finite_difference_jacobian",
+            message: format!("failed to build sparse matrix from triplets: {e:?}"),
+        }
+    })
+}
+
+/// Same contract as [`theta_method_step`], with an additional sparse path:
+/// when `jacobian_bandwidth` is `Some(k)` **and** `n > sparse_threshold`,
+/// assembles `I - theta*dt*J` directly in sparse (banded) form via
+/// [`banded_jacobian_entries`] and solves it with `sparse_solver`. Falls
+/// back to [`theta_method_step`] unchanged in every other case — `None`
+/// bandwidth, or a small enough system that the dense path is cheaper
+/// regardless of bandwidth.
+///
+/// `jacobian_bandwidth`/`sparse_threshold`/`sparse_solver` are supplied by
+/// the caller's own HOW-side configuration (DD-043, amendment 1) — never
+/// read from `Domain` or `PhysicalModel`.
+#[cfg(feature = "sparse")]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn theta_method_step_adaptive(
+    domain: &Domain,
+    chain: &[&dyn ContextCalculator],
+    state: &mut ContextValue,
+    t: f64,
+    dt: f64,
+    theta: f64,
+    dense_solver: &dyn LinearSolver,
+    sparse_solver: &dyn SparseLinearSolver,
+    sparse_threshold: usize,
+    jacobian_bandwidth: Option<usize>,
+) -> Result<ContextValue, OxiflowError> {
+    let n = state.as_scalar_field()?.len();
+
+    match jacobian_bandwidth {
+        Some(k) if n > sparse_threshold => {
+            let f_n = evaluate_derivative(domain, chain, state, t, dt)?;
+            let u_n_field = state.as_scalar_field()?.clone();
+            let f_n_field = f_n.as_scalar_field()?.clone();
+
+            // Jacobian frozen at the (now BC-corrected) u^n, evaluated at
+            // t + dt — same convention as theta_method_step.
+            let (n_check, raw_triplets) =
+                banded_jacobian_entries(domain, chain, state, t + dt, dt, k)?;
+            debug_assert_eq!(n_check, n);
+
+            // I - theta*dt*J, folded into the triplets directly rather than
+            // building J's sparse matrix first and combining afterward —
+            // banded_jacobian_entries always includes the diagonal (j is
+            // always within its own band), so every row gets its "+1.0".
+            let coeff = -theta * dt;
+            let system_triplets: Vec<faer::sparse::Triplet<usize, usize, f64>> = raw_triplets
+                .into_iter()
+                .map(|(i, j, deriv)| {
+                    let mut value = coeff * deriv;
+                    if i == j {
+                        value += 1.0;
+                    }
+                    faer::sparse::Triplet::new(i, j, value)
+                })
+                .collect();
+
+            let system_matrix =
+                faer::sparse::SparseColMat::try_new_from_triplets(n, n, &system_triplets)
+                    .map_err(|e| OxiflowError::PreconditionFailed {
+                        context: "theta_method_step_adaptive",
+                        message: format!("failed to build sparse system matrix: {e:?}"),
+                    })?;
+
+            let rhs = f_n_field * dt;
+            let delta_u = sparse_solver.solve(&system_matrix, &rhs)?;
+
+            let u_next: DVector<f64> = u_n_field + delta_u;
+            Ok(ContextValue::ScalarField(u_next))
+        }
+        _ => theta_method_step(domain, chain, state, t, dt, theta, dense_solver),
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -300,6 +475,246 @@ mod tests {
         for v in field.iter() {
             assert!(v.is_finite(), "value diverged: {v}");
             assert!(v.abs() < 1.0, "expected strong damping, got {v}");
+        }
+    }
+}
+
+#[cfg(all(test, feature = "sparse"))]
+mod sparse_tests {
+    use super::*;
+    use crate::context::compute::ComputeContext;
+    use crate::context::variable::ContextVariable;
+    use crate::mesh::{Mesh, UniformGrid1D};
+    use crate::model::traits::{PhysicalModel, RequiresContext};
+    use crate::solver::chain::build_calculator_chain;
+    use crate::solver::linear::NalgebraDenseSolver;
+    use crate::solver::scenario::Scenario;
+    use crate::solver::sparse::FaerSparseSolver;
+
+    /// Discrete tridiagonal diffusion — `du_i/dt = D*(u[i-1] - 2u[i] +
+    /// u[i+1])`, zero outside the domain. Not a real `BoundaryCondition` —
+    /// this fixture exists only to exercise the banded path with a
+    /// genuinely local, bandwidth-1 coupling (real Dirichlet/Neumann
+    /// boundary handling is out of scope here, see the module's own
+    /// known-untested-limitation note).
+    #[derive(Debug)]
+    struct TridiagonalDiffusion {
+        diffusion: f64,
+    }
+
+    impl RequiresContext for TridiagonalDiffusion {
+        fn required_variables(&self) -> Vec<ContextVariable> {
+            vec![]
+        }
+    }
+
+    impl PhysicalModel for TridiagonalDiffusion {
+        fn compute_physics(
+            &self,
+            state: &ContextValue,
+            _ctx: &ComputeContext,
+        ) -> Result<ContextValue, OxiflowError> {
+            let u = state.as_scalar_field()?;
+            let n = u.len();
+            let d = self.diffusion;
+            let out = DVector::from_fn(n, |i, _| {
+                let left = if i > 0 { u[i - 1] } else { 0.0 };
+                let right = if i + 1 < n { u[i + 1] } else { 0.0 };
+                d * (left - 2.0 * u[i] + right)
+            });
+            Ok(ContextValue::ScalarField(out))
+        }
+
+        fn initial_state(&self, mesh: &dyn Mesh) -> ContextValue {
+            let n = mesh.n_dof();
+            ContextValue::ScalarField(DVector::from_fn(
+                n,
+                |i, _| if i == n / 2 { 1.0 } else { 0.0 },
+            ))
+        }
+
+        fn name(&self) -> &str {
+            "tridiagonal_diffusion_test"
+        }
+    }
+
+    /// A [`SparseLinearSolver`] that panics if ever called — used to prove
+    /// the dense path was actually taken (threshold/bandwidth conditions
+    /// not met), not just that the result happens to look dense-like.
+    struct PanicIfCalled;
+
+    impl SparseLinearSolver for PanicIfCalled {
+        fn solve(
+            &self,
+            _a: &faer::sparse::SparseColMat<usize, f64>,
+            _b: &DVector<f64>,
+        ) -> Result<DVector<f64>, OxiflowError> {
+            panic!("sparse solver called when the dense path should have been taken");
+        }
+    }
+
+    fn make_mesh(n: usize) -> Box<dyn Mesh> {
+        Box::new(UniformGrid1D::new(n, 0.0, 1.0).unwrap())
+    }
+
+    #[test]
+    fn banded_jacobian_entries_match_dense_jacobian() {
+        let n = 12;
+        let scenario = Scenario::single(
+            Box::new(TridiagonalDiffusion { diffusion: 0.7 }),
+            make_mesh(n),
+        );
+        let domain = scenario.single_domain().unwrap();
+        let requirements = scenario.context_requirements();
+        let chain = build_calculator_chain(&requirements, &[]).unwrap();
+        let state = domain.model.initial_state(domain.mesh.as_ref());
+
+        let dense = finite_difference_jacobian(domain, &chain, &state, 0.0, 0.01).unwrap();
+        let (n_check, banded_triplets) =
+            banded_jacobian_entries(domain, &chain, &state, 0.0, 0.01, 1).unwrap();
+        assert_eq!(n_check, n);
+
+        // Every banded entry must match the corresponding dense entry.
+        for (i, j, v) in &banded_triplets {
+            assert!(
+                (dense[(*i, *j)] - v).abs() < 1e-6,
+                "mismatch at ({i},{j}): dense={}, banded={v}",
+                dense[(*i, *j)]
+            );
+        }
+
+        // Every dense entry outside the band must be (near) zero — a
+        // genuinely tridiagonal problem has no coupling beyond bandwidth 1,
+        // so nothing should be missing from the banded set that matters.
+        for i in 0..n {
+            for j in 0..n {
+                if i.abs_diff(j) > 1 {
+                    assert!(
+                        dense[(i, j)].abs() < 1e-6,
+                        "unexpected nonzero outside the band at ({i},{j}): {}",
+                        dense[(i, j)]
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn adaptive_step_with_no_bandwidth_matches_theta_method_step_exactly() {
+        let n = 6;
+        let scenario = Scenario::single(
+            Box::new(TridiagonalDiffusion { diffusion: 0.5 }),
+            make_mesh(n),
+        );
+        let domain = scenario.single_domain().unwrap();
+        let requirements = scenario.context_requirements();
+        let chain = build_calculator_chain(&requirements, &[]).unwrap();
+
+        let mut state_a = domain.model.initial_state(domain.mesh.as_ref());
+        let mut state_b = state_a.clone();
+
+        let via_adaptive = theta_method_step_adaptive(
+            domain,
+            &chain,
+            &mut state_a,
+            0.0,
+            0.05,
+            1.0,
+            &NalgebraDenseSolver,
+            &PanicIfCalled,
+            100,
+            None, // no bandwidth declared -> dense path, unconditionally
+        )
+        .unwrap();
+
+        let via_plain =
+            theta_method_step(domain, &chain, &mut state_b, 0.0, 0.05, 1.0, &NalgebraDenseSolver)
+                .unwrap();
+
+        let a = via_adaptive.as_scalar_field().unwrap();
+        let b = via_plain.as_scalar_field().unwrap();
+        for i in 0..n {
+            assert!((a[i] - b[i]).abs() < 1e-12, "mismatch at {i}: {} vs {}", a[i], b[i]);
+        }
+    }
+
+    #[test]
+    fn small_system_stays_dense_even_with_bandwidth_declared() {
+        let n = 6; // below sparse_threshold below
+        let scenario = Scenario::single(
+            Box::new(TridiagonalDiffusion { diffusion: 0.5 }),
+            make_mesh(n),
+        );
+        let domain = scenario.single_domain().unwrap();
+        let requirements = scenario.context_requirements();
+        let chain = build_calculator_chain(&requirements, &[]).unwrap();
+        let mut state = domain.model.initial_state(domain.mesh.as_ref());
+
+        // PanicIfCalled proves the sparse path was never entered: bandwidth
+        // is declared (Some(1)) but n (6) does not exceed sparse_threshold
+        // (100), so the dense path must be taken regardless.
+        let result = theta_method_step_adaptive(
+            domain,
+            &chain,
+            &mut state,
+            0.0,
+            0.05,
+            1.0,
+            &NalgebraDenseSolver,
+            &PanicIfCalled,
+            100,
+            Some(1),
+        )
+        .unwrap();
+
+        assert!(result.as_scalar_field().unwrap().iter().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    fn adaptive_step_with_bandwidth_matches_dense_result_above_threshold() {
+        let n = 40; // above the small sparse_threshold used below
+        let diffusion = 0.3;
+        let dt = 0.02;
+
+        let scenario_a = Scenario::single(Box::new(TridiagonalDiffusion { diffusion }), make_mesh(n));
+        let domain_a = scenario_a.single_domain().unwrap();
+        let requirements_a = scenario_a.context_requirements();
+        let chain_a = build_calculator_chain(&requirements_a, &[]).unwrap();
+        let mut state_a = domain_a.model.initial_state(domain_a.mesh.as_ref());
+
+        let scenario_b = Scenario::single(Box::new(TridiagonalDiffusion { diffusion }), make_mesh(n));
+        let domain_b = scenario_b.single_domain().unwrap();
+        let requirements_b = scenario_b.context_requirements();
+        let chain_b = build_calculator_chain(&requirements_b, &[]).unwrap();
+        let mut state_b = domain_b.model.initial_state(domain_b.mesh.as_ref());
+
+        let via_sparse = theta_method_step_adaptive(
+            domain_a,
+            &chain_a,
+            &mut state_a,
+            0.0,
+            dt,
+            1.0,
+            &NalgebraDenseSolver,
+            &FaerSparseSolver,
+            10, // sparse_threshold well below n=40
+            Some(1),
+        )
+        .unwrap();
+
+        let via_dense =
+            theta_method_step(domain_b, &chain_b, &mut state_b, 0.0, dt, 1.0, &NalgebraDenseSolver)
+                .unwrap();
+
+        let a = via_sparse.as_scalar_field().unwrap();
+        let b = via_dense.as_scalar_field().unwrap();
+        for i in 0..n {
+            assert!(
+                (a[i] - b[i]).abs() < 1e-6,
+                "sparse/dense mismatch at {i}: {} vs {}",
+                a[i],
+                b[i]
+            );
         }
     }
 }

--- a/src/solver/methods/implicit.rs
+++ b/src/solver/methods/implicit.rs
@@ -302,11 +302,12 @@ pub(crate) fn theta_method_step_adaptive(
                 .collect();
 
             let system_matrix =
-                faer::sparse::SparseColMat::try_new_from_triplets(n, n, &system_triplets)
-                    .map_err(|e| OxiflowError::PreconditionFailed {
+                faer::sparse::SparseColMat::try_new_from_triplets(n, n, &system_triplets).map_err(
+                    |e| OxiflowError::PreconditionFailed {
                         context: "theta_method_step_adaptive",
                         message: format!("failed to build sparse system matrix: {e:?}"),
-                    })?;
+                    },
+                )?;
 
             let rhs = f_n_field * dt;
             let delta_u = sparse_solver.solve(&system_matrix, &rhs)?;
@@ -627,14 +628,26 @@ mod sparse_tests {
         )
         .unwrap();
 
-        let via_plain =
-            theta_method_step(domain, &chain, &mut state_b, 0.0, 0.05, 1.0, &NalgebraDenseSolver)
-                .unwrap();
+        let via_plain = theta_method_step(
+            domain,
+            &chain,
+            &mut state_b,
+            0.0,
+            0.05,
+            1.0,
+            &NalgebraDenseSolver,
+        )
+        .unwrap();
 
         let a = via_adaptive.as_scalar_field().unwrap();
         let b = via_plain.as_scalar_field().unwrap();
         for i in 0..n {
-            assert!((a[i] - b[i]).abs() < 1e-12, "mismatch at {i}: {} vs {}", a[i], b[i]);
+            assert!(
+                (a[i] - b[i]).abs() < 1e-12,
+                "mismatch at {i}: {} vs {}",
+                a[i],
+                b[i]
+            );
         }
     }
 
@@ -667,7 +680,11 @@ mod sparse_tests {
         )
         .unwrap();
 
-        assert!(result.as_scalar_field().unwrap().iter().all(|v| v.is_finite()));
+        assert!(result
+            .as_scalar_field()
+            .unwrap()
+            .iter()
+            .all(|v| v.is_finite()));
     }
 
     #[test]
@@ -676,13 +693,15 @@ mod sparse_tests {
         let diffusion = 0.3;
         let dt = 0.02;
 
-        let scenario_a = Scenario::single(Box::new(TridiagonalDiffusion { diffusion }), make_mesh(n));
+        let scenario_a =
+            Scenario::single(Box::new(TridiagonalDiffusion { diffusion }), make_mesh(n));
         let domain_a = scenario_a.single_domain().unwrap();
         let requirements_a = scenario_a.context_requirements();
         let chain_a = build_calculator_chain(&requirements_a, &[]).unwrap();
         let mut state_a = domain_a.model.initial_state(domain_a.mesh.as_ref());
 
-        let scenario_b = Scenario::single(Box::new(TridiagonalDiffusion { diffusion }), make_mesh(n));
+        let scenario_b =
+            Scenario::single(Box::new(TridiagonalDiffusion { diffusion }), make_mesh(n));
         let domain_b = scenario_b.single_domain().unwrap();
         let requirements_b = scenario_b.context_requirements();
         let chain_b = build_calculator_chain(&requirements_b, &[]).unwrap();
@@ -702,9 +721,16 @@ mod sparse_tests {
         )
         .unwrap();
 
-        let via_dense =
-            theta_method_step(domain_b, &chain_b, &mut state_b, 0.0, dt, 1.0, &NalgebraDenseSolver)
-                .unwrap();
+        let via_dense = theta_method_step(
+            domain_b,
+            &chain_b,
+            &mut state_b,
+            0.0,
+            dt,
+            1.0,
+            &NalgebraDenseSolver,
+        )
+        .unwrap();
 
         let a = via_sparse.as_scalar_field().unwrap();
         let b = via_dense.as_scalar_field().unwrap();

--- a/src/solver/methods/mod.rs
+++ b/src/solver/methods/mod.rs
@@ -302,7 +302,23 @@ pub trait SteppableSolver: Solver {
                 u = next;
             }
 
-            check_finite(&u, t_next)?;
+            if let Err(e) = check_finite(&u, t_next) {
+                self.on_divergence(&crate::solver::snapshot::SimulationSnapshot {
+                    time_config: config.time.clone(),
+                    integrator: config.integrator.clone(),
+                    state: u.clone(),
+                    t: t_next,
+                    n_steps: step + 1,
+                    error: Some(e.to_string()),
+                    partial: Some(SimulationResult {
+                        states: states.clone(),
+                        times: times.clone(),
+                        n_steps: step + 1,
+                        metadata: HashMap::new(),
+                    }),
+                });
+                return Err(e);
+            }
 
             if (step + 1) % save_every == 0 {
                 states.push(u.clone());

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -28,11 +28,13 @@ pub mod linear;
 pub mod methods;
 pub mod orchestrator;
 pub mod scenario;
+pub mod snapshot;
 #[cfg(feature = "sparse")]
 pub mod sparse;
 
 pub use config::{IntegratorKind, SolverConfiguration, StepControl, TimeConfiguration};
 pub use scenario::{Domain, DomainId, Scenario};
+pub use snapshot::SimulationSnapshot;
 
 use crate::context::error::OxiflowError;
 
@@ -58,7 +60,7 @@ use crate::context::error::OxiflowError;
 /// assert_eq!(result.states.len(), result.times.len());
 /// ```
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SimulationResult {
     /// Saved field states at each recorded time.

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -31,10 +31,14 @@ pub mod scenario;
 pub mod snapshot;
 #[cfg(feature = "sparse")]
 pub mod sparse;
+#[cfg(feature = "sparse")]
+pub mod spec;
 
 pub use config::{IntegratorKind, SolverConfiguration, StepControl, TimeConfiguration};
 pub use scenario::{Domain, DomainId, Scenario};
 pub use snapshot::SimulationSnapshot;
+#[cfg(feature = "sparse")]
+pub use spec::IntegratorSpec;
 
 use crate::context::error::OxiflowError;
 

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -92,6 +92,123 @@ impl SimulationResult {
     pub fn t_final(&self) -> Option<f64> {
         self.times.last().copied()
     }
+
+    /// Writes the **final** saved state to an XML VTK unstructured grid
+    /// (`.vtu`), for visualisation in ParaView/VisIt (DD-027, issue #78).
+    ///
+    /// Node coordinates come from `mesh`; nodes are connected by `Line`
+    /// cells in `Mesh` node order (`n_dof() - 1` segments), matching the
+    /// only mesh currently implemented (`UniformGrid1D`). Only `mesh.
+    /// spatial_dimension() == 1` is supported for this first increment —
+    /// coordinates are padded with zeros to the 3 components VTK requires.
+    ///
+    /// Exports the last entry of `states` only — not the full time series.
+    /// A `.pvd` time-series collection is future work, not part of this
+    /// increment (see #78's acceptance criteria, scoped to a single file).
+    ///
+    /// Requires the `vtk` feature.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OxiflowError::Persistence`] if: `states` is empty; `mesh`
+    /// has `spatial_dimension() != 1`; the last state is not a
+    /// [`crate::context::value::ContextValue::ScalarField`]; its length
+    /// doesn't match `mesh.n_dof()`; or the underlying `vtkio` export
+    /// fails.
+    #[cfg(feature = "vtk")]
+    pub fn write_vtk(
+        &self,
+        mesh: &dyn crate::mesh::Mesh,
+        path: &std::path::Path,
+    ) -> Result<(), OxiflowError> {
+        use crate::context::value::ContextValue;
+        use vtkio::model::{
+            Attribute, Attributes, ByteOrder, CellType, Cells, DataSet, IOBuffer,
+            UnstructuredGridPiece, Version, VertexNumbers, Vtk,
+        };
+
+        if mesh.spatial_dimension() != 1 {
+            return Err(OxiflowError::Persistence(format!(
+                "write_vtk currently only supports 1D meshes (Line cells), \
+                 got spatial_dimension() = {}",
+                mesh.spatial_dimension()
+            )));
+        }
+
+        let n = mesh.n_dof();
+        if n == 0 {
+            return Err(OxiflowError::Persistence(
+                "write_vtk: mesh has zero degrees of freedom".to_string(),
+            ));
+        }
+
+        let last_state = self.states.last().ok_or_else(|| {
+            OxiflowError::Persistence("write_vtk: SimulationResult has no saved states".to_string())
+        })?;
+        let values: Vec<f64> = match last_state {
+            ContextValue::ScalarField(v) => v.iter().copied().collect(),
+            other => {
+                return Err(OxiflowError::Persistence(format!(
+                    "write_vtk currently only supports ScalarField states, got {other:?}"
+                )));
+            }
+        };
+        if values.len() != n {
+            return Err(OxiflowError::Persistence(format!(
+                "write_vtk: state has {} values, mesh has {n} degrees of freedom",
+                values.len()
+            )));
+        }
+
+        // Node coordinates, padded to 3 components (VTK always stores 3D points).
+        let mut points = Vec::with_capacity(n * 3);
+        for i in 0..n {
+            let c = mesh.coordinates(i);
+            points.push(c[0]);
+            points.push(0.0);
+            points.push(0.0);
+        }
+
+        // Line cells connecting consecutive nodes; a single Vertex if n == 1.
+        let (connectivity, offsets, types) = if n >= 2 {
+            let mut connectivity = Vec::with_capacity((n - 1) * 2);
+            let mut offsets = Vec::with_capacity(n - 1);
+            for i in 0..n - 1 {
+                connectivity.push(i as u64);
+                connectivity.push((i + 1) as u64);
+                offsets.push(((i + 1) * 2) as u64);
+            }
+            (connectivity, offsets, vec![CellType::Line; n - 1])
+        } else {
+            (vec![0u64], vec![1u64], vec![CellType::Vertex])
+        };
+
+        let mut attributes = Attributes::new();
+        attributes
+            .point
+            .push(Attribute::scalars("field", 1).with_data(IOBuffer::F64(values)));
+
+        let vtk = Vtk {
+            version: Version::new((2, 0)),
+            title: String::from("oxiflow SimulationResult"),
+            byte_order: ByteOrder::BigEndian,
+            file_path: Some(path.to_path_buf()),
+            data: DataSet::inline(UnstructuredGridPiece {
+                points: IOBuffer::F64(points),
+                cells: Cells {
+                    cell_verts: VertexNumbers::XML {
+                        connectivity,
+                        offsets,
+                    },
+                    types,
+                },
+                data: attributes,
+            }),
+        };
+
+        vtk.export(path)
+            .map_err(|e| OxiflowError::Persistence(format!("VTK export failed: {e}")))
+    }
 }
 
 // ── Solver trait ──────────────────────────────────────────────────────────────
@@ -187,5 +304,96 @@ mod tests {
     fn solver_is_object_safe() {
         fn assert_object_safe<T: Solver + ?Sized>() {}
         assert_object_safe::<dyn Solver>();
+    }
+
+    // ── write_vtk ─────────────────────────────────────────────────────────────
+
+    #[cfg(feature = "vtk")]
+    #[test]
+    fn write_vtk_round_trip() {
+        use crate::mesh::structured::UniformGrid1D;
+
+        let mesh = UniformGrid1D::new(5, 0.0, 4.0).unwrap();
+        let result = SimulationResult {
+            states: vec![ContextValue::ScalarField(DVector::from_vec(vec![
+                0.0, 1.0, 2.0, 1.0, 0.0,
+            ]))],
+            times: vec![0.4],
+            n_steps: 4,
+            metadata: std::collections::HashMap::new(),
+        };
+
+        let path = std::env::temp_dir().join("oxiflow_test_write_vtk_round_trip.vtu");
+        result.write_vtk(&mesh, &path).unwrap();
+
+        // Round-trip: re-parse the file and check the point-data values match.
+        let reimported = vtkio::model::Vtk::import(&path).unwrap();
+        let vtkio::model::DataSet::UnstructuredGrid { pieces, .. } = reimported.data else {
+            panic!("expected an UnstructuredGrid dataset");
+        };
+        let piece = pieces[0]
+            .load_piece_data(None)
+            .expect("failed to load piece data");
+        assert_eq!(piece.points.len(), 5 * 3); // n_dof * 3 components
+        let field = piece
+            .data
+            .point
+            .iter()
+            .find(|a| a.name() == "field")
+            .expect("missing 'field' point attribute");
+        let vtkio::model::Attribute::DataArray(da) = field else {
+            panic!("expected a DataArray attribute");
+        };
+        let values: Vec<f64> = da.data.clone().cast_into().unwrap();
+        assert_eq!(values, vec![0.0, 1.0, 2.0, 1.0, 0.0]);
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[cfg(feature = "vtk")]
+    #[test]
+    fn write_vtk_rejects_2d_mesh() {
+        struct FakeMesh2D;
+        impl crate::mesh::Mesh for FakeMesh2D {
+            fn n_dof(&self) -> usize {
+                1
+            }
+            fn coordinates(&self, _i: usize) -> &[f64] {
+                &[0.0, 0.0]
+            }
+            fn spatial_dimension(&self) -> usize {
+                2
+            }
+            fn characteristic_length(&self) -> f64 {
+                1.0
+            }
+        }
+
+        let result = SimulationResult {
+            states: vec![ContextValue::ScalarField(DVector::from_element(1, 0.0))],
+            times: vec![0.0],
+            n_steps: 0,
+            metadata: std::collections::HashMap::new(),
+        };
+        let path = std::env::temp_dir().join("oxiflow_test_write_vtk_rejects_2d.vtu");
+        let result = result.write_vtk(&FakeMesh2D, &path);
+        assert!(matches!(result, Err(OxiflowError::Persistence(_))));
+    }
+
+    #[cfg(feature = "vtk")]
+    #[test]
+    fn write_vtk_rejects_empty_states() {
+        use crate::mesh::structured::UniformGrid1D;
+
+        let mesh = UniformGrid1D::new(3, 0.0, 1.0).unwrap();
+        let result = SimulationResult {
+            states: vec![],
+            times: vec![],
+            n_steps: 0,
+            metadata: std::collections::HashMap::new(),
+        };
+        let path = std::env::temp_dir().join("oxiflow_test_write_vtk_rejects_empty.vtu");
+        let outcome = result.write_vtk(&mesh, &path);
+        assert!(matches!(outcome, Err(OxiflowError::Persistence(_))));
     }
 }

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -123,6 +123,18 @@ pub trait Solver: Send + Sync {
         scenario: &Scenario,
         config: &SolverConfiguration,
     ) -> Result<SimulationResult, OxiflowError>;
+
+    /// Called automatically right before a [`OxiflowError::SolverDivergence`]
+    /// is returned, with a [`SimulationSnapshot`] capturing the physical
+    /// state at the point of divergence (DD-025 Option B, issue #71).
+    ///
+    /// Default implementation is a no-op — override to persist (e.g. via
+    /// [`snapshot::write_snapshot`]) or log. There is no `checkpoint()`
+    /// counterpart on this trait; see the [`snapshot`] module docs for why
+    /// explicit checkpoints are constructed directly by caller code instead.
+    fn on_divergence(&self, snapshot: &snapshot::SimulationSnapshot) {
+        let _ = snapshot;
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -28,6 +28,8 @@ pub mod linear;
 pub mod methods;
 pub mod orchestrator;
 pub mod scenario;
+#[cfg(feature = "sparse")]
+pub mod sparse;
 
 pub use config::{IntegratorKind, SolverConfiguration, StepControl, TimeConfiguration};
 pub use scenario::{Domain, DomainId, Scenario};

--- a/src/solver/snapshot.rs
+++ b/src/solver/snapshot.rs
@@ -1,0 +1,239 @@
+//! # Module `solver::snapshot`
+//!
+//! Serialisable snapshot of a simulation's physical state, for post-mortem
+//! divergence analysis and normal pause/resume (DD-025 Option B, issue #71 ;
+//! generalised by DD-029, issue #77).
+//!
+//! ## Two-phase restore contract (DD-025)
+//!
+//! `SimulationSnapshot` captures only the **physical state** (`ContextValue`,
+//! the temporal configuration in effect, and the integration method used) —
+//! never `Scenario`/`Domain`, which hold `Box<dyn Trait>` fields and are not
+//! serialisable. Restoring a run is a two-phase contract: oxiflow supplies
+//! the physical state via this type; the caller reconstructs
+//! `Domain`/`Scenario`/`SolverConfiguration` themselves and re-injects the
+//! state as the initial condition.
+//!
+//! ## Two triggers, one type (DD-029)
+//!
+//! - **Automatic** — [`Solver::on_divergence`](super::Solver::on_divergence)
+//!   is called with a snapshot right before a [`OxiflowError::SolverDivergence`]
+//!   is returned. Default implementation is a no-op; override to persist.
+//! - **Explicit** — normal pause/resume checkpointing. There is no
+//!   `Solver::checkpoint()` method: every field of `SimulationSnapshot` is
+//!   already public, and the live physical state (`ContextValue`, `t`,
+//!   `n_steps`) only exists in the caller's own loop when driving
+//!   [`SteppableSolver::step`](super::methods::SteppableSolver::step)
+//!   directly — `Solver::solve()` is a single blocking call with no
+//!   externally reachable state to hand a trait method. Callers construct
+//!   `SimulationSnapshot` directly instead (see example below).
+//!
+//! # Examples
+//!
+//! ```rust
+//! use oxiflow::solver::snapshot::SimulationSnapshot;
+//! use oxiflow::solver::config::{IntegratorKind, StepControl, TimeConfiguration};
+//! use oxiflow::context::value::ContextValue;
+//! use nalgebra::DVector;
+//!
+//! // Explicit checkpoint, constructed directly by caller code driving its
+//! // own `SteppableSolver::step()` loop — no trait method involved.
+//! let snapshot = SimulationSnapshot {
+//!     time_config: TimeConfiguration::new(600.0, StepControl::Fixed { dt: 0.1 }),
+//!     integrator:  IntegratorKind::BackwardEuler,
+//!     state:       ContextValue::ScalarField(DVector::from_element(10, 0.0)),
+//!     t:           12.3,
+//!     n_steps:     123,
+//!     error:       None,
+//!     partial:     None,
+//! };
+//! assert_eq!(snapshot.t, 12.3);
+//! ```
+
+#[cfg(feature = "serde")]
+use crate::context::error::OxiflowError;
+use crate::context::value::ContextValue;
+use crate::solver::config::{IntegratorKind, TimeConfiguration};
+use crate::solver::SimulationResult;
+
+// ── SimulationSnapshot ──────────────────────────────────────────────────────────
+
+/// Serialisable snapshot of a simulation's physical state.
+///
+/// See the [module docs](self) for the two-phase restore contract and the
+/// two triggers (`on_divergence` automatic, explicit checkpoint constructed
+/// directly).
+///
+/// Deliberately **not** `#[non_exhaustive]`: the whole point of not having a
+/// `Solver::checkpoint()` method is that callers construct this struct
+/// directly via its public fields (see module docs) — `#[non_exhaustive]`
+/// would block exactly that from outside this crate.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SimulationSnapshot {
+    /// Serialisable temporal configuration in effect when the snapshot was
+    /// taken.
+    pub time_config: TimeConfiguration,
+    /// Integration method in effect when the snapshot was taken.
+    pub integrator: IntegratorKind,
+    /// Physical state at snapshot time.
+    pub state: ContextValue,
+    /// Simulation time at snapshot.
+    pub t: f64,
+    /// Number of time steps taken up to the snapshot.
+    pub n_steps: usize,
+    /// Populated on failure — error message for post-mortem analysis.
+    /// `None` for a normal explicit checkpoint.
+    pub error: Option<String>,
+    /// Partial result up to the snapshot point, if available.
+    pub partial: Option<SimulationResult>,
+}
+
+// ── File format ──────────────────────────────────────────────────────────────
+
+/// On-disk format for [`write_snapshot`] / [`read_snapshot`].
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotFormat {
+    /// Human-readable JSON (`serde_json`) — intended for debugging.
+    Json,
+    /// Native binary format (`bincode` 1.x) — fidelity and speed, the
+    /// recommended default for `on_divergence`/checkpoint round-trips.
+    Bincode,
+}
+
+/// Writes `snapshot` to `path` in the given [`SnapshotFormat`].
+///
+/// Requires the `serde` feature.
+///
+/// # Errors
+///
+/// Returns [`OxiflowError::Persistence`] if the file cannot be created or
+/// written, or if serialisation fails.
+#[cfg(feature = "serde")]
+pub fn write_snapshot(
+    snapshot: &SimulationSnapshot,
+    path: &std::path::Path,
+    format: SnapshotFormat,
+) -> Result<(), OxiflowError> {
+    match format {
+        SnapshotFormat::Json => {
+            let file = std::fs::File::create(path)
+                .map_err(|e| OxiflowError::Persistence(format!("cannot create {path:?}: {e}")))?;
+            serde_json::to_writer_pretty(file, snapshot)
+                .map_err(|e| OxiflowError::Persistence(format!("JSON serialisation failed: {e}")))
+        }
+        SnapshotFormat::Bincode => {
+            let bytes = bincode::serialize(snapshot).map_err(|e| {
+                OxiflowError::Persistence(format!("bincode serialisation failed: {e}"))
+            })?;
+            std::fs::write(path, bytes)
+                .map_err(|e| OxiflowError::Persistence(format!("cannot write {path:?}: {e}")))
+        }
+    }
+}
+
+/// Reads a [`SimulationSnapshot`] previously written by [`write_snapshot`].
+///
+/// Requires the `serde` feature.
+///
+/// # Errors
+///
+/// Returns [`OxiflowError::Persistence`] if the file cannot be read or if
+/// deserialisation fails.
+#[cfg(feature = "serde")]
+pub fn read_snapshot(
+    path: &std::path::Path,
+    format: SnapshotFormat,
+) -> Result<SimulationSnapshot, OxiflowError> {
+    match format {
+        SnapshotFormat::Json => {
+            let file = std::fs::File::open(path)
+                .map_err(|e| OxiflowError::Persistence(format!("cannot open {path:?}: {e}")))?;
+            serde_json::from_reader(file)
+                .map_err(|e| OxiflowError::Persistence(format!("JSON deserialisation failed: {e}")))
+        }
+        SnapshotFormat::Bincode => {
+            let bytes = std::fs::read(path)
+                .map_err(|e| OxiflowError::Persistence(format!("cannot read {path:?}: {e}")))?;
+            bincode::deserialize(&bytes).map_err(|e| {
+                OxiflowError::Persistence(format!("bincode deserialisation failed: {e}"))
+            })
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::solver::config::StepControl;
+    use nalgebra::DVector;
+
+    fn sample_snapshot() -> SimulationSnapshot {
+        SimulationSnapshot {
+            time_config: TimeConfiguration::new(10.0, StepControl::Fixed { dt: 0.1 }),
+            integrator: IntegratorKind::BackwardEuler,
+            state: ContextValue::ScalarField(DVector::from_element(5, 1.5)),
+            t: 3.4,
+            n_steps: 34,
+            error: Some("non-finite value detected in state vector".to_string()),
+            partial: None,
+        }
+    }
+
+    #[test]
+    fn snapshot_fields_accessible() {
+        let s = sample_snapshot();
+        assert_eq!(s.t, 3.4);
+        assert_eq!(s.n_steps, 34);
+        assert!(s.error.is_some());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn json_round_trip() {
+        let dir = tempdir();
+        let path = dir.join("snapshot.json");
+        let original = sample_snapshot();
+
+        write_snapshot(&original, &path, SnapshotFormat::Json).unwrap();
+        let restored = read_snapshot(&path, SnapshotFormat::Json).unwrap();
+
+        assert_eq!(restored.t, original.t);
+        assert_eq!(restored.n_steps, original.n_steps);
+        assert_eq!(restored.error, original.error);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn bincode_round_trip() {
+        let dir = tempdir();
+        let path = dir.join("snapshot.bin");
+        let original = sample_snapshot();
+
+        write_snapshot(&original, &path, SnapshotFormat::Bincode).unwrap();
+        let restored = read_snapshot(&path, SnapshotFormat::Bincode).unwrap();
+
+        assert_eq!(restored.t, original.t);
+        assert_eq!(restored.n_steps, original.n_steps);
+        assert_eq!(restored.error, original.error);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn read_snapshot_missing_file_is_persistence_error() {
+        let path = std::path::PathBuf::from("/nonexistent/path/snapshot.json");
+        let err = read_snapshot(&path, SnapshotFormat::Json).unwrap_err();
+        assert!(matches!(err, OxiflowError::Persistence(_)));
+    }
+
+    /// Returns the system temp dir — no external crate needed for this.
+    #[cfg(feature = "serde")]
+    fn tempdir() -> std::path::PathBuf {
+        std::env::temp_dir()
+    }
+}

--- a/src/solver/sparse.rs
+++ b/src/solver/sparse.rs
@@ -42,6 +42,7 @@
 //! variant, so a signature mismatch there is the most likely first
 //! compile error.
 
+use faer::prelude::Solve;
 use nalgebra::DVector;
 
 use crate::context::error::OxiflowError;

--- a/src/solver/sparse.rs
+++ b/src/solver/sparse.rs
@@ -1,0 +1,193 @@
+//! # Module `solver::sparse`
+//!
+//! Sparse linear system solver abstraction — DD-013 (second phase), DD-043.
+//!
+//! **`#[cfg(feature = "sparse")]` only** — this module does not exist in a
+//! build without the `sparse` feature, and links no `faer` code in that
+//! case (zero overhead for the cas simple, same posture as `parallel`/
+//! `serde`/`hdf5`).
+//!
+//! ## Why a sibling trait, not an extension of `LinearSolver`
+//!
+//! [`crate::solver::linear::LinearSolver::solve`] takes `&DMatrix<f64>` — a
+//! dense `nalgebra` type. `faer`'s sparse column matrix
+//! (`faer::sparse::SparseColMat`) is structurally incompatible with
+//! `DMatrix` without a conversion that would erase the memory benefit
+//! sparsity exists to provide in the first place. `SparseLinearSolver`
+//! therefore has its own `solve()` signature over the sparse type — the
+//! same posture as [`crate::operators::FluxDivergenceOperator`] relative to
+//! [`crate::operators::DiscreteOperator`] (DD-039): a sibling trait when
+//! the two signatures genuinely diverge, not a sub-trait forcing one onto
+//! the other (DD-043, "Décision — forme du trait", option C).
+//!
+//! `b` and the return value stay `nalgebra::DVector<f64>` — consistent with
+//! the rest of the codebase; converting to/from `faer`'s own vector
+//! representation is the implementation's job ([`FaerSparseSolver`]), a
+//! negligible cost next to the sparse factorization itself.
+//!
+//! ## Verification status
+//!
+//! **Written without a working Rust toolchain for the `sparse` feature** —
+//! this environment's `rustc`/`cargo` cannot resolve `faer`'s own
+//! dependency graph (`edition2024` requirement upstream, unavailable
+//! here). The exact `faer` 0.24 API surface used below (method names,
+//! error types, `Triplet` construction) is transcribed from the
+//! architecture notes carried over from the interrupted session
+//! (`prompt_next_session.md`) and general `faer` familiarity, **not
+//! confirmed against a real compile**. Before relying on this module:
+//! `cargo doc --open -p faer --features sparse` (or the docs.rs page for
+//! `faer` 0.24) to check `SparseColMat::try_new_from_triplets`, `Triplet`,
+//! `sp_lu()`'s error type in particular — this file treats that error as
+//! `impl Debug` via `{e:?}` deliberately, never matched on a specific
+//! variant, so a signature mismatch there is the most likely first
+//! compile error.
+
+use nalgebra::DVector;
+
+use crate::context::error::OxiflowError;
+
+/// Solves a sparse linear system `A * x = b`.
+///
+/// Sibling to [`crate::solver::linear::LinearSolver`] — see the module docs
+/// for why this is a separate trait rather than an extension.
+pub trait SparseLinearSolver: Send + Sync {
+    /// Solves `a * x = b` for `x`, where `a` is stored in a sparse format.
+    ///
+    /// # Errors
+    ///
+    /// Returns `OxiflowError::PreconditionFailed` if the factorization
+    /// fails (singular or near-singular system).
+    fn solve(
+        &self,
+        a: &faer::sparse::SparseColMat<usize, f64>,
+        b: &DVector<f64>,
+    ) -> Result<DVector<f64>, OxiflowError>;
+}
+
+/// Default sparse backend — LU factorization via `faer`.
+///
+/// Tested standalone against systems built directly in sparse form (e.g. a
+/// tridiagonal system assembled as triplets) — not through
+/// `solver::methods::implicit`'s finite-difference jacobian, which stays
+/// dense (DD-043: banded assembly is a separate, later addition).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FaerSparseSolver;
+
+impl SparseLinearSolver for FaerSparseSolver {
+    fn solve(
+        &self,
+        a: &faer::sparse::SparseColMat<usize, f64>,
+        b: &DVector<f64>,
+    ) -> Result<DVector<f64>, OxiflowError> {
+        let n = b.len();
+        if a.nrows() != n || a.ncols() != n {
+            return Err(OxiflowError::PreconditionFailed {
+                context: "FaerSparseSolver",
+                message: format!(
+                    "dimension mismatch: a is {}x{}, b has length {n}",
+                    a.nrows(),
+                    a.ncols()
+                ),
+            });
+        }
+
+        // faer's own column vector type — b converted in, x converted back
+        // out to nalgebra::DVector at the end. See module docs: this
+        // conversion is unverified against a real faer 0.24 build.
+        let b_faer = faer::Col::from_fn(n, |i| b[i]);
+
+        let lu = a.sp_lu().map_err(|e| OxiflowError::PreconditionFailed {
+            context: "FaerSparseSolver",
+            message: format!(
+                "sparse LU factorization failed (singular or near-singular system): {e:?}"
+            ),
+        })?;
+
+        let x_faer = lu.solve(&b_faer);
+
+        Ok(DVector::from_fn(n, |i, _| x_faer[i]))
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+//
+// Unverified by compilation (see module docs) — a first draft to check
+// against a real `faer` 0.24 build before trusting these pass.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faer::sparse::{SparseColMat, Triplet};
+
+    /// Builds an `n x n` tridiagonal system `[-1, 2, -1]` (a standard
+    /// discrete-Laplacian-like test matrix) directly in sparse form.
+    fn tridiagonal(n: usize) -> SparseColMat<usize, f64> {
+        let mut triplets = Vec::with_capacity(3 * n);
+        for i in 0..n {
+            triplets.push(Triplet::new(i, i, 2.0));
+            if i > 0 {
+                triplets.push(Triplet::new(i, i - 1, -1.0));
+            }
+            if i + 1 < n {
+                triplets.push(Triplet::new(i, i + 1, -1.0));
+            }
+        }
+        SparseColMat::try_new_from_triplets(n, n, &triplets)
+            .expect("valid triplets for a tridiagonal system")
+    }
+
+    #[test]
+    fn solves_small_tridiagonal_system() {
+        let n = 5;
+        let a = tridiagonal(n);
+        let b = DVector::from_element(n, 1.0);
+        let x = FaerSparseSolver.solve(&a, &b).unwrap();
+
+        // Residual check rather than a hand-derived closed form — robust to
+        // the exact API details above being slightly off in a way that
+        // still produces a self-consistent solve.
+        for i in 0..n {
+            let mut residual = 2.0 * x[i];
+            if i > 0 {
+                residual -= x[i - 1];
+            }
+            if i + 1 < n {
+                residual -= x[i + 1];
+            }
+            assert!(
+                (residual - b[i]).abs() < 1e-9,
+                "residual too large at row {i}: {residual} vs {}",
+                b[i]
+            );
+        }
+    }
+
+    #[test]
+    fn solves_500x500_tridiagonal_system() {
+        // Acceptance criterion from #50: faer-sparse solves Ax=b for a
+        // 500x500 tridiagonal system.
+        let n = 500;
+        let a = tridiagonal(n);
+        let b = DVector::from_element(n, 1.0);
+        let x = FaerSparseSolver.solve(&a, &b).unwrap();
+
+        for i in 0..n {
+            let mut residual = 2.0 * x[i];
+            if i > 0 {
+                residual -= x[i - 1];
+            }
+            if i + 1 < n {
+                residual -= x[i + 1];
+            }
+            assert!((residual - b[i]).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn dimension_mismatch_returns_error() {
+        let a = tridiagonal(5);
+        let b = DVector::from_element(3, 1.0);
+        let err = FaerSparseSolver.solve(&a, &b).unwrap_err();
+        assert!(matches!(err, OxiflowError::PreconditionFailed { .. }));
+    }
+}

--- a/src/solver/spec.rs
+++ b/src/solver/spec.rs
@@ -1,0 +1,160 @@
+//! # Module `solver::spec`
+//!
+//! External, serialisable DTO describing *which* integration method to
+//! build and with what parameters — the HOW-axis config-loading increment
+//! of DD-027 amendment 1 (issue #104).
+//!
+//! ## Not `IntegratorKind`
+//!
+//! [`IntegratorSpec`] is deliberately a separate type from
+//! [`super::IntegratorKind`]. The latter is a pure descriptive label,
+//! already carried by [`super::SolverConfiguration`] and
+//! [`super::snapshot::SimulationSnapshot`] — it is never consumed to
+//! *build* a solver. `IntegratorSpec` exists specifically to be consumed:
+//! [`TryFrom<IntegratorSpec> for Box<dyn Solver>`](TryFrom) bridges it to
+//! the existing `BackwardEulerSolver` builder, with no duplicated
+//! construction logic. Naming history: this type was called `SolverConfig`
+//! in issue #104's original body — renamed before implementation to avoid
+//! colliding with [`super::SolverConfiguration`], which already covers the
+//! full HOW pole (`TimeConfiguration` + calculators); see #104's closing
+//! comment for the rationale.
+//!
+//! ## Scope of this first increment
+//!
+//! Only [`IntegratorSpec::BackwardEuler`], covering the DD-043 (#50) sparse
+//! dispatch path — this whole module is gated behind the `sparse` feature:
+//! without it, a config DTO for `BackwardEuler` adds nothing over the
+//! existing [`super::IntegratorKind::BackwardEuler`] label, since the dense
+//! path takes no parameters. Remaining integrators (`RK4`, `CrankNicolson`,
+//! `BDF2`, `DoPri45`) and the WHAT axis (`ModelConfig`/`MeshConfig`/
+//! `BoundaryConditionConfig`) are tracked as follow-up, not blocking this
+//! issue's closure (per #104's own stated scope).
+//!
+//! The sparse backend itself is always [`FaerSparseSolver`] — a fixed,
+//! non-configurable choice: `Box<dyn SparseLinearSolver>` is a trait
+//! object and cannot be deserialised, so there is no way for a config file
+//! to name an arbitrary backend (see #104's discussion of this
+//! constraint).
+
+use super::methods::backward_euler::BackwardEulerSolver;
+use super::sparse::FaerSparseSolver;
+use super::Solver;
+use crate::context::error::OxiflowError;
+
+/// External DTO describing which integrator to build and with what
+/// parameters. See the [module docs](self) for why this is not
+/// `IntegratorKind`, and for this increment's deliberately narrow scope.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+pub enum IntegratorSpec {
+    /// Backward Euler (DD-... implicit method), optionally dispatching to
+    /// the sparse linear solver path (DD-043, #50) above `sparse_threshold`
+    /// once `jacobian_bandwidth` is also supplied. The sparse backend
+    /// itself is always [`FaerSparseSolver`] (see [module docs](self)).
+    BackwardEuler {
+        /// System size above which the sparse path is used — see
+        /// [`BackwardEulerSolver::with_sparse_threshold`].
+        #[cfg_attr(feature = "serde", serde(default = "default_sparse_threshold"))]
+        sparse_threshold: usize,
+        /// Half-bandwidth of the Jacobian (e.g. `scheme.stencil_radius()`,
+        /// DD-039) — see [`BackwardEulerSolver::with_jacobian_bandwidth`].
+        /// `None` keeps the dense path regardless of `sparse_threshold`.
+        #[cfg_attr(feature = "serde", serde(default))]
+        jacobian_bandwidth: Option<usize>,
+    },
+}
+
+/// Default for `sparse_threshold` when omitted from a deserialised config.
+///
+/// Duplicates the literal `100` from `BackwardEulerSolver`'s private
+/// `Default` impl (`backward_euler.rs`) — that field isn't publicly
+/// readable, so this can't delegate to it directly. If that default ever
+/// changes, update this constant too.
+#[cfg(feature = "serde")]
+fn default_sparse_threshold() -> usize {
+    100
+}
+
+impl TryFrom<IntegratorSpec> for Box<dyn Solver> {
+    type Error = OxiflowError;
+
+    fn try_from(spec: IntegratorSpec) -> Result<Self, Self::Error> {
+        match spec {
+            IntegratorSpec::BackwardEuler {
+                sparse_threshold,
+                jacobian_bandwidth,
+            } => {
+                let mut solver = BackwardEulerSolver::new().with_sparse_threshold(sparse_threshold);
+                if let Some(bandwidth) = jacobian_bandwidth {
+                    solver = solver
+                        .with_jacobian_bandwidth(bandwidth)
+                        .with_sparse_solver(Box::new(FaerSparseSolver));
+                }
+                Ok(Box::new(solver))
+            }
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dense_path_when_no_jacobian_bandwidth() {
+        let spec = IntegratorSpec::BackwardEuler {
+            sparse_threshold: 100,
+            jacobian_bandwidth: None,
+        };
+        let solver: Box<dyn Solver> = spec.try_into().unwrap();
+        // Object-safety + successful construction is the assertion here —
+        // BackwardEulerSolver's internal sparse_solver field is private,
+        // not observable from outside the crate.
+        let _ = solver;
+    }
+
+    #[test]
+    fn sparse_path_when_jacobian_bandwidth_given() {
+        let spec = IntegratorSpec::BackwardEuler {
+            sparse_threshold: 50,
+            jacobian_bandwidth: Some(3),
+        };
+        let solver: Box<dyn Solver> = spec.try_into().unwrap();
+        let _ = solver;
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialises_with_defaults() {
+        let json = r#"{ "BackwardEuler": {} }"#;
+        let spec: IntegratorSpec = serde_json::from_str(json).unwrap();
+        match spec {
+            IntegratorSpec::BackwardEuler {
+                sparse_threshold,
+                jacobian_bandwidth,
+            } => {
+                assert_eq!(sparse_threshold, default_sparse_threshold());
+                assert_eq!(jacobian_bandwidth, None);
+            }
+        }
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialises_explicit_fields() {
+        let json = r#"{ "BackwardEuler": { "sparse_threshold": 42, "jacobian_bandwidth": 2 } }"#;
+        let spec: IntegratorSpec = serde_json::from_str(json).unwrap();
+        match spec {
+            IntegratorSpec::BackwardEuler {
+                sparse_threshold,
+                jacobian_bandwidth,
+            } => {
+                assert_eq!(sparse_threshold, 42);
+                assert_eq!(jacobian_bandwidth, Some(2));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Merges the validated `staging` branch (see `update → staging` PR for the detailed per-issue breakdown) into `main` ahead of the `v0.6.0` tag.

## Checklist
- [x] `Cargo.toml` version bumped to `0.6.0`
- [x] `CHANGELOG.md` — `[Unreleased]` renamed to `[0.6.0] — 2026-07-21`
- [x] `README.md` — Development Status / Feature Flags tables current
- [x] Full CI green on `staging` (already validated — see linked PR)
- [x] No open blocking issues on the `v0.6.0 — Sparse Linear Algebra &  Persistence` milestone