### PR TITLE
Release v0.7.0 — Nonlinear Time Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ oxiflow adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Dedicated test for the perturbed-Jacobian × Dirichlet boundary-condition
+  interaction, closing a known-untested gap documented since DD-033
+  (v0.4.0): the constrained node's column in `finite_difference_jacobian`
+  is exactly zero, while its row keeps genuine physics-based coupling to
+  unconstrained neighbours (#113)
 - `IntegratorSpec::BDF2` variant — Newton fields only, deliberately no
   sparse fields (`BDF2Solver` has no sparse builders to map, a DD-043 gap
   distinct from this DTO increment) (DD-044, #116)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ oxiflow adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `BDF2Solver` gains `with_newton_convergence()`, `with_jacobian_strategy()`,
+  `with_max_newton_iterations()` builders; `bdf2_step_newton()`
+  (`solver::methods::bdf2`) routes through the generic Newton loop with
+  caller-supplied configuration — defaults reproduce the pre-DD-044
+  single-correction behaviour exactly on affine problems. The
+  startup/bootstrap step is unaffected: it always uses
+  `theta_method_step()`'s non-configurable path (DD-044, #109, #112)
 - `BackwardEulerSolver`/`CrankNicolsonSolver` gain `with_newton_convergence()`,
   `with_jacobian_strategy()`, `with_max_newton_iterations()` builders;
   `theta_method_step_newton()` (`solver::methods::implicit`) routes through
@@ -20,24 +27,24 @@ oxiflow adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Iterated Newton solver core (`solver::methods::newton`): `NewtonConvergence`
   (`ResidualOnly`/`CombinedOr`/`CombinedAnd`), `JacobianStrategy`
   (`ModifiedFrozen`/`FullNewton`/`ModifiedWithStagnationCheck`), and the
-  generic convergence loop shared by theta-method and BDF2 — not yet wired
-  into `BDF2Solver` (DD-044, #109, #110)
+  generic convergence loop shared by theta-method and BDF2 (DD-044, #109,
+  #110)
 - `OxiflowError::NewtonNotConverged { iterations, residual }` — routed
   through `Solver::on_divergence()` once wired (#110)
 
 ### Changed
 
 - Introduced `stiff_jacobian_convergence()` (`solver::methods::implicit`,
-  `tol_abs = 1e-5`), used by `theta_method_step()` and by
-  `BackwardEulerSolver`/`CrankNicolsonSolver`'s zero-config constructors —
-  distinct from `NewtonConvergence::default()` (unchanged, `tol_abs =
-  1e-8`). The existing very-stiff (`λ = 1e4`) affine regression tests'
-  single Newton correction is exact, but its finite-difference Jacobian
-  carries catastrophic-cancellation error of that order — a precision
-  floor, not a nonlinearity signal; zero-config solver construction needs
-  the looser value to keep reproducing history exactly, without loosening
-  what `NewtonConvergence::default()` means for callers configuring the
-  loop themselves (#111)
+  `tol_abs = 1e-5`), used by `theta_method_step()`/`bdf2_step()` and by
+  `BackwardEulerSolver`/`CrankNicolsonSolver`/`BDF2Solver`'s zero-config
+  constructors — distinct from `NewtonConvergence::default()` (unchanged,
+  `tol_abs = 1e-8`). The existing very-stiff (`λ = 1e4`) affine regression
+  tests' single Newton correction is exact, but its finite-difference
+  Jacobian carries catastrophic-cancellation error of that order — a
+  precision floor, not a nonlinearity signal; zero-config solver
+  construction needs the looser value to keep reproducing history exactly,
+  without loosening what `NewtonConvergence::default()` means for callers
+  configuring the loop themselves (#111, #112)
 
 ### Known gaps
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ oxiflow adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `IntegratorSpec::BackwardEuler` gains `newton_convergence`,
+  `jacobian_strategy`, `max_iterations` fields (`serde` feature), mapped to
+  `BackwardEulerSolver`'s three Newton builders via `TryFrom`; defaults
+  match the solver's own zero-config values (DD-044, #114)
+- `NewtonConvergence`/`JacobianStrategy` gain `serde::Deserialize` under
+  the `serde` feature (#114)
 - `BDF2Solver` gains `with_newton_convergence()`, `with_jacobian_strategy()`,
   `with_max_newton_iterations()` builders; `bdf2_step_newton()`
   (`solver::methods::bdf2`) routes through the generic Newton loop with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,40 @@ oxiflow adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `BackwardEulerSolver`/`CrankNicolsonSolver` gain `with_newton_convergence()`,
+  `with_jacobian_strategy()`, `with_max_newton_iterations()` builders;
+  `theta_method_step_newton()` (`solver::methods::implicit`) routes through
+  the generic Newton loop with caller-supplied configuration — defaults
+  reproduce the pre-DD-044 single-correction behaviour exactly on affine
+  problems (DD-044, #109, #111)
 - Iterated Newton solver core (`solver::methods::newton`): `NewtonConvergence`
   (`ResidualOnly`/`CombinedOr`/`CombinedAnd`), `JacobianStrategy`
   (`ModifiedFrozen`/`FullNewton`/`ModifiedWithStagnationCheck`), and the
   generic convergence loop shared by theta-method and BDF2 — not yet wired
-  into `BackwardEulerSolver`/`CrankNicolsonSolver`/`BDF2Solver` (DD-044, #109,
-  #110)
+  into `BDF2Solver` (DD-044, #109, #110)
 - `OxiflowError::NewtonNotConverged { iterations, residual }` — routed
   through `Solver::on_divergence()` once wired (#110)
+
+### Changed
+
+- Introduced `stiff_jacobian_convergence()` (`solver::methods::implicit`,
+  `tol_abs = 1e-5`), used by `theta_method_step()` and by
+  `BackwardEulerSolver`/`CrankNicolsonSolver`'s zero-config constructors —
+  distinct from `NewtonConvergence::default()` (unchanged, `tol_abs =
+  1e-8`). The existing very-stiff (`λ = 1e4`) affine regression tests'
+  single Newton correction is exact, but its finite-difference Jacobian
+  carries catastrophic-cancellation error of that order — a precision
+  floor, not a nonlinearity signal; zero-config solver construction needs
+  the looser value to keep reproducing history exactly, without loosening
+  what `NewtonConvergence::default()` means for callers configuring the
+  loop themselves (#111)
+
+### Known gaps
+
+- `theta_method_step_adaptive` (sparse/banded dispatch, DD-043) is not yet
+  Newton-aware: configuring both a sparse backend and a non-default Newton
+  budget on `BackwardEulerSolver`/`CrankNicolsonSolver` silently keeps the
+  sparse path single-shot (#111)
 
 ## [0.6.0] — 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ oxiflow adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `IntegratorSpec::CrankNicolson` variant, symmetric to `BackwardEuler` in
+  every field (sparse dispatch + Newton configuration); `theta = 0.5`
+  stays implicit to the variant, matching `BackwardEuler`'s own
+  `theta = 1.0` (DD-044, #115)
 - `IntegratorSpec::BackwardEuler` gains `newton_convergence`,
   `jacobian_strategy`, `max_iterations` fields (`serde` feature), mapped to
   `BackwardEulerSolver`'s three Newton builders via `TryFrom`; defaults

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ oxiflow adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Iterated Newton solver core (`solver::methods::newton`): `NewtonConvergence`
+  (`ResidualOnly`/`CombinedOr`/`CombinedAnd`), `JacobianStrategy`
+  (`ModifiedFrozen`/`FullNewton`/`ModifiedWithStagnationCheck`), and the
+  generic convergence loop shared by theta-method and BDF2 — not yet wired
+  into `BackwardEulerSolver`/`CrankNicolsonSolver`/`BDF2Solver` (DD-044, #109,
+  #110)
+- `OxiflowError::NewtonNotConverged { iterations, residual }` — routed
+  through `Solver::on_divergence()` once wired (#110)
+
 ## [0.6.0] — 2026-07-21
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ oxiflow adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `IntegratorSpec::BDF2` variant — Newton fields only, deliberately no
+  sparse fields (`BDF2Solver` has no sparse builders to map, a DD-043 gap
+  distinct from this DTO increment) (DD-044, #116)
 - `IntegratorSpec::CrankNicolson` variant, symmetric to `BackwardEuler` in
   every field (sparse dispatch + Newton configuration); `theta = 0.5`
   stays implicit to the variant, matching `BackwardEuler`'s own

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,13 @@ criterion = { version = "0.8", features = ["html_reports"] }
 # harness = false
 
 # ──────────────────────────────────────────────────────────────────────────────
+# Définition du package / Package specification
+# ──────────────────────────────────────────────────────────────────────────────
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--html-in-header", "docs/katex-header.html"]
+
+# ──────────────────────────────────────────────────────────────────────────────
 # Profils / Build profiles
 # ──────────────────────────────────────────────────────────────────────────────
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -306,6 +306,70 @@ a first-order approximation otherwise. J7 lifts this limitation: a nonlinear sol
 iterated to convergence, or a related method) plugged in behind the same extension point
 DD-033 already anticipated, with no rewrite of the J4a solvers.
 
+### Why this is needed: the discretised residual is not always linear
+
+The canonical form (§1) is `∂u/∂t + ∇·F(u, ∇u) = S(u, x, t)`. Write the right-hand side as a
+single function of the state, `f(u) = -∇·F(u, ∇u) + S(u, x, t)`. Discretising with the
+theta-method (Backward Euler: θ=1, Crank-Nicolson: θ=0.5) turns the PDE into, at every time
+step, a root-finding problem in the unknown `u^{n+1}`:
+
+```
+g(u^{n+1}) = u^{n+1} - u^n - Δt · [(1-θ)·f(u^n) + θ·f(u^{n+1})] = 0
+```
+
+(BDF2 has its own residual, `g(u) = (3/2)u - 2u^n + (1/2)u^{n-1} - Δt·f(u)`, but the same
+argument applies.) `g` is **linear** in `u^{n+1}` exactly when `f` is affine in `u` — i.e. when
+both `F` and `S` are affine. That is the case J4a's single frozen-Jacobian correction (DD-033,
+Option B) already solves exactly: for affine `f`, the Jacobian `∂g/∂u` is constant, independent
+of `u^{n+1}`, so a single Newton step from `u^n` lands exactly on the root — no iteration
+needed. This is not an approximation choice, it's a property of linear algebra.
+
+Any **physically nonlinear** `F` or `S` breaks this: `g` becomes a nonlinear algebraic equation,
+and J4a's single correction is only a first-order approximation to its root — good enough for
+mildly nonlinear problems and small `Δt`, not exact in general. Concrete cases oxiflow needs to
+handle correctly, drawn from the project's own target domains:
+
+- **Nonlinear flux `F(u)`** — e.g. Burgers-type nonlinear advection (`F(u) = u²/2`), or a
+  diffusion coefficient that depends on the field itself (`F = -D(u)∇u`, degenerate/nonlinear
+  diffusion).
+- **Nonlinear source `S(u)`** — e.g. Langmuir-type adsorption isotherms in chromatography
+  (`q(c) = q_max·K·c / (1 + K·c)`, oxiflow's own originating domain via chrom-rs), or
+  Arrhenius-type reaction-rate kinetics (`S ∝ exp(-E_a / R·T)`).
+
+Newton solves `g(u) = 0` by linearising it around the current iterate `u^k` and correcting:
+
+```
+J^k · Δu^k = -g(u^k),    J^k = ∂g/∂u |_{u=u^k} = I - Δt·θ · ∂f/∂u |_{u=u^k}
+u^{k+1} = u^k + Δu^k
+```
+
+`∂f/∂u` is exactly what `finite_difference_jacobian` (DD-013, already in place since J4a)
+approximates by finite differences — Newton reuses it unchanged. What DD-044 changes is *how
+many times* this Jacobian is (re-)evaluated per time step and *when the loop stops* — see
+below — not the residual, the Jacobian assembly, or the canonical form itself.
+
+### DD-044 — activating this correctly
+
+DD-044 formalises this activation: `NewtonConvergence` (residual-based, default) and
+`JacobianStrategy` (modified/frozen, default) as configurable HOW-axis enums;
+`OxiflowError::NewtonNotConverged` routed through `Solver::on_divergence()`; a single generic
+Newton loop shared by theta-method (Backward Euler/Crank-Nicolson) and BDF2, rather than the
+per-family duplication J4a used when Newton had only one consumer; `IntegratorSpec` extended
+to `BackwardEuler` (Newton fields added) plus new `CrankNicolson` and `BDF2` variants (the
+latter without sparse fields — `BDF2Solver` has no sparse dispatch, a DD-043 gap left open
+here, not a J7 concern).
+
+Operational breakdown (DD-044, `oxiflow-issues-v0.7.0.yml`):
+
+1. Newton core loop (`NewtonConvergence`, `JacobianStrategy`, `NewtonNotConverged`,
+   `newton_residual`/`newton_linear_correction`, generic loop) — prerequisite for 2–3.
+2. Wire into Backward Euler/Crank-Nicolson.
+3. Wire into BDF2.
+4. `IntegratorSpec::BackwardEuler` extended, `CrankNicolson` and `BDF2` variants added —
+   depend on 2/3 respectively.
+5. Regression test for the DD-033 known-untested limitation (perturbed-Jacobian ×
+   Dirichlet BC interaction) — independent of 1–4.
+
 **Exit criterion:** a problem nonlinear in `u` converges at the expected order under
 Backward Euler/Crank-Nicolson/BDF2 with the nonlinear solver, where the frozen J4a
 correction only gave a first-order approximation.
@@ -521,7 +585,7 @@ Requirements for a third-party framework:
 | Operator context access | `FluxDivergenceOperator`: sibling trait to `DiscreteOperator`, carries `ctx`/`RequiresContext` | Adding `ctx` directly to `DiscreteOperator`; subtrait of `DiscreteOperator` | J5 | INV-2 |
 | Linear solvers (sparse) | `faer-sparse` delegation | Custom implementation | J6 | |
 | Results export | VTK interop pivot + HDF5 for bulk data | Custom format | J6 | |
-| Nonlinear integration | Iterated Newton, DD-033 extension point | Rewrite of J4a solvers | J7 | |
+| Nonlinear integration | Iterated Newton, DD-033 extension point activated by DD-044 (generic loop, no per-family duplication) | Rewrite of J4a solvers; per-family duplicated loop | J7 | |
 | GPU readiness | Structural invariants formalised before `gpu` feature | `wgpu` without prior constraints | J8 | |
 | Parallelism | Rayon, opt-in feature flag | Mandatory or absent | J9 | |
 | Caching | Dirty flag + temporal invalidation | Systematic recomputation | J9 | |

--- a/DEVELOPPEMENT.md
+++ b/DEVELOPPEMENT.md
@@ -313,6 +313,72 @@ en `u`, approximation de premier ordre sinon. J7 lève cette limitation : solveu
 (Newton itéré à convergence, ou méthode apparentée) branché derrière le même point d'extension
 que DD-033 anticipait déjà, sans réécriture des solveurs J4a.
 
+### Pourquoi c'est nécessaire : le résidu discrétisé n'est pas toujours linéaire
+
+La forme canonique (§1) est `∂u/∂t + ∇·F(u, ∇u) = S(u, x, t)`. En notant
+`f(u) = -∇·F(u, ∇u) + S(u, x, t)` le second membre, la discrétisation par méthode theta
+(Backward Euler : θ=1, Crank-Nicolson : θ=0,5) transforme l'EDP en, à chaque pas de temps, un
+problème de recherche de racine sur l'inconnue `u^{n+1}` :
+
+```
+g(u^{n+1}) = u^{n+1} - u^n - Δt · [(1-θ)·f(u^n) + θ·f(u^{n+1})] = 0
+```
+
+(BDF2 a son propre résidu, `g(u) = (3/2)u - 2u^n + (1/2)u^{n-1} - Δt·f(u)`, mais le
+raisonnement est identique.) `g` est **linéaire** en `u^{n+1}` exactement lorsque `f` est
+affine en `u` — c'est-à-dire lorsque `F` et `S` sont tous deux affines. C'est précisément le
+cas que la correction unique à Jacobien gelé de J4a (DD-033, Option B) résout déjà de façon
+exacte : pour `f` affine, le Jacobien `∂g/∂u` est constant, indépendant de `u^{n+1}` — un
+unique pas de Newton depuis `u^n` tombe donc exactement sur la racine, sans itération
+nécessaire. Ce n'est pas un choix d'approximation, c'est une propriété d'algèbre linéaire.
+
+Toute non-linéarité **physique** de `F` ou `S` brise cette propriété : `g` devient une
+équation algébrique non linéaire, et la correction unique de J4a n'en donne alors qu'une
+approximation de premier ordre de la racine — suffisant pour des problèmes faiblement non
+linéaires et un `Δt` petit, pas exact en général. Cas physiques concrets qu'oxiflow doit
+traiter correctement, issus des domaines cibles du projet lui-même :
+
+- **Flux non linéaire `F(u)`** — ex. advection non linéaire de type Burgers
+  (`F(u) = u²/2`), ou un coefficient de diffusion dépendant du champ lui-même
+  (`F = -D(u)∇u`, diffusion non linéaire/dégénérée).
+- **Terme source non linéaire `S(u)`** — ex. isothermes d'adsorption de type Langmuir en
+  chromatographie (`q(c) = q_max·K·c / (1 + K·c)`, le domaine d'origine d'oxiflow via
+  chrom-rs), ou cinétique de réaction de type Arrhenius (`S ∝ exp(-E_a / R·T)`).
+
+Newton résout `g(u) = 0` en linéarisant autour de l'itéré courant `u^k` et en corrigeant :
+
+```
+J^k · Δu^k = -g(u^k),    J^k = ∂g/∂u |_{u=u^k} = I - Δt·θ · ∂f/∂u |_{u=u^k}
+u^{k+1} = u^k + Δu^k
+```
+
+`∂f/∂u` est exactement ce que `finite_difference_jacobian` (DD-013, déjà en place depuis J4a)
+approxime par différences finies — Newton la réutilise inchangée. Ce que DD-044 change, c'est
+*combien de fois* ce Jacobien est réévalué par pas de temps et *quand la boucle s'arrête* —
+voir ci-dessous — pas le résidu, l'assemblage du Jacobien, ni la forme canonique elle-même.
+
+### DD-044 — activer cela correctement
+
+DD-044 formalise cette activation : `NewtonConvergence` (basé résidu, par défaut) et
+`JacobianStrategy` (Newton modifié/gelé, par défaut) comme énumérations HOW configurables ;
+`OxiflowError::NewtonNotConverged` routée via `Solver::on_divergence()` élargi ; une boucle
+Newton générique unique partagée par la méthode theta (Backward Euler/Crank-Nicolson) et BDF2,
+au lieu de la duplication par famille que J4a utilisait quand Newton n'avait qu'un seul
+consommateur ; `IntegratorSpec` étendu à `BackwardEuler` (champs Newton ajoutés) plus nouveaux
+variants `CrankNicolson` et `BDF2` (ce dernier sans champs sparse — `BDF2Solver` n'a pas de
+dispatch sparse, un écart DD-043 laissé ouvert ici, pas une préoccupation de J7).
+
+Découpage opérationnel (DD-044, `oxiflow-issues-v0.7.0.yml`) :
+
+1. Cœur de la boucle Newton (`NewtonConvergence`, `JacobianStrategy`, `NewtonNotConverged`,
+   `newton_residual`/`newton_linear_correction`, boucle générique) — prérequis pour 2–3.
+2. Branchement Backward Euler/Crank-Nicolson.
+3. Branchement BDF2.
+4. `IntegratorSpec::BackwardEuler` étendu, variants `CrankNicolson` et `BDF2` ajoutés —
+   dépendent respectivement de 2/3.
+5. Test de régression pour la limitation connue et non testée de DD-033 (interaction
+   Jacobien perturbé × condition Dirichlet) — indépendant de 1–4.
+
 **Critère de sortie :** un problème non affine en `u` converge à l'ordre attendu sous
 Backward Euler/Crank-Nicolson/BDF2 avec le solveur non linéaire, là où la correction gelée
 de J4a ne donnait qu'une approximation de premier ordre.
@@ -530,7 +596,7 @@ Conditions pour un framework tiers :
 | Accès contexte des opérateurs | `FluxDivergenceOperator` : trait frère de `DiscreteOperator`, porte `ctx`/`RequiresContext` | Ajout de `ctx` directement sur `DiscreteOperator` ; sous-trait de `DiscreteOperator` | J5 | INV-2 |
 | Solveurs linéaires (creux) | Délégation `faer-sparse` | Implémentation maison | J6 | |
 | Export de résultats | VTK pivot interop + HDF5 données volumineuses | Format maison | J6 | |
-| Intégration non linéaire | Newton itéré, point d'extension DD-033 | Réécriture des solveurs J4a | J7 | |
+| Intégration non linéaire | Newton itéré, point d'extension DD-033 activé par DD-044 (boucle générique, pas de duplication par famille) | Réécriture des solveurs J4a ; boucle dupliquée par famille | J7 | |
 | GPU-readiness | Invariants structurels formalisés avant feature `gpu` | `wgpu` sans contrainte préalable | J8 | |
 | Parallélisme | Rayon, opt-in feature flag | Obligatoire ou absent | J9 | |
 | Cache | Dirty flag + invalidation temporelle | Recalcul systématique | J9 | |

--- a/src/context/error.rs
+++ b/src/context/error.rs
@@ -106,6 +106,25 @@ pub enum OxiflowError {
     /// [`crate::solver::snapshot`] (DD-025 Option B / DD-029, issue #71).
     #[error("snapshot persistence error: {0}")]
     Persistence(String),
+
+    /// The iterated Newton solver ([`crate::solver::methods::newton`])
+    /// did not reach its convergence criterion within `iterations` steps.
+    ///
+    /// Distinct from [`SolverDivergence`]: this is a failure of the
+    /// *nonlinear correction* to converge, not a non-finite field value —
+    /// though both are routed through [`crate::solver::Solver::on_divergence`]
+    /// before being returned (DD-044, issue #109).
+    ///
+    /// [`SolverDivergence`]: OxiflowError::SolverDivergence
+    #[error("Newton iteration did not converge after {iterations} iterations (residual = {residual:.4e})")]
+    NewtonNotConverged {
+        /// Number of iterations actually performed (equals the configured
+        /// `max_iterations` — the loop only reaches this variant once its
+        /// budget is exhausted).
+        iterations: usize,
+        /// Norm of the residual at the last iterate.
+        residual: f64,
+    },
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -285,9 +304,34 @@ mod tests {
                 time: 0.0,
                 reason: "test".into(),
             }),
+            Box::new(OxiflowError::NewtonNotConverged {
+                iterations: 20,
+                residual: 1.0e-3,
+            }),
         ];
         for v in &variants {
             assert!(!format!("{:?}", v).is_empty());
         }
+    }
+
+    #[test]
+    fn newton_not_converged_is_matchable() {
+        let err = OxiflowError::NewtonNotConverged {
+            iterations: 20,
+            residual: 1.0e-3,
+        };
+        assert!(matches!(err, OxiflowError::NewtonNotConverged { .. }));
+    }
+
+    #[test]
+    fn newton_not_converged_display_contains_iterations_and_residual() {
+        let err = OxiflowError::NewtonNotConverged {
+            iterations: 20,
+            residual: 1.0e-3,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("20"));
+        assert!(msg.contains("1.0"));
+        assert!(msg.contains("e-"));
     }
 }

--- a/src/solver/methods/backward_euler.rs
+++ b/src/solver/methods/backward_euler.rs
@@ -24,8 +24,8 @@
 //! - Single-domain scenarios only — same restriction as the explicit
 //!   solvers; see #40 for the dedicated multi-domain path.
 //! - `StepControl::Fixed { dt }` only.
-//! - See [`super::implicit`] for the boundary-condition interaction
-//!   caveat — not yet covered by a dedicated test.
+//! - See [`super::implicit`] for the boundary-condition interaction with
+//!   the perturbed Jacobian — covered by a dedicated test since #113.
 
 use crate::context::error::OxiflowError;
 use crate::context::value::ContextValue;

--- a/src/solver/methods/backward_euler.rs
+++ b/src/solver/methods/backward_euler.rs
@@ -7,9 +7,10 @@
 //! $$u^{n+1} = u^n + \Delta t \cdot f(u^{n+1}, t^{n+1})$$
 //!
 //! A thin wrapper around the shared generalised theta method
-//! ([`super::implicit::theta_method_step`], θ=1) — see that module's docs
-//! for the frozen-Jacobian v1 scope and the path to a future iterated
-//! Newton solver (DD-033).
+//! ([`super::implicit::theta_method_step_newton`], θ=1, DD-044, #111) —
+//! see that module's docs for the frozen-Jacobian default and the
+//! iterated Newton path configurable via [`BackwardEulerSolver`]'s
+//! builders.
 //!
 //! ## Stability
 //!
@@ -30,9 +31,10 @@ use crate::context::error::OxiflowError;
 use crate::context::value::ContextValue;
 use crate::context::ContextCalculator;
 use crate::solver::linear::{LinearSolver, NalgebraDenseSolver};
-use crate::solver::methods::implicit::theta_method_step;
 #[cfg(feature = "sparse")]
 use crate::solver::methods::implicit::theta_method_step_adaptive;
+use crate::solver::methods::implicit::{stiff_jacobian_convergence, theta_method_step_newton};
+use crate::solver::methods::newton::{JacobianStrategy, NewtonConvergence};
 use crate::solver::methods::SteppableSolver;
 use crate::solver::scenario::{Domain, Scenario};
 #[cfg(feature = "sparse")]
@@ -56,9 +58,26 @@ use crate::solver::{SimulationResult, Solver, SolverConfiguration};
 /// ```
 pub struct BackwardEulerSolver {
     linear_solver: Box<dyn LinearSolver>,
+    /// Newton convergence criterion (DD-044, #111) — default
+    /// [`stiff_jacobian_convergence`] (deliberately looser than
+    /// [`NewtonConvergence::default`] — see that function's docs for why
+    /// zero-config construction needs it).
+    newton_convergence: NewtonConvergence,
+    /// Jacobian refresh strategy (DD-044, #111) — default
+    /// [`JacobianStrategy::default`] (`ModifiedFrozen`).
+    jacobian_strategy: JacobianStrategy,
+    /// Newton iteration budget (DD-044, #111). Default `1`: exactly the
+    /// pre-DD-044 single frozen-Jacobian correction — see
+    /// [`super::implicit`]'s module docs for why this reproduces the
+    /// historical behaviour exactly, not approximately, on affine
+    /// problems. Raise this (and typically pair with
+    /// [`JacobianStrategy::FullNewton`]) for genuinely nonlinear models.
+    max_newton_iterations: usize,
     /// Sparse backend (DD-043) — `None` by default: the dense path
-    /// ([`theta_method_step`]) is unconditionally used unless this is
-    /// explicitly configured via [`Self::with_sparse_solver`].
+    /// ([`theta_method_step_newton`]) is unconditionally used unless this is
+    /// explicitly configured via [`Self::with_sparse_solver`]. Not yet
+    /// Newton-aware when configured — see [`super::implicit`]'s module
+    /// docs for the known gap.
     #[cfg(feature = "sparse")]
     sparse_solver: Option<Box<dyn SparseLinearSolver>>,
     /// System size above which the sparse path is used, once a
@@ -78,6 +97,9 @@ impl Default for BackwardEulerSolver {
     fn default() -> Self {
         Self {
             linear_solver: Box::new(NalgebraDenseSolver),
+            newton_convergence: stiff_jacobian_convergence(),
+            jacobian_strategy: JacobianStrategy::default(),
+            max_newton_iterations: 1,
             #[cfg(feature = "sparse")]
             sparse_solver: None,
             #[cfg(feature = "sparse")]
@@ -97,6 +119,26 @@ impl BackwardEulerSolver {
     /// Substitutes the linear solver backend (DD-013).
     pub fn with_linear_solver(mut self, linear_solver: Box<dyn LinearSolver>) -> Self {
         self.linear_solver = linear_solver;
+        self
+    }
+
+    /// Configures the Newton convergence criterion (DD-044, #111).
+    pub fn with_newton_convergence(mut self, newton_convergence: NewtonConvergence) -> Self {
+        self.newton_convergence = newton_convergence;
+        self
+    }
+
+    /// Configures the Jacobian refresh strategy (DD-044, #111).
+    pub fn with_jacobian_strategy(mut self, jacobian_strategy: JacobianStrategy) -> Self {
+        self.jacobian_strategy = jacobian_strategy;
+        self
+    }
+
+    /// Configures the Newton iteration budget (DD-044, #111) — see the
+    /// field's own docs for why the default (`1`) reproduces the
+    /// pre-DD-044 behaviour exactly on affine problems.
+    pub fn with_max_newton_iterations(mut self, max_newton_iterations: usize) -> Self {
+        self.max_newton_iterations = max_newton_iterations;
         self
     }
 
@@ -170,7 +212,7 @@ impl SteppableSolver for BackwardEulerSolver {
                 self.sparse_threshold,
                 self.jacobian_bandwidth,
             ),
-            None => theta_method_step(
+            None => theta_method_step_newton(
                 domain,
                 chain,
                 state,
@@ -178,6 +220,9 @@ impl SteppableSolver for BackwardEulerSolver {
                 dt,
                 1.0,
                 self.linear_solver.as_ref(),
+                self.newton_convergence,
+                self.jacobian_strategy,
+                self.max_newton_iterations,
             ),
         }
     }
@@ -196,7 +241,7 @@ impl SteppableSolver for BackwardEulerSolver {
     ) -> Result<ContextValue, OxiflowError> {
         // history_depth() defaults to 0 -- Backward Euler is a one-step
         // method, `_history` is always empty here and intentionally unused.
-        theta_method_step(
+        theta_method_step_newton(
             domain,
             chain,
             state,
@@ -204,6 +249,9 @@ impl SteppableSolver for BackwardEulerSolver {
             dt,
             1.0,
             self.linear_solver.as_ref(),
+            self.newton_convergence,
+            self.jacobian_strategy,
+            self.max_newton_iterations,
         )
     }
 }
@@ -484,5 +532,95 @@ mod tests {
             .solve(&scenario, &config)
             .unwrap_err();
         assert!(matches!(err, OxiflowError::MissingCalculator(_)));
+    }
+
+    // ── Iterated Newton (DD-044, #111) ─────────────────────────────────────────
+
+    #[derive(Debug)]
+    struct CubicDecay;
+
+    impl RequiresContext for CubicDecay {
+        fn required_variables(&self) -> Vec<ContextVariable> {
+            vec![]
+        }
+    }
+
+    impl PhysicalModel for CubicDecay {
+        fn compute_physics(
+            &self,
+            state: &ContextValue,
+            _ctx: &ComputeContext,
+        ) -> Result<ContextValue, OxiflowError> {
+            let u = state.as_scalar_field()?;
+            Ok(ContextValue::ScalarField(u.map(|v| -v * v * v)))
+        }
+
+        fn initial_state(&self, mesh: &dyn Mesh) -> ContextValue {
+            ContextValue::ScalarField(DVector::from_element(mesh.n_dof(), 1.0))
+        }
+
+        fn name(&self) -> &str {
+            "cubic_decay_test"
+        }
+    }
+
+    #[test]
+    fn full_newton_resolves_nonaffine_correction_beyond_frozen_jacobian() {
+        // f(u) = -u^3 -- genuinely nonlinear. Backward Euler's own
+        // discrete equation for one step is u_next + dt*u_next^3 = u_n;
+        // the default single frozen correction (max_newton_iterations=1,
+        // the pre-DD-044 behaviour) is only a first-order approximation
+        // of that equation's solution, not the solution itself -- under
+        // the default tolerance this surfaces as an honest convergence
+        // failure rather than a silently inaccurate "success" (nothing
+        // about affine-ness is special-cased, see
+        // `solver::methods::newton`'s docs). Configuring FullNewton with
+        // enough iterations reaches the converged solution -- the J7
+        // exit criterion (#111).
+        let dt = 0.5; // deliberately large so the gap is clearly visible
+        let config = make_config(dt, dt); // exactly one step
+
+        let scenario_default = Scenario::single(Box::new(CubicDecay), make_mesh(2));
+        let default_err = BackwardEulerSolver::new()
+            .solve(&scenario_default, &config)
+            .unwrap_err();
+        assert!(
+            matches!(default_err, OxiflowError::NewtonNotConverged { .. }),
+            "default single correction should fail to converge on a genuinely \
+             nonlinear model: got {default_err:?}"
+        );
+
+        let scenario_full = Scenario::single(Box::new(CubicDecay), make_mesh(2));
+        // Explicit `NewtonConvergence::default()` (tol_abs=1e-8): the
+        // solver's zero-config value is `stiff_jacobian_convergence()`
+        // (tol_abs=1e-5, tuned for backward compatibility on stiff
+        // affine problems, see that function's docs) -- this test wants
+        // the tighter, general-purpose criterion to demonstrate genuine
+        // convergence, not the loose one.
+        let full_result = BackwardEulerSolver::new()
+            .with_newton_convergence(NewtonConvergence::default())
+            .with_jacobian_strategy(JacobianStrategy::FullNewton)
+            .with_max_newton_iterations(50)
+            .solve(&scenario_full, &config)
+            .unwrap();
+        let full_value = full_result
+            .states
+            .last()
+            .unwrap()
+            .as_scalar_field()
+            .unwrap()[0];
+
+        // Independently solved scalar equation: u_next + dt*u_next^3 = 1.0.
+        let mut u_scalar = 1.0_f64;
+        for _ in 0..100 {
+            let g = u_scalar + dt * u_scalar.powi(3) - 1.0;
+            let dg = 1.0 + 3.0 * dt * u_scalar.powi(2);
+            u_scalar -= g / dg;
+        }
+
+        assert!(
+            (full_value - u_scalar).abs() < 1e-6,
+            "FullNewton should reach the converged discrete solution: got {full_value}, expected {u_scalar}"
+        );
     }
 }

--- a/src/solver/methods/bdf2.rs
+++ b/src/solver/methods/bdf2.rs
@@ -11,11 +11,21 @@
 //! returns `1` here (DD-034), and [`BDF2Solver::step`] receives `u^{n-1}`
 //! via the `history` parameter.
 //!
-//! `bdf2_step` (below) is BDF2-specific and stays in this file rather than
-//! [`super::implicit`]: unlike `theta_method_step`, which serves two
-//! solvers (Backward Euler, Crank-Nicolson), this formula has exactly one
-//! consumer. It still reuses [`super::implicit::finite_difference_jacobian`]
-//! and [`super::evaluate_derivative`] — the genuinely shared pieces.
+//! `bdf2_step_newton` (below) is BDF2-specific and stays in this file
+//! rather than [`super::implicit`]: unlike `theta_method_step_newton`,
+//! which serves two solvers (Backward Euler, Crank-Nicolson), this
+//! formula has exactly one consumer. It still reuses
+//! [`super::implicit::finite_difference_jacobian`],
+//! [`super::evaluate_derivative`], and the shared [`super::newton`] loop
+//! (DD-044, #112) — the genuinely shared pieces. Unlike
+//! [`super::implicit::theta_method_step`] (kept as a separate,
+//! non-configurable wrapper for BE/CN because *production* code — this
+//! module's own bootstrap step, below — calls it directly), BDF2 has no
+//! such production caller for the unconfigured form: `bdf2_step_newton`
+//! is called directly, both by [`BDF2Solver::step`] and by this module's
+//! own tests, passing `stiff_jacobian_convergence()`/
+//! [`JacobianStrategy::default`]/`max_iterations = 1` explicitly where
+//! the pre-DD-044 behaviour is wanted.
 //!
 //! ## Startup (acceptance criterion, #44)
 //!
@@ -42,13 +52,16 @@
 //! stiff modes, same qualitative behaviour as Backward Euler but 2nd
 //! order accurate.
 
-use nalgebra::{DMatrix, DVector};
+use nalgebra::DVector;
 
 use crate::context::error::OxiflowError;
 use crate::context::value::ContextValue;
 use crate::context::ContextCalculator;
 use crate::solver::linear::{LinearSolver, NalgebraDenseSolver};
-use crate::solver::methods::implicit::{finite_difference_jacobian, theta_method_step};
+use crate::solver::methods::implicit::{
+    finite_difference_jacobian, stiff_jacobian_convergence, theta_method_step,
+};
+use crate::solver::methods::newton::{self, JacobianStrategy, NewtonConvergence};
 use crate::solver::methods::{evaluate_derivative, SteppableSolver};
 use crate::solver::scenario::{Domain, Scenario};
 use crate::solver::{SimulationResult, Solver, SolverConfiguration};
@@ -59,12 +72,30 @@ use crate::solver::{SimulationResult, Solver, SolverConfiguration};
 /// scope at J4a.
 pub struct BDF2Solver {
     linear_solver: Box<dyn LinearSolver>,
+    /// Newton convergence criterion (DD-044, #112) — default
+    /// [`stiff_jacobian_convergence`](super::implicit::stiff_jacobian_convergence)
+    /// (deliberately looser than [`NewtonConvergence::default`] — see
+    /// that function's docs for why zero-config construction needs it).
+    /// Only affects the real BDF2 update ([`bdf2_step_newton`]) — the
+    /// startup/bootstrap step always uses
+    /// [`theta_method_step`](super::implicit::theta_method_step)
+    /// unconditionally, per [module docs](self).
+    newton_convergence: NewtonConvergence,
+    /// Jacobian refresh strategy (DD-044, #112) — default
+    /// [`JacobianStrategy::default`] (`ModifiedFrozen`).
+    jacobian_strategy: JacobianStrategy,
+    /// Newton iteration budget (DD-044, #112). Default `1`: exactly the
+    /// pre-DD-044 single frozen-Jacobian correction.
+    max_newton_iterations: usize,
 }
 
 impl Default for BDF2Solver {
     fn default() -> Self {
         Self {
             linear_solver: Box::new(NalgebraDenseSolver),
+            newton_convergence: stiff_jacobian_convergence(),
+            jacobian_strategy: JacobianStrategy::default(),
+            max_newton_iterations: 1,
         }
     }
 }
@@ -78,6 +109,27 @@ impl BDF2Solver {
     /// Substitutes the linear solver backend (DD-013).
     pub fn with_linear_solver(mut self, linear_solver: Box<dyn LinearSolver>) -> Self {
         self.linear_solver = linear_solver;
+        self
+    }
+
+    /// Configures the Newton convergence criterion (DD-044, #112) — only
+    /// affects the real BDF2 update, not the startup/bootstrap step (see
+    /// [module docs](self)).
+    pub fn with_newton_convergence(mut self, newton_convergence: NewtonConvergence) -> Self {
+        self.newton_convergence = newton_convergence;
+        self
+    }
+
+    /// Configures the Jacobian refresh strategy (DD-044, #112).
+    pub fn with_jacobian_strategy(mut self, jacobian_strategy: JacobianStrategy) -> Self {
+        self.jacobian_strategy = jacobian_strategy;
+        self
+    }
+
+    /// Configures the Newton iteration budget (DD-044, #112) — see
+    /// [`BackwardEulerSolver::with_max_newton_iterations`](super::backward_euler::BackwardEulerSolver::with_max_newton_iterations).
+    pub fn with_max_newton_iterations(mut self, max_newton_iterations: usize) -> Self {
+        self.max_newton_iterations = max_newton_iterations;
         self
     }
 }
@@ -123,7 +175,7 @@ impl SteppableSolver for BDF2Solver {
                 1.0,
                 self.linear_solver.as_ref(),
             ),
-            Some(u_prev) => bdf2_step(
+            Some(u_prev) => bdf2_step_newton(
                 domain,
                 chain,
                 state,
@@ -131,22 +183,35 @@ impl SteppableSolver for BDF2Solver {
                 t,
                 dt,
                 self.linear_solver.as_ref(),
+                self.newton_convergence,
+                self.jacobian_strategy,
+                self.max_newton_iterations,
             ),
         }
     }
 }
 
-/// Performs one BDF2 step, given `u^{n-1}` (`u_prev`) and `u^n` (`state`).
+/// Same contract as the pre-DD-044 single-correction BDF2 step, routed
+/// through the generic iterated Newton loop ([`newton::solve`]) with
+/// caller-supplied convergence/Jacobian-strategy/iteration-budget
+/// configuration (DD-044, #112) — [`BDF2Solver`] calls this directly,
+/// passing its own configured fields. Passing `stiff_jacobian_convergence()`,
+/// [`JacobianStrategy::default`], and `max_iterations = 1` reproduces the
+/// pre-DD-044 behaviour exactly, matching
+/// [`theta_method_step`](super::implicit::theta_method_step)'s own
+/// delegate pattern for BE/CN — kept as a plain function call here rather
+/// than a separate wrapper, since (unlike `theta_method_step`) nothing in
+/// production calls the unconfigured form; only this module's own tests
+/// do.
 ///
-/// Same frozen-Jacobian, single-Newton-correction approach as
-/// [`super::implicit::theta_method_step`] (DD-033): exact when `f` is
-/// affine in `u`, a first-order approximation otherwise.
-///
-/// Derivation: linearising `g(u) = (3/2)u - 2u^n + (1/2)u^{n-1} - dt*f(u)`
-/// at `u = u^n` gives `g(u^n) = -(1/2)u^n + (1/2)u^{n-1} - dt*f(u^n)` and
-/// Jacobian `(3/2)I - dt*J_f`. The correction solves
-/// `[(3/2)I - dt*J_f] * delta_u = -g(u^n)`.
-fn bdf2_step(
+/// Follows [`newton`](super::newton)'s residual convention with $\alpha =
+/// 3/2$, $c = \Delta t$, $u^{*} = \frac{4u^n - u^{n-1}}{3}$ — derived from
+/// $g(u) = \frac{3}{2}u - 2u^n + \frac{1}{2}u^{n-1} - \Delta t f(u) =
+/// \frac{3}{2}(u - u^{*}) - \Delta t f(u)$ (see [module docs](self)).
+/// `f(u^n)` is evaluated once, at time `t`; every subsequent candidate
+/// `f`/Jacobian evaluation inside the Newton loop is at time `t + dt`.
+#[allow(clippy::too_many_arguments)]
+fn bdf2_step_newton(
     domain: &Domain,
     chain: &[&dyn ContextCalculator],
     state: &mut ContextValue,
@@ -154,11 +219,16 @@ fn bdf2_step(
     t: f64,
     dt: f64,
     linear_solver: &dyn LinearSolver,
+    newton_convergence: NewtonConvergence,
+    jacobian_strategy: JacobianStrategy,
+    max_iterations: usize,
 ) -> Result<ContextValue, OxiflowError> {
-    // f(u^n, t) -- BCs applied in-place to `state` itself.
-    let f_n = evaluate_derivative(domain, chain, state, t, dt)?;
+    // Applies calculators + BCs to `state` itself (same contract as
+    // `theta_method_step_newton`) -- the returned f(u^n) itself isn't
+    // needed: unlike theta-method's u_star, BDF2's u_star (below) carries
+    // no f(u^n) term, only u^n and u^{n-1}.
+    let _f_n = evaluate_derivative(domain, chain, state, t, dt)?;
     let u_n_field = state.as_scalar_field()?.clone();
-    let f_n_field = f_n.as_scalar_field()?.clone();
     let u_prev_field = u_prev.as_scalar_field()?.clone();
 
     let n = u_n_field.len();
@@ -169,24 +239,34 @@ fn bdf2_step(
         )));
     }
 
-    // Jacobian frozen at u^n, evaluated at the target time t + dt.
-    let jacobian = finite_difference_jacobian(domain, chain, state, t + dt, dt)?;
+    let u0 = u_n_field.clone();
+    let u_star: DVector<f64> = (u_n_field * 4.0 - u_prev_field) / 3.0;
+    let alpha = 1.5;
+    let coeff = dt;
+    let t_target = t + dt;
 
-    // System matrix: (3/2)*I - dt*J_f.
-    let identity = DMatrix::<f64>::identity(n, n);
-    let system_matrix = identity * 1.5 - jacobian * dt;
+    let u_next = newton::solve(
+        u0,
+        &u_star,
+        alpha,
+        coeff,
+        move |candidate: &DVector<f64>| {
+            let mut candidate_state = ContextValue::ScalarField(candidate.clone());
+            let f = evaluate_derivative(domain, chain, &mut candidate_state, t_target, dt)?;
+            Ok(f.as_scalar_field()?.clone())
+        },
+        move |candidate: &DVector<f64>| {
+            let candidate_state = ContextValue::ScalarField(candidate.clone());
+            finite_difference_jacobian(domain, chain, &candidate_state, t_target, dt)
+        },
+        linear_solver,
+        &newton::NewtonParams {
+            convergence: newton_convergence,
+            jacobian_strategy,
+            max_iterations,
+        },
+    )?;
 
-    // RHS: -g(u^n) = (1/2)*u^n - (1/2)*u^{n-1} + dt*f(u^n). Built from
-    // fully-owned operands throughout -- see DD-033 rationale on avoiding
-    // ambiguous reference/owned nalgebra operator resolution.
-    let half_u_n = u_n_field.clone() * 0.5;
-    let half_u_prev = u_prev_field * 0.5;
-    let dt_f_n = f_n_field * dt;
-    let rhs: DVector<f64> = half_u_n + dt_f_n - half_u_prev;
-
-    let delta_u = linear_solver.solve(&system_matrix, &rhs)?;
-
-    let u_next: DVector<f64> = u_n_field + delta_u;
     Ok(ContextValue::ScalarField(u_next))
 }
 
@@ -202,6 +282,7 @@ mod tests {
     use crate::solver::config::{
         IntegratorKind, SolverConfiguration, StepControl, TimeConfiguration,
     };
+    use nalgebra::DMatrix;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
@@ -527,7 +608,7 @@ mod tests {
         let mut state = domain.model.initial_state(domain.mesh.as_ref());
         let wrong_length_prev = ContextValue::ScalarField(DVector::from_element(2, 1.0)); // mesh has 3 nodes
 
-        let err = bdf2_step(
+        let err = bdf2_step_newton(
             domain,
             &chain,
             &mut state,
@@ -535,8 +616,104 @@ mod tests {
             0.0,
             0.1,
             &NalgebraDenseSolver,
+            stiff_jacobian_convergence(),
+            JacobianStrategy::default(),
+            1,
         )
         .unwrap_err();
         assert!(matches!(err, OxiflowError::InvalidDomain(_)));
+    }
+
+    // ── Iterated Newton (DD-044, #112) ─────────────────────────────────────────
+
+    #[derive(Debug)]
+    struct CubicDecay;
+
+    impl RequiresContext for CubicDecay {
+        fn required_variables(&self) -> Vec<ContextVariable> {
+            vec![]
+        }
+    }
+
+    impl PhysicalModel for CubicDecay {
+        fn compute_physics(
+            &self,
+            state: &ContextValue,
+            _ctx: &ComputeContext,
+        ) -> Result<ContextValue, OxiflowError> {
+            let u = state.as_scalar_field()?;
+            Ok(ContextValue::ScalarField(u.map(|v| -v * v * v)))
+        }
+
+        fn initial_state(&self, mesh: &dyn Mesh) -> ContextValue {
+            ContextValue::ScalarField(DVector::from_element(mesh.n_dof(), 1.0))
+        }
+
+        fn name(&self) -> &str {
+            "cubic_decay_test"
+        }
+    }
+
+    #[test]
+    fn full_newton_resolves_nonaffine_correction_beyond_frozen_jacobian() {
+        // f(u) = -u^3 -- genuinely nonlinear. `dt` is deliberately small
+        // (unlike BE/CN's own version of this test): BDF2's startup
+        // step is *always* a single, unconfigurable Backward-Euler-style
+        // correction (module docs) -- for a large `dt` that bootstrap
+        // itself would fail to converge under any configuration,
+        // masking the real BDF2 step this test wants to exercise. At
+        // this `dt`, both the bootstrap and the real BDF2 step's default
+        // single correction still converge, but only approximately;
+        // FullNewton on the real BDF2 step reaches the true discrete
+        // solution (J7 exit criterion, #112).
+        let dt = 0.01;
+        let config = make_config(2.0 * dt, dt); // exactly two steps
+
+        let scenario_default = Scenario::single(Box::new(CubicDecay), make_mesh(2));
+        let default_result = BDF2Solver::new().solve(&scenario_default, &config).unwrap();
+
+        let scenario_full = Scenario::single(Box::new(CubicDecay), make_mesh(2));
+        let full_result = BDF2Solver::new()
+            .with_newton_convergence(NewtonConvergence::default())
+            .with_jacobian_strategy(JacobianStrategy::FullNewton)
+            .with_max_newton_iterations(50)
+            .solve(&scenario_full, &config)
+            .unwrap();
+
+        // u^1 (the bootstrap step) is unaffected by solver configuration
+        // (module docs) -- both runs must agree on it exactly.
+        let u1_default = default_result.states[1].as_scalar_field().unwrap()[0];
+        let u1_full = full_result.states[1].as_scalar_field().unwrap()[0];
+        assert!(
+            (u1_default - u1_full).abs() < 1e-15,
+            "the bootstrap step must be identical regardless of solver configuration"
+        );
+
+        // Independently solved BDF2 equation for the real second step:
+        // (3/2)*u2 - 2*u1 + (1/2)*u0 = dt*(-u2^3), i.e.
+        // 1.5*u2 + dt*u2^3 = 2*u1 - 0.5*u0, using the *actual* u1 above
+        // (not re-derived) so this reference isn't sensitive to the
+        // bootstrap's own approximation.
+        let u0 = 1.0_f64;
+        let rhs = 2.0 * u1_default - 0.5 * u0;
+        let mut u2_scalar = u1_default;
+        for _ in 0..100 {
+            let g = 1.5 * u2_scalar + dt * u2_scalar.powi(3) - rhs;
+            let dg = 1.5 + 3.0 * dt * u2_scalar.powi(2);
+            u2_scalar -= g / dg;
+        }
+
+        let full_value = full_result.states[2].as_scalar_field().unwrap()[0];
+        let default_value = default_result.states[2].as_scalar_field().unwrap()[0];
+
+        assert!(
+            (full_value - u2_scalar).abs() < 1e-6,
+            "FullNewton should reach the converged discrete solution: got {full_value}, expected {u2_scalar}"
+        );
+        assert!(
+            (default_value - full_value).abs() > 1e-7,
+            "default single correction should measurably differ from the converged solution: \
+             default={default_value}, full={full_value}"
+        );
     }
 }

--- a/src/solver/methods/crank_nicolson.rs
+++ b/src/solver/methods/crank_nicolson.rs
@@ -24,8 +24,8 @@
 //! ## Scope at J4a
 //!
 //! Same restrictions as `BackwardEulerSolver`: single-domain,
-//! `StepControl::Fixed` only, BC interaction with the frozen Jacobian not
-//! yet covered by a dedicated test (see [`super::implicit`]).
+//! `StepControl::Fixed` only. BC interaction with the perturbed Jacobian
+//! is covered by a dedicated test since #113 (see [`super::implicit`]).
 
 use crate::context::error::OxiflowError;
 use crate::context::value::ContextValue;

--- a/src/solver/methods/crank_nicolson.rs
+++ b/src/solver/methods/crank_nicolson.rs
@@ -7,9 +7,10 @@
 //! $$u^{n+1} = u^n + \frac{\Delta t}{2}\left[f(u^n, t^n) + f(u^{n+1}, t^{n+1})\right]$$
 //!
 //! A thin wrapper around the shared generalised theta method
-//! ([`super::implicit::theta_method_step`], θ=0.5) — see that module's
-//! docs for the frozen-Jacobian v1 scope and the path to a future
-//! iterated Newton solver (DD-033). Identical structure to
+//! ([`super::implicit::theta_method_step_newton`], θ=0.5, DD-044, #111)
+//! — see that module's docs for the frozen-Jacobian default and the
+//! iterated Newton path configurable via [`CrankNicolsonSolver`]'s
+//! builders. Identical structure to
 //! [`BackwardEulerSolver`](super::backward_euler::BackwardEulerSolver) —
 //! only `theta` differs.
 //!
@@ -30,9 +31,10 @@ use crate::context::error::OxiflowError;
 use crate::context::value::ContextValue;
 use crate::context::ContextCalculator;
 use crate::solver::linear::{LinearSolver, NalgebraDenseSolver};
-use crate::solver::methods::implicit::theta_method_step;
 #[cfg(feature = "sparse")]
 use crate::solver::methods::implicit::theta_method_step_adaptive;
+use crate::solver::methods::implicit::{stiff_jacobian_convergence, theta_method_step_newton};
+use crate::solver::methods::newton::{JacobianStrategy, NewtonConvergence};
 use crate::solver::methods::SteppableSolver;
 use crate::solver::scenario::{Domain, Scenario};
 #[cfg(feature = "sparse")]
@@ -42,6 +44,18 @@ use crate::solver::{SimulationResult, Solver, SolverConfiguration};
 /// Crank-Nicolson solver — semi-implicit, 2nd order.
 pub struct CrankNicolsonSolver {
     linear_solver: Box<dyn LinearSolver>,
+    /// Newton convergence criterion (DD-044, #111) — default
+    /// [`stiff_jacobian_convergence`](super::implicit::stiff_jacobian_convergence)
+    /// (deliberately looser than
+    /// [`NewtonConvergence::default`] — see
+    /// [`BackwardEulerSolver`](super::backward_euler::BackwardEulerSolver)'s
+    /// field docs for the full rationale, identical here).
+    newton_convergence: NewtonConvergence,
+    /// Jacobian refresh strategy (DD-044, #111).
+    jacobian_strategy: JacobianStrategy,
+    /// Newton iteration budget (DD-044, #111). Default `1` — the
+    /// pre-DD-044 single frozen-Jacobian correction.
+    max_newton_iterations: usize,
     /// Sparse backend (DD-043) — see
     /// [`BackwardEulerSolver`](super::backward_euler::BackwardEulerSolver)'s
     /// fields for the full rationale, identical here.
@@ -57,6 +71,9 @@ impl Default for CrankNicolsonSolver {
     fn default() -> Self {
         Self {
             linear_solver: Box::new(NalgebraDenseSolver),
+            newton_convergence: stiff_jacobian_convergence(),
+            jacobian_strategy: JacobianStrategy::default(),
+            max_newton_iterations: 1,
             #[cfg(feature = "sparse")]
             sparse_solver: None,
             #[cfg(feature = "sparse")]
@@ -76,6 +93,25 @@ impl CrankNicolsonSolver {
     /// Substitutes the linear solver backend (DD-013).
     pub fn with_linear_solver(mut self, linear_solver: Box<dyn LinearSolver>) -> Self {
         self.linear_solver = linear_solver;
+        self
+    }
+
+    /// Configures the Newton convergence criterion (DD-044, #111).
+    pub fn with_newton_convergence(mut self, newton_convergence: NewtonConvergence) -> Self {
+        self.newton_convergence = newton_convergence;
+        self
+    }
+
+    /// Configures the Jacobian refresh strategy (DD-044, #111).
+    pub fn with_jacobian_strategy(mut self, jacobian_strategy: JacobianStrategy) -> Self {
+        self.jacobian_strategy = jacobian_strategy;
+        self
+    }
+
+    /// Configures the Newton iteration budget (DD-044, #111) — see
+    /// [`BackwardEulerSolver::with_max_newton_iterations`](super::backward_euler::BackwardEulerSolver::with_max_newton_iterations).
+    pub fn with_max_newton_iterations(mut self, max_newton_iterations: usize) -> Self {
+        self.max_newton_iterations = max_newton_iterations;
         self
     }
 
@@ -142,7 +178,7 @@ impl SteppableSolver for CrankNicolsonSolver {
                 self.sparse_threshold,
                 self.jacobian_bandwidth,
             ),
-            None => theta_method_step(
+            None => theta_method_step_newton(
                 domain,
                 chain,
                 state,
@@ -150,6 +186,9 @@ impl SteppableSolver for CrankNicolsonSolver {
                 dt,
                 0.5,
                 self.linear_solver.as_ref(),
+                self.newton_convergence,
+                self.jacobian_strategy,
+                self.max_newton_iterations,
             ),
         }
     }
@@ -168,7 +207,7 @@ impl SteppableSolver for CrankNicolsonSolver {
     ) -> Result<ContextValue, OxiflowError> {
         // history_depth() defaults to 0 -- Crank-Nicolson is a one-step
         // method, `_history` is always empty here and intentionally unused.
-        theta_method_step(
+        theta_method_step_newton(
             domain,
             chain,
             state,
@@ -176,6 +215,9 @@ impl SteppableSolver for CrankNicolsonSolver {
             dt,
             0.5,
             self.linear_solver.as_ref(),
+            self.newton_convergence,
+            self.jacobian_strategy,
+            self.max_newton_iterations,
         )
     }
 }
@@ -461,5 +503,103 @@ mod tests {
             .solve(&scenario, &config)
             .unwrap_err();
         assert!(matches!(err, OxiflowError::MissingCalculator(_)));
+    }
+
+    // ── Iterated Newton (DD-044, #111) ─────────────────────────────────────────
+
+    #[derive(Debug)]
+    struct CubicDecay;
+
+    impl RequiresContext for CubicDecay {
+        fn required_variables(&self) -> Vec<ContextVariable> {
+            vec![]
+        }
+    }
+
+    impl PhysicalModel for CubicDecay {
+        fn compute_physics(
+            &self,
+            state: &ContextValue,
+            _ctx: &ComputeContext,
+        ) -> Result<ContextValue, OxiflowError> {
+            let u = state.as_scalar_field()?;
+            Ok(ContextValue::ScalarField(u.map(|v| -v * v * v)))
+        }
+
+        fn initial_state(&self, mesh: &dyn Mesh) -> ContextValue {
+            ContextValue::ScalarField(DVector::from_element(mesh.n_dof(), 1.0))
+        }
+
+        fn name(&self) -> &str {
+            "cubic_decay_test"
+        }
+    }
+
+    #[test]
+    fn full_newton_resolves_nonaffine_correction_beyond_frozen_jacobian() {
+        // f(u) = -u^3 -- genuinely nonlinear. Crank-Nicolson's own
+        // discrete equation for one step is
+        // u_next - dt/2*(-u_next^3) = u_n + dt/2*(-u_n^3); the default
+        // single frozen correction (max_newton_iterations=1, the
+        // pre-DD-044 behaviour) is only a first-order approximation of
+        // that equation's solution, not the solution itself -- under the
+        // default tolerance this surfaces as an honest convergence
+        // failure rather than a silently inaccurate "success" (nothing
+        // about affine-ness is special-cased, see
+        // `solver::methods::newton`'s docs). Configuring FullNewton with
+        // enough iterations reaches it (J7 exit criterion, #111) -- see
+        // the identical test in `backward_euler.rs` for the full
+        // rationale.
+        let dt = 0.5; // deliberately large so the gap is clearly visible
+        let config = SolverConfiguration::new(
+            TimeConfiguration::new(dt, StepControl::Fixed { dt }),
+            IntegratorKind::CrankNicolson,
+        );
+
+        let scenario_default = Scenario::single(Box::new(CubicDecay), make_mesh(2));
+        let default_err = CrankNicolsonSolver::new()
+            .solve(&scenario_default, &config)
+            .unwrap_err();
+        assert!(
+            matches!(default_err, OxiflowError::NewtonNotConverged { .. }),
+            "default single correction should fail to converge on a genuinely \
+             nonlinear model: got {default_err:?}"
+        );
+
+        let scenario_full = Scenario::single(Box::new(CubicDecay), make_mesh(2));
+        // Explicit `NewtonConvergence::default()` (tol_abs=1e-8): the
+        // solver's zero-config value is `stiff_jacobian_convergence()`
+        // (tol_abs=1e-5, tuned for backward compatibility on stiff
+        // affine problems, see that function's docs) -- this test wants
+        // the tighter, general-purpose criterion to demonstrate genuine
+        // convergence, not the loose one.
+        let full_result = CrankNicolsonSolver::new()
+            .with_newton_convergence(NewtonConvergence::default())
+            .with_jacobian_strategy(JacobianStrategy::FullNewton)
+            .with_max_newton_iterations(50)
+            .solve(&scenario_full, &config)
+            .unwrap();
+        let full_value = full_result
+            .states
+            .last()
+            .unwrap()
+            .as_scalar_field()
+            .unwrap()[0];
+
+        // Independently solved scalar equation:
+        // u_next - dt/2*(-u_next^3) = 1.0 + dt/2*(-1.0^3)
+        // i.e. u_next + dt/2*u_next^3 = 1.0 - dt/2.
+        let rhs = 1.0 - dt / 2.0;
+        let mut u_scalar = 1.0_f64;
+        for _ in 0..100 {
+            let g = u_scalar + (dt / 2.0) * u_scalar.powi(3) - rhs;
+            let dg = 1.0 + 1.5 * dt * u_scalar.powi(2);
+            u_scalar -= g / dg;
+        }
+
+        assert!(
+            (full_value - u_scalar).abs() < 1e-6,
+            "FullNewton should reach the converged discrete solution: got {full_value}, expected {u_scalar}"
+        );
     }
 }

--- a/src/solver/methods/implicit.rs
+++ b/src/solver/methods/implicit.rs
@@ -4,8 +4,10 @@
 //!
 //! [`BackwardEulerSolver`](super::backward_euler::BackwardEulerSolver) (θ=1)
 //! and [`CrankNicolsonSolver`](super::crank_nicolson::CrankNicolsonSolver)
-//! (θ=0.5) are thin wrappers around [`theta_method_step`], which itself
-//! relies on [`finite_difference_jacobian`].
+//! (θ=0.5) are thin wrappers around [`theta_method_step_newton`] (DD-044,
+//! #111), which itself relies on [`finite_difference_jacobian`] and the
+//! shared [`super::newton`] loop. [`theta_method_step`] keeps the
+//! original, non-configurable entry point for direct callers — see below.
 //!
 //! ## Why a single shared function for two methods
 //!
@@ -19,18 +21,39 @@
 //! depend on θ at all. Only the system matrix does
 //! ($I - \theta \Delta t J_f$). One function, one parameter.
 //!
-//! ## v1 scope — frozen Jacobian, single correction (DD-033)
+//! ## v1 scope — frozen Jacobian, single correction (DD-033) by default
 //!
 //! [`theta_method_step`] performs exactly **one** Newton-style correction,
-//! with the Jacobian frozen at $u^n$. This is exact when `compute_physics`
-//! is affine in `u` — the stiff *linear* test problems these methods
-//! target (`λΔt ≫ 1`) — and a first-order approximation otherwise.
+//! with the Jacobian frozen at $u^n$ — this is exact when `compute_physics`
+//! is affine in `u` and a first-order approximation otherwise, and stays
+//! the behaviour of [`theta_method_step`] itself (used directly by
+//! callers that don't need more) and of
+//! [`BackwardEulerSolver`](super::backward_euler::BackwardEulerSolver)/
+//! [`CrankNicolsonSolver`](super::crank_nicolson::CrankNicolsonSolver)
+//! when left unconfigured.
 //!
-//! A future nonlinear solver (Newton iterated to convergence, v0.6.0–v1.0.0,
-//! DD-033) would call this same function repeatedly, re-evaluating
-//! [`finite_difference_jacobian`] at each updated guess if the frozen
-//! approximation is dropped — neither function needs rewriting, only the
-//! calling loop changes.
+//! [`theta_method_step_newton`] (DD-044, #111) is the genuinely iterated
+//! alternative DD-033 anticipated: it routes through the shared
+//! [`super::newton`] loop with caller-supplied convergence/Jacobian-
+//! strategy/iteration-budget configuration.
+//! `BackwardEulerSolver`/`CrankNicolsonSolver` call it directly (with
+//! `with_newton_convergence`/`with_jacobian_strategy`/
+//! `with_max_newton_iterations` builders); [`theta_method_step`] itself
+//! stays at its original signature by delegating to it with
+//! `k_max = 1`/[`JacobianStrategy::ModifiedFrozen`](super::newton::JacobianStrategy::ModifiedFrozen)
+//! baked in, reproducing its historical output exactly (see
+//! [`super::newton`]'s own docs for why no special-casing is needed for
+//! this to hold on affine problems).
+//!
+//! ## Known gap — sparse path not yet Newton-aware
+//!
+//! [`theta_method_step_adaptive`] (the sparse/banded dispatch, DD-043)
+//! still performs a single frozen-Jacobian correction unconditionally —
+//! it is not wired through [`super::newton`] at this increment. Composing
+//! the two was verified, not implemented, per #111's stated scope:
+//! configuring both a sparse backend *and* a non-default Newton budget on
+//! the same solver silently keeps the sparse path single-shot. Tracked as
+//! a follow-up, mirroring the existing BDF2/sparse gap.
 //!
 //! ## Known untested limitation — boundary conditions
 //!
@@ -45,6 +68,7 @@
 use nalgebra::{DMatrix, DVector};
 
 use super::evaluate_derivative;
+use super::newton::{self, JacobianStrategy, NewtonConvergence};
 use crate::context::error::OxiflowError;
 use crate::context::value::ContextValue;
 use crate::context::ContextCalculator;
@@ -100,6 +124,34 @@ pub(crate) fn finite_difference_jacobian(
     Ok(jacobian)
 }
 
+/// Convergence criterion guaranteeing [`theta_method_step`]'s
+/// single-correction contract succeeds on the stiffest affine problems
+/// this crate currently tests (`λ = 1e4`-scale exponential decay).
+///
+/// Deliberately distinct from [`NewtonConvergence::default`] (`tol_abs =
+/// 1e-8`): on such problems, [`finite_difference_jacobian`]'s fixed step
+/// size suffers catastrophic-cancellation error whose absolute magnitude
+/// scales roughly as `λ · ε_machine / FD_EPSILON` — empirically up to
+/// ~1e-6 for the stiffest cases tested. The single correction itself is
+/// still mathematically exact for affine `f`; this is a
+/// finite-difference precision floor, not a nonlinearity signal, and
+/// [`NewtonConvergence::default`] remains the right general-purpose
+/// starting point for callers configuring the loop themselves — it just
+/// isn't loose enough to guarantee success on this specific,
+/// already-tested edge of the stiffness range. Used here and by
+/// [`BackwardEulerSolver::default`](super::backward_euler::BackwardEulerSolver)/
+/// [`CrankNicolsonSolver::default`](super::crank_nicolson::CrankNicolsonSolver)
+/// — not by `NewtonConvergence`'s own `Default` impl — precisely so that
+/// zero-config solver construction keeps reproducing history exactly,
+/// without changing what a fresh, explicitly-configured
+/// `NewtonConvergence::default()` means elsewhere.
+pub(crate) fn stiff_jacobian_convergence() -> NewtonConvergence {
+    NewtonConvergence::ResidualOnly {
+        tol_abs: 1e-5,
+        tol_rel: 1e-6,
+    }
+}
+
 /// Performs one step of the generalised theta method, with the Jacobian
 /// frozen at `state` (one Newton-style correction, not iterated — see
 /// [module docs](self)).
@@ -110,6 +162,12 @@ pub(crate) fn finite_difference_jacobian(
 /// contract as the explicit solvers (see
 /// [`crate::solver::methods::evaluate_derivative`]): callers should not
 /// assume `state` is left unchanged after this call.
+///
+/// Delegates to [`theta_method_step_newton`] with the pre-DD-044 defaults
+/// (`k_max = 1`, [`JacobianStrategy::ModifiedFrozen`],
+/// [`stiff_jacobian_convergence`]) baked in — kept at its original
+/// signature (DD-044, #110) for direct callers that don't need the
+/// configurable path.
 pub(crate) fn theta_method_step(
     domain: &Domain,
     chain: &[&dyn ContextCalculator],
@@ -119,29 +177,80 @@ pub(crate) fn theta_method_step(
     theta: f64,
     linear_solver: &dyn LinearSolver,
 ) -> Result<ContextValue, OxiflowError> {
+    theta_method_step_newton(
+        domain,
+        chain,
+        state,
+        t,
+        dt,
+        theta,
+        linear_solver,
+        stiff_jacobian_convergence(),
+        JacobianStrategy::default(),
+        1,
+    )
+}
+
+/// Same contract as [`theta_method_step`], routed through the generic
+/// iterated Newton loop ([`newton::solve`]) with caller-supplied
+/// convergence/Jacobian-strategy/iteration-budget configuration (DD-044,
+/// #111) — [`BackwardEulerSolver`](super::backward_euler::BackwardEulerSolver)
+/// and [`CrankNicolsonSolver`](super::crank_nicolson::CrankNicolsonSolver)
+/// call this directly, passing their own configured fields; their
+/// defaults reproduce [`theta_method_step`]'s call above exactly.
+///
+/// Follows [`newton`]'s residual convention with $\alpha = 1$, $c = \theta
+/// \Delta t$, $u^{*} = u^n + \Delta t(1-\theta)f(u^n)$ — see that
+/// module's docs. `f(u^n)` is evaluated once, at time `t` (the known
+/// term); every subsequent candidate `f`/Jacobian evaluation inside the
+/// Newton loop is at time `t + dt` (the implicit/target time), matching
+/// [`theta_method_step`]'s original convention.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn theta_method_step_newton(
+    domain: &Domain,
+    chain: &[&dyn ContextCalculator],
+    state: &mut ContextValue,
+    t: f64,
+    dt: f64,
+    theta: f64,
+    linear_solver: &dyn LinearSolver,
+    newton_convergence: NewtonConvergence,
+    jacobian_strategy: JacobianStrategy,
+    max_iterations: usize,
+) -> Result<ContextValue, OxiflowError> {
     // f(u^n, t) -- BCs applied in-place to `state` itself, consistent with
-    // the explicit solvers' contract. Everything below reads the
-    // now-BC-corrected `state`, not a separate untouched clone.
+    // the explicit solvers' contract (same as `theta_method_step`).
     let f_n = evaluate_derivative(domain, chain, state, t, dt)?;
     let u_n_field = state.as_scalar_field()?.clone();
     let f_n_field = f_n.as_scalar_field()?.clone();
 
-    let n = u_n_field.len();
+    let u0 = u_n_field.clone();
+    let u_star: DVector<f64> = u_n_field + f_n_field * (dt * (1.0 - theta));
+    let coeff = theta * dt;
+    let t_target = t + dt;
 
-    // Jacobian frozen at the (now BC-corrected) u^n, evaluated at the
-    // *target* time t + dt (the point the implicit equation is actually
-    // stated at).
-    let jacobian = finite_difference_jacobian(domain, chain, state, t + dt, dt)?;
+    let u_next = newton::solve(
+        u0,
+        &u_star,
+        1.0,
+        coeff,
+        move |candidate: &DVector<f64>| {
+            let mut candidate_state = ContextValue::ScalarField(candidate.clone());
+            let f = evaluate_derivative(domain, chain, &mut candidate_state, t_target, dt)?;
+            Ok(f.as_scalar_field()?.clone())
+        },
+        move |candidate: &DVector<f64>| {
+            let candidate_state = ContextValue::ScalarField(candidate.clone());
+            finite_difference_jacobian(domain, chain, &candidate_state, t_target, dt)
+        },
+        linear_solver,
+        &newton::NewtonParams {
+            convergence: newton_convergence,
+            jacobian_strategy,
+            max_iterations,
+        },
+    )?;
 
-    // System matrix: I - theta * dt * J_f. RHS: dt * f(u^n) -- identical
-    // for any theta, see module docs.
-    let identity = DMatrix::<f64>::identity(n, n);
-    let system_matrix = identity - jacobian * (theta * dt);
-    let rhs = f_n_field * dt;
-
-    let delta_u = linear_solver.solve(&system_matrix, &rhs)?;
-
-    let u_next: DVector<f64> = u_n_field + delta_u;
     Ok(ContextValue::ScalarField(u_next))
 }
 

--- a/src/solver/methods/implicit.rs
+++ b/src/solver/methods/implicit.rs
@@ -55,15 +55,19 @@
 //! the same solver silently keeps the sparse path single-shot. Tracked as
 //! a follow-up, mirroring the existing BDF2/sparse gap.
 //!
-//! ## Known untested limitation — boundary conditions
+//! ## Boundary conditions × the perturbed Jacobian
 //!
 //! [`finite_difference_jacobian`] perturbs each component of the state and
 //! re-evaluates [`evaluate_derivative`], which re-applies boundary
 //! conditions on every call. A Dirichlet-constrained node will have its
 //! perturbation overwritten before `compute_physics` sees it — physically
-//! correct (a BC-constrained node isn't a free unknown), but **no test
-//! case exercises this yet**. Validate explicitly before using an implicit
-//! solver on a domain with boundary conditions.
+//! correct (a BC-constrained node isn't a free unknown): the constrained
+//! node's own *column* in the assembled Jacobian is exactly zero, while
+//! its *row* still reflects genuine physics-based coupling to
+//! unconstrained neighbours. Verified by
+//! `tests::dirichlet_constrained_column_is_exactly_zero_row_keeps_real_coupling`
+//! (#113) — previously documented as a known untested limitation (DD-033,
+//! v0.4.0).
 
 use nalgebra::{DMatrix, DVector};
 
@@ -91,7 +95,7 @@ const FD_EPSILON: f64 = 1e-7;
 /// against), forward differences are exact regardless of step size — no
 /// truncation error from the linear approximation itself.
 ///
-/// See the [known limitation on boundary conditions](self#known-untested-limitation--boundary-conditions).
+/// See [boundary conditions × the perturbed Jacobian](self#boundary-conditions--the-perturbed-jacobian).
 pub(crate) fn finite_difference_jacobian(
     domain: &Domain,
     chain: &[&dyn ContextCalculator],
@@ -608,6 +612,153 @@ mod tests {
             assert!(v.abs() < 1.0, "expected strong damping, got {v}");
         }
     }
+
+    // ── Dirichlet BC × perturbed Jacobian (#113) ───────────────────────────────
+
+    use crate::boundary::{BoundaryCondition, BoundaryType};
+
+    /// Discrete tridiagonal diffusion with a spike initial condition —
+    /// genuine spatial coupling to neighbours, needed to distinguish
+    /// "legitimate physics coupling" from "spurious coupling introduced by
+    /// BC re-application" in the test below. A local copy rather than
+    /// reusing `sparse_tests::TridiagonalDiffusion`: that fixture only
+    /// exists under `feature = "sparse"`, and this test needs no sparse
+    /// machinery.
+    #[derive(Debug)]
+    struct TridiagonalDiffusion {
+        diffusion: f64,
+    }
+
+    impl RequiresContext for TridiagonalDiffusion {
+        fn required_variables(&self) -> Vec<ContextVariable> {
+            vec![]
+        }
+    }
+
+    impl PhysicalModel for TridiagonalDiffusion {
+        fn compute_physics(
+            &self,
+            state: &ContextValue,
+            _ctx: &ComputeContext,
+        ) -> Result<ContextValue, OxiflowError> {
+            let u = state.as_scalar_field()?;
+            let n = u.len();
+            let d = self.diffusion;
+            let out = DVector::from_fn(n, |i, _| {
+                let left = if i > 0 { u[i - 1] } else { 0.0 };
+                let right = if i + 1 < n { u[i + 1] } else { 0.0 };
+                d * (left - 2.0 * u[i] + right)
+            });
+            Ok(ContextValue::ScalarField(out))
+        }
+
+        fn initial_state(&self, mesh: &dyn Mesh) -> ContextValue {
+            let n = mesh.n_dof();
+            ContextValue::ScalarField(DVector::from_fn(
+                n,
+                |i, _| if i == n / 2 { 1.0 } else { 0.0 },
+            ))
+        }
+
+        fn name(&self) -> &str {
+            "tridiagonal_diffusion_dirichlet_test"
+        }
+    }
+
+    /// Fixes a single node to a constant value — a minimal Dirichlet BC.
+    /// No built-in `BoundaryCondition` implementation in `crate::boundary`
+    /// enforces a plain Dirichlet constraint today (only `DanckwertsInlet`/
+    /// `DanckwertsOutlet`, Robin/Neumann), so this test defines its own.
+    #[derive(Debug)]
+    struct FixedDirichlet {
+        node_index: usize,
+        value: f64,
+    }
+
+    impl RequiresContext for FixedDirichlet {
+        fn required_variables(&self) -> Vec<ContextVariable> {
+            vec![]
+        }
+    }
+
+    impl BoundaryCondition for FixedDirichlet {
+        fn boundary_type(&self) -> BoundaryType {
+            BoundaryType::Dirichlet
+        }
+
+        fn apply(
+            &self,
+            state: &mut DVector<f64>,
+            _ctx: &ComputeContext,
+            _mesh: &dyn Mesh,
+        ) -> Result<(), OxiflowError> {
+            state[self.node_index] = self.value;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn dirichlet_constrained_column_is_exactly_zero_row_keeps_real_coupling() {
+        // DD-033's known limitation, closed by #113: `finite_difference_jacobian`
+        // perturbs each state component and re-evaluates `evaluate_derivative`,
+        // which re-applies boundary conditions on every call. A
+        // Dirichlet-constrained node's perturbation is therefore overwritten
+        // before `compute_physics` ever sees it -- physically correct (a
+        // BC-constrained node isn't a free unknown), verified here rather
+        // than merely documented.
+        let n = 5;
+        let constrained = n / 2; // the model's initial spike location
+        let diffusion = 0.7;
+
+        let domain = Domain::new(
+            "dirichlet_test",
+            Box::new(TridiagonalDiffusion { diffusion }),
+            make_mesh(n),
+        )
+        .with_boundary_conditions(vec![Box::new(FixedDirichlet {
+            node_index: constrained,
+            value: 0.0,
+        })]);
+        let scenario = Scenario::multi(vec![domain]).unwrap();
+        let domain = scenario.single_domain().unwrap();
+        let requirements = scenario.context_requirements();
+        let chain = build_calculator_chain(&requirements, &[]).unwrap();
+
+        let state = domain.model.initial_state(domain.mesh.as_ref());
+        let jac = finite_difference_jacobian(domain, &chain, &state, 0.0, 0.01).unwrap();
+
+        // Column: perturbing the constrained node itself must leave every
+        // row's output exactly unchanged -- the perturbation never
+        // survives BC re-application, so both the base and perturbed
+        // evaluations see bit-identical states, giving f_j - f0 = 0
+        // exactly, not merely small.
+        for i in 0..n {
+            assert_eq!(
+                jac[(i, constrained)],
+                0.0,
+                "column {constrained} (the constrained node) must be exactly \
+                 zero at row {i} -- got {}",
+                jac[(i, constrained)]
+            );
+        }
+
+        // Row: the constrained node's own output still genuinely depends
+        // on its unconstrained neighbours through the model's real spatial
+        // coupling -- legitimate physics, not spurious coupling, and must
+        // not be zeroed out by the fix the column check above verifies.
+        let left = constrained - 1;
+        let right = constrained + 1;
+        assert!(
+            (jac[(constrained, left)] - diffusion).abs() < 1e-6,
+            "expected left-neighbour coupling ~{diffusion}, got {}",
+            jac[(constrained, left)]
+        );
+        assert!(
+            (jac[(constrained, right)] - diffusion).abs() < 1e-6,
+            "expected right-neighbour coupling ~{diffusion}, got {}",
+            jac[(constrained, right)]
+        );
+    }
 }
 
 #[cfg(all(test, feature = "sparse"))]
@@ -626,8 +777,10 @@ mod sparse_tests {
     /// u[i+1])`, zero outside the domain. Not a real `BoundaryCondition` —
     /// this fixture exists only to exercise the banded path with a
     /// genuinely local, bandwidth-1 coupling (real Dirichlet/Neumann
-    /// boundary handling is out of scope here, see the module's own
-    /// known-untested-limitation note).
+    /// boundary handling is covered separately, see the module's own docs
+    /// on boundary conditions × the perturbed Jacobian, and
+    /// `tests::dirichlet_constrained_column_is_exactly_zero_row_keeps_real_coupling`,
+    /// #113).
     #[derive(Debug)]
     struct TridiagonalDiffusion {
         diffusion: f64,

--- a/src/solver/methods/mod.rs
+++ b/src/solver/methods/mod.rs
@@ -29,7 +29,10 @@
 //! Implicit methods ([`backward_euler`], [`crank_nicolson`], [`bdf2`]) build
 //! on the same [`evaluate_derivative`] for their explicit-derivative
 //! evaluation, plus the shared machinery in [`implicit`] (frozen-Jacobian
-//! Newton correction, DD-033) for the implicit part.
+//! single correction, DD-033) for the implicit part. [`newton`] adds the
+//! genuinely iterated alternative DD-033 anticipated (DD-044, v0.7.0) —
+//! not yet wired into [`backward_euler`]/[`crank_nicolson`]/[`bdf2`] at
+//! this increment (see [`newton`]'s own module docs for scope).
 //!
 //! ## Per-step primitive, with history (DD-031, DD-034)
 //!
@@ -66,6 +69,7 @@ pub mod dopri45;
 pub mod euler;
 pub mod imex;
 pub mod implicit;
+pub mod newton;
 pub mod rk4;
 pub mod step_control;
 
@@ -75,6 +79,7 @@ pub use crank_nicolson::CrankNicolsonSolver;
 pub use dopri45::DoPri45Solver;
 pub use euler::ForwardEulerSolver;
 pub use imex::{OperatorSplittingSolver, SplitOperator, SplittingScheme};
+pub use newton::{JacobianStrategy, NewtonConvergence};
 pub use rk4::RK4Solver;
 pub use step_control::StepSizeController;
 

--- a/src/solver/methods/mod.rs
+++ b/src/solver/methods/mod.rs
@@ -31,7 +31,9 @@
 //! evaluation, plus the shared machinery in [`implicit`] for the implicit
 //! part. [`newton`] provides the iterated Newton alternative DD-033
 //! anticipated (DD-044, v0.7.0), wired into [`backward_euler`]/
-//! [`crank_nicolson`] (#111) — not yet into [`bdf2`] (#112).
+//! [`crank_nicolson`] (#111) and [`bdf2`] (#112) — [`bdf2`]'s
+//! startup/bootstrap step is the one exception, unconditionally using
+//! the non-configurable single-correction path (see that module's docs).
 //!
 //! ## Per-step primitive, with history (DD-031, DD-034)
 //!

--- a/src/solver/methods/mod.rs
+++ b/src/solver/methods/mod.rs
@@ -28,11 +28,10 @@
 //!
 //! Implicit methods ([`backward_euler`], [`crank_nicolson`], [`bdf2`]) build
 //! on the same [`evaluate_derivative`] for their explicit-derivative
-//! evaluation, plus the shared machinery in [`implicit`] (frozen-Jacobian
-//! single correction, DD-033) for the implicit part. [`newton`] adds the
-//! genuinely iterated alternative DD-033 anticipated (DD-044, v0.7.0) —
-//! not yet wired into [`backward_euler`]/[`crank_nicolson`]/[`bdf2`] at
-//! this increment (see [`newton`]'s own module docs for scope).
+//! evaluation, plus the shared machinery in [`implicit`] for the implicit
+//! part. [`newton`] provides the iterated Newton alternative DD-033
+//! anticipated (DD-044, v0.7.0), wired into [`backward_euler`]/
+//! [`crank_nicolson`] (#111) — not yet into [`bdf2`] (#112).
 //!
 //! ## Per-step primitive, with history (DD-031, DD-034)
 //!

--- a/src/solver/methods/newton.rs
+++ b/src/solver/methods/newton.rs
@@ -1,0 +1,526 @@
+//! # Module `solver::methods::newton`
+//!
+//! Iterated Newton solver — shared, integrator-agnostic core (DD-044,
+//! issue #109, activating DD-033's Option A).
+//!
+//! ## Why this exists
+//!
+//! [`super::implicit::theta_method_step`] and [`super::bdf2::bdf2_step`]
+//! (through v0.6.0) each performed exactly **one** Newton-style
+//! correction with a frozen Jacobian — exact when the underlying
+//! `compute_physics` is affine in `u`, a first-order approximation
+//! otherwise. This module provides the genuinely iterated alternative
+//! DD-033 always anticipated, shared by both call sites rather than
+//! duplicated: theta-method and BDF2 (this sprint's two concrete
+//! consumers) differ only in how they express their residual as an
+//! affine transform of `u` plus an implicit term — see
+//! [the residual convention](#residual-convention) below.
+//!
+//! ## Residual convention
+//!
+//! Both consumers' implicit equations reduce to the same shape:
+//!
+//! $$g(u) = \alpha (u - u^{*}) - c \cdot f(u)$$
+//!
+//! - **theta-method** (Backward Euler `θ=1`, Crank-Nicolson `θ=0.5`):
+//!   $\alpha = 1$, $c = \theta \Delta t$, $u^{*} = u^n + \Delta t(1-\theta)
+//!   f(u^n)$.
+//! - **BDF2**: $\alpha = 3/2$, $c = \Delta t$, $u^{*} = \frac{4u^n -
+//!   u^{n-1}}{3}$.
+//!
+//! `u^{*}` folds in every term that doesn't depend on the unknown `u` —
+//! callers compute it once, outside the loop, from already-known past
+//! states. [`residual`] and [`linear_correction`] are the two building
+//! blocks operating on this shape; [`solve`] is the generic loop wiring
+//! them together with a [`NewtonConvergence`] criterion and a
+//! [`JacobianStrategy`].
+//!
+//! ## Dense/sparse agnosticism
+//!
+//! This module knows nothing about `Domain`, `ContextCalculator`, or
+//! `faer` — [`solve`] is parameterised over caller-supplied closures for
+//! evaluating $f(u)$ and its Jacobian, and over `&dyn LinearSolver` for
+//! the correction step. The existing sparse/banded dispatch
+//! (DD-043, `theta_method_step_adaptive`) is therefore untouched by this
+//! module: composing the two is [`super::implicit`]'s concern (chantier
+//! 2), not this one's.
+//!
+//! ## Scope of this increment (issue #110)
+//!
+//! This module is the shared core only — it is not yet called from
+//! [`super::implicit::theta_method_step`] or [`super::bdf2::bdf2_step`].
+//! That wiring, and the `with_newton_convergence`/`with_jacobian_strategy`/
+//! `with_max_newton_iterations` builders on the three implicit solvers,
+//! land in the follow-up issues (#111, #112).
+
+use nalgebra::{DMatrix, DVector};
+
+use crate::context::error::OxiflowError;
+use crate::solver::linear::LinearSolver;
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+/// Convergence criterion for the iterated Newton loop ([`solve`]).
+///
+/// Every variant carries the same `tol_abs`/`tol_rel` pair: convergence
+/// is tested against `tol_abs + tol_rel * ||u||`, evaluated on the
+/// iterate *after* applying the current correction (so that, e.g.,
+/// `max_iterations = 1` with an exactly affine `f` succeeds immediately —
+/// the single correction is already exact up to floating-point rounding).
+///
+/// Default: [`ResidualOnly`](Self::ResidualOnly) with `tol_abs = 1e-8`,
+/// `tol_rel = 1e-6` — starting points, not fixed constants; tune via the
+/// solver builders once this lands (#111/#112).
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum NewtonConvergence {
+    /// Converged once `||g(u)|| < tol_abs + tol_rel * ||u||`.
+    ///
+    /// The residual is available at zero extra cost — `f(u)` is already
+    /// evaluated to build the next correction — so this is the cheapest
+    /// criterion, not merely the default for convenience.
+    ResidualOnly { tol_abs: f64, tol_rel: f64 },
+    /// Converged once **either** the residual **or** the correction norm
+    /// (`||δu||`) satisfies the tolerance.
+    CombinedOr { tol_abs: f64, tol_rel: f64 },
+    /// Converged only once **both** the residual **and** the correction
+    /// norm satisfy the tolerance — the strictest of the three.
+    CombinedAnd { tol_abs: f64, tol_rel: f64 },
+}
+
+impl Default for NewtonConvergence {
+    fn default() -> Self {
+        NewtonConvergence::ResidualOnly {
+            tol_abs: 1e-8,
+            tol_rel: 1e-6,
+        }
+    }
+}
+
+impl NewtonConvergence {
+    /// Extracts the common `(tol_abs, tol_rel)` pair, regardless of
+    /// variant.
+    // TODO(#111/#112): called from `solve` below, itself unwired until
+    // then — see that function's own TODO.
+    #[allow(dead_code)]
+    fn tolerances(&self) -> (f64, f64) {
+        match *self {
+            NewtonConvergence::ResidualOnly { tol_abs, tol_rel }
+            | NewtonConvergence::CombinedOr { tol_abs, tol_rel }
+            | NewtonConvergence::CombinedAnd { tol_abs, tol_rel } => (tol_abs, tol_rel),
+        }
+    }
+}
+
+/// Jacobian refresh strategy for the iterated Newton loop ([`solve`]).
+///
+/// Default: [`ModifiedFrozen`](Self::ModifiedFrozen) — matches the
+/// pre-DD-044 behaviour (Jacobian evaluated once, at the initial guess,
+/// never refreshed) as a special case of the generic loop, rather than a
+/// separate code path.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum JacobianStrategy {
+    /// Evaluate the Jacobian once, at the initial guess, and reuse it for
+    /// every correction (modified Newton).
+    #[default]
+    ModifiedFrozen,
+    /// Re-evaluate the Jacobian at every iterate (full Newton) — most
+    /// robust on strongly nonlinear problems, at the cost of one
+    /// [`finite_difference_jacobian`](super::implicit::finite_difference_jacobian)
+    /// (or its banded equivalent) per iteration.
+    FullNewton,
+    /// Reuse the frozen Jacobian while convergence is proceeding
+    /// acceptably; re-evaluate it once the residual stops shrinking fast
+    /// enough. Refreshed whenever
+    /// `residual_norm_k / residual_norm_{k-1} > stagnation_ratio` — an
+    /// explicit extension point for J8 (v0.8.0) cost/robustness tuning,
+    /// not yet auto-tuned.
+    ModifiedWithStagnationCheck { stagnation_ratio: f64 },
+}
+
+// ── Building blocks ───────────────────────────────────────────────────────────
+
+/// Evaluates the residual $g(u) = \alpha (u - u^{*}) - c \cdot f(u)$ — see
+/// the [module docs](self#residual-convention) for what `alpha`/`coeff`/
+/// `u_star` mean for each of this loop's two consumers.
+///
+/// `f_u` is `f(u)`, already evaluated by the caller (it is also needed
+/// to decide, e.g., whether to refresh the Jacobian — evaluating it here
+/// again would be redundant).
+// TODO(#111/#112): wire in once BackwardEulerSolver/CrankNicolsonSolver/
+// BDF2Solver route theta_method_step/bdf2_step through the generic loop —
+// currently only exercised by this module's own unit tests.
+#[allow(dead_code)]
+pub(crate) fn residual(
+    u: &DVector<f64>,
+    u_star: &DVector<f64>,
+    alpha: f64,
+    coeff: f64,
+    f_u: &DVector<f64>,
+) -> DVector<f64> {
+    let delta: DVector<f64> = u - u_star;
+    delta * alpha - f_u.clone() * coeff
+}
+
+/// Solves the linearised correction $[\alpha I - c J_f] \delta u = -g(u)$
+/// for $\delta u$, given an already-assembled Jacobian $J_f =
+/// \partial f/\partial u$.
+///
+/// Resolution only — `jacobian` is supplied by the caller (typically
+/// [`finite_difference_jacobian`](super::implicit::finite_difference_jacobian),
+/// unchanged) rather than computed here, so this function stays
+/// dense/sparse-agnostic in principle; only the dense path
+/// (`&dyn LinearSolver`) is wired at this increment (#110) — banded/sparse
+/// composition is verified, not redecided, in #111.
+// TODO(#111/#112): wire in alongside `residual` above.
+#[allow(dead_code)]
+pub(crate) fn linear_correction(
+    jacobian: &DMatrix<f64>,
+    alpha: f64,
+    coeff: f64,
+    residual: &DVector<f64>,
+    linear_solver: &dyn LinearSolver,
+) -> Result<DVector<f64>, OxiflowError> {
+    let n = jacobian.nrows();
+    let identity = DMatrix::<f64>::identity(n, n);
+    let system_matrix = identity * alpha - jacobian.clone() * coeff;
+    let rhs: DVector<f64> = -residual.clone();
+    linear_solver.solve(&system_matrix, &rhs)
+}
+
+// ── Generic loop ──────────────────────────────────────────────────────────────
+
+/// Parameters governing the iterated Newton loop ([`solve`]), gathered
+/// into one struct so the loop's own argument list stays manageable
+/// alongside the residual-shape parameters (`u_star`/`alpha`/`coeff`)
+/// and the two evaluation closures.
+// TODO(#111/#112): constructed by BackwardEulerSolver/CrankNicolsonSolver/
+// BDF2Solver once they gain `with_newton_convergence`/`with_jacobian_strategy`/
+// `with_max_newton_iterations` builders.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct NewtonParams {
+    pub convergence: NewtonConvergence,
+    pub jacobian_strategy: JacobianStrategy,
+    pub max_iterations: usize,
+}
+
+/// Runs the iterated Newton loop for $g(u) = \alpha(u - u^{*}) - c f(u) =
+/// 0$, starting from `u0`.
+///
+/// `f_eval` evaluates $f(u)$ for a candidate iterate (in production,
+/// this wraps [`evaluate_derivative`](super::evaluate_derivative) —
+/// including its boundary-condition re-application, see
+/// [`super::implicit`]'s known-limitation note); `jac_eval` evaluates
+/// $\partial f/\partial u$ at a candidate iterate (wraps
+/// [`finite_difference_jacobian`](super::implicit::finite_difference_jacobian)
+/// or its banded equivalent). Both are called at most `max_iterations + 1`
+/// times each.
+///
+/// Convergence is checked **after** applying each correction, uniformly
+/// regardless of `max_iterations` — there is no special case for
+/// `max_iterations == 1`. This is deliberate: whether `f` is affine in
+/// `u` is not tracked or asserted anywhere (doing so would require the
+/// HOW pole to know something about the WHAT pole's `PhysicalModel`,
+/// which DD-044 does not introduce) — it is instead *inferred for free*
+/// from the residual itself. For an affine `f`, a single correction is
+/// exact, so the post-application residual already sits at
+/// floating-point precision and passes any reasonable tolerance; for a
+/// genuinely nonlinear `f`, it generally does not, and
+/// `max_iterations == 1` then correctly reports
+/// [`OxiflowError::NewtonNotConverged`] instead of silently returning a
+/// first-order-accurate value.
+///
+/// Consequence for callers migrating from the pre-DD-044
+/// `theta_method_step`/`bdf2_step` (which never checked convergence, and
+/// so could never fail this way): calling this loop with the historical
+/// defaults (`max_iterations = 1`, `ModifiedFrozen`) reproduces the exact
+/// same numeric result on every existing (affine) regression case, but
+/// — unlike before — now surfaces an explicit error rather than a silent
+/// first-order approximation on a genuinely nonlinear model. Widen
+/// `max_iterations` (or the tolerance) for such models rather than
+/// relying on the single-correction default.
+///
+/// # Errors
+///
+/// Returns [`OxiflowError::NewtonNotConverged`] if `max_iterations` is
+/// exhausted without satisfying `params.convergence`. Propagates any
+/// error from `f_eval`, `jac_eval`, or the linear solve unchanged.
+// TODO(#111/#112): called from BackwardEulerSolver/CrankNicolsonSolver/
+// BDF2Solver's step() once wired — currently only exercised by this
+// module's own unit tests (see the `tests` module below).
+#[allow(dead_code)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn solve(
+    u0: DVector<f64>,
+    u_star: &DVector<f64>,
+    alpha: f64,
+    coeff: f64,
+    mut f_eval: impl FnMut(&DVector<f64>) -> Result<DVector<f64>, OxiflowError>,
+    mut jac_eval: impl FnMut(&DVector<f64>) -> Result<DMatrix<f64>, OxiflowError>,
+    linear_solver: &dyn LinearSolver,
+    params: &NewtonParams,
+) -> Result<DVector<f64>, OxiflowError> {
+    let (tol_abs, tol_rel) = params.convergence.tolerances();
+
+    let mut u = u0;
+    let mut jacobian = jac_eval(&u)?;
+    let mut f_u = f_eval(&u)?;
+    let mut prev_residual_norm: Option<f64> = None;
+    let mut last_residual_norm = f64::INFINITY;
+
+    for _ in 0..params.max_iterations {
+        let res = residual(&u, u_star, alpha, coeff, &f_u);
+        let correction = linear_correction(&jacobian, alpha, coeff, &res, linear_solver)?;
+        let correction_norm = correction.norm();
+        u += correction;
+
+        f_u = f_eval(&u)?;
+        let res_new = residual(&u, u_star, alpha, coeff, &f_u);
+        let res_new_norm = res_new.norm();
+        last_residual_norm = res_new_norm;
+
+        let tol = tol_abs + tol_rel * u.norm();
+        let residual_ok = res_new_norm < tol;
+        let correction_ok = correction_norm < tol;
+        let converged = match params.convergence {
+            NewtonConvergence::ResidualOnly { .. } => residual_ok,
+            NewtonConvergence::CombinedOr { .. } => residual_ok || correction_ok,
+            NewtonConvergence::CombinedAnd { .. } => residual_ok && correction_ok,
+        };
+        if converged {
+            return Ok(u);
+        }
+
+        match params.jacobian_strategy {
+            JacobianStrategy::ModifiedFrozen => {}
+            JacobianStrategy::FullNewton => {
+                jacobian = jac_eval(&u)?;
+            }
+            JacobianStrategy::ModifiedWithStagnationCheck { stagnation_ratio } => {
+                let stagnating = prev_residual_norm
+                    .map(|prev| prev > 0.0 && res_new_norm / prev > stagnation_ratio)
+                    .unwrap_or(false);
+                if stagnating {
+                    jacobian = jac_eval(&u)?;
+                }
+            }
+        }
+        prev_residual_norm = Some(res_new_norm);
+    }
+
+    Err(OxiflowError::NewtonNotConverged {
+        iterations: params.max_iterations,
+        residual: last_residual_norm,
+    })
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::solver::linear::NalgebraDenseSolver;
+
+    // Two synthetic, domain-free test problems — this module is
+    // integrator-agnostic, so its own tests exercise `solve` directly
+    // against hand-written f/jacobian closures rather than a full
+    // Domain/Scenario, unlike `implicit.rs`/`bdf2.rs`'s tests.
+
+    /// f(u) = -lambda*u — affine, so a single correction is exact
+    /// regardless of `max_iterations`/`jacobian_strategy`.
+    fn affine_decay(
+        lambda: f64,
+    ) -> (
+        impl FnMut(&DVector<f64>) -> Result<DVector<f64>, OxiflowError>,
+        impl FnMut(&DVector<f64>) -> Result<DMatrix<f64>, OxiflowError>,
+    ) {
+        let f = move |u: &DVector<f64>| Ok(u.map(|v| -lambda * v));
+        let jac =
+            move |u: &DVector<f64>| Ok(DMatrix::<f64>::identity(u.len(), u.len()) * (-lambda));
+        (f, jac)
+    }
+
+    /// f(u) = -u^3 — genuinely nonlinear; one frozen-Jacobian correction
+    /// is only a first-order approximation, iterated Newton is needed
+    /// for tight convergence.
+    fn cubic_decay() -> (
+        impl FnMut(&DVector<f64>) -> Result<DVector<f64>, OxiflowError>,
+        impl FnMut(&DVector<f64>) -> Result<DMatrix<f64>, OxiflowError>,
+    ) {
+        let f = move |u: &DVector<f64>| Ok(u.map(|v| -v * v * v));
+        let jac =
+            move |u: &DVector<f64>| Ok(DMatrix::<f64>::from_diagonal(&u.map(|v| -3.0 * v * v)));
+        (f, jac)
+    }
+
+    #[test]
+    fn residual_matches_hand_derivation() {
+        let u = DVector::from_vec(vec![2.0, 3.0]);
+        let u_star = DVector::from_vec(vec![1.0, 1.0]);
+        let f_u = DVector::from_vec(vec![0.5, 0.5]);
+        // g(u) = 1.5*(u - u_star) - 0.1*f(u)
+        let res = residual(&u, &u_star, 1.5, 0.1, &f_u);
+        assert!((res[0] - (1.5 * 1.0 - 0.1 * 0.5)).abs() < 1e-12);
+        assert!((res[1] - (1.5 * 2.0 - 0.1 * 0.5)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn linear_correction_solves_the_linearised_system() {
+        // alpha*I - coeff*J with J = -2*I, alpha=1, coeff=0.1 -> 1.2*I.
+        let jacobian = DMatrix::<f64>::identity(2, 2) * -2.0;
+        let res = DVector::from_vec(vec![1.2, 2.4]);
+        let delta = linear_correction(&jacobian, 1.0, 0.1, &res, &NalgebraDenseSolver).unwrap();
+        assert!((delta[0] - (-1.0)).abs() < 1e-9);
+        assert!((delta[1] - (-2.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn single_iteration_is_exact_for_affine_problem() {
+        // Backward-Euler-style step: alpha=1, coeff=theta*dt=0.1,
+        // u_star = u_n (theta=1 so the (1-theta) term vanishes).
+        let lambda = 3.0;
+        let (f, jac) = affine_decay(lambda);
+        let u0 = DVector::from_element(3, 1.0);
+        let u_star = u0.clone();
+        let params = NewtonParams {
+            convergence: NewtonConvergence::default(),
+            jacobian_strategy: JacobianStrategy::ModifiedFrozen,
+            max_iterations: 1,
+        };
+
+        let u_next = solve(u0, &u_star, 1.0, 0.1, f, jac, &NalgebraDenseSolver, &params).unwrap();
+
+        let expected = 1.0 / (1.0 + lambda * 0.1);
+        for v in u_next.iter() {
+            assert!((v - expected).abs() < 1e-9, "got {v}, expected {expected}");
+        }
+    }
+
+    #[test]
+    fn full_newton_converges_on_nonaffine_problem() {
+        let (f, jac) = cubic_decay();
+        let u0 = DVector::from_element(2, 1.0);
+        let u_star = u0.clone();
+        let params = NewtonParams {
+            convergence: NewtonConvergence::default(),
+            jacobian_strategy: JacobianStrategy::FullNewton,
+            max_iterations: 20,
+        };
+
+        let u_next = solve(u0, &u_star, 1.0, 0.1, f, jac, &NalgebraDenseSolver, &params).unwrap();
+
+        // Cross-check against an independently solved scalar equation:
+        // u + 0.1*u^3 = 1.0 (Backward-Euler-style implicit cubic decay).
+        let mut u_scalar = 1.0_f64;
+        for _ in 0..50 {
+            let g = u_scalar + 0.1 * u_scalar.powi(3) - 1.0;
+            let dg = 1.0 + 0.3 * u_scalar.powi(2);
+            u_scalar -= g / dg;
+        }
+        for v in u_next.iter() {
+            assert!((v - u_scalar).abs() < 1e-5, "got {v}, expected {u_scalar}");
+        }
+    }
+
+    #[test]
+    fn modified_frozen_with_single_correction_does_not_converge_on_nonaffine_problem() {
+        // A single frozen-Jacobian correction is only a first-order
+        // approximation for this nonaffine f (contrast with
+        // `full_newton_converges_on_nonaffine_problem`, which reaches the
+        // true root): under the loop's default tolerance, that shows up
+        // as an honest convergence failure -- not a silently inaccurate
+        // "success" -- since nothing about affine-ness is special-cased;
+        // see `solve`'s docs.
+        let (f, jac) = cubic_decay();
+        let u0 = DVector::from_element(1, 1.0);
+        let u_star = u0.clone();
+        let params = NewtonParams {
+            convergence: NewtonConvergence::default(),
+            jacobian_strategy: JacobianStrategy::ModifiedFrozen,
+            max_iterations: 1,
+        };
+
+        let err = solve(u0, &u_star, 1.0, 0.1, f, jac, &NalgebraDenseSolver, &params).unwrap_err();
+        assert!(matches!(
+            err,
+            OxiflowError::NewtonNotConverged { iterations: 1, .. }
+        ));
+    }
+
+    #[test]
+    fn not_converged_when_iteration_budget_too_small() {
+        let (f, jac) = cubic_decay();
+        let u0 = DVector::from_element(1, 1.0);
+        let u_star = u0.clone();
+        let params = NewtonParams {
+            convergence: NewtonConvergence::ResidualOnly {
+                tol_abs: 1e-14,
+                tol_rel: 0.0,
+            },
+            jacobian_strategy: JacobianStrategy::ModifiedFrozen,
+            max_iterations: 1,
+        };
+
+        let err = solve(u0, &u_star, 1.0, 0.1, f, jac, &NalgebraDenseSolver, &params).unwrap_err();
+        assert!(matches!(
+            err,
+            OxiflowError::NewtonNotConverged { iterations: 1, .. }
+        ));
+    }
+
+    #[test]
+    fn combined_or_converges_when_correction_is_small_even_if_residual_is_not() {
+        let f = |u: &DVector<f64>| Ok(u.map(|v| v + 1.0)); // never zero for u >= 0
+        let jac = |u: &DVector<f64>| Ok(DMatrix::<f64>::identity(u.len(), u.len()) * -1.0e6);
+        let u0 = DVector::from_element(1, 0.0);
+        let u_star = u0.clone();
+        // A deliberately stiff Jacobian (-1e6) makes the correction
+        // collapse to a tiny step even though the residual itself does
+        // not shrink below tolerance -- see the closures above.
+        let params_or = NewtonParams {
+            convergence: NewtonConvergence::CombinedOr {
+                tol_abs: 1e-3,
+                tol_rel: 0.0,
+            },
+            jacobian_strategy: JacobianStrategy::ModifiedFrozen,
+            max_iterations: 1,
+        };
+        let params_residual_only = NewtonParams {
+            convergence: NewtonConvergence::ResidualOnly {
+                tol_abs: 1e-3,
+                tol_rel: 0.0,
+            },
+            jacobian_strategy: JacobianStrategy::ModifiedFrozen,
+            max_iterations: 1,
+        };
+
+        let out_or = solve(
+            u0.clone(),
+            &u_star,
+            1.0,
+            1.0,
+            f,
+            jac,
+            &NalgebraDenseSolver,
+            &params_or,
+        );
+        let out_residual_only = solve(
+            u0,
+            &u_star,
+            1.0,
+            1.0,
+            f,
+            jac,
+            &NalgebraDenseSolver,
+            &params_residual_only,
+        );
+
+        assert!(out_or.is_ok(), "CombinedOr should accept a tiny correction");
+        assert!(
+            out_residual_only.is_err(),
+            "ResidualOnly should reject a large residual"
+        );
+    }
+}

--- a/src/solver/methods/newton.rs
+++ b/src/solver/methods/newton.rs
@@ -87,6 +87,7 @@ use crate::solver::linear::LinearSolver;
 /// floor.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub enum NewtonConvergence {
     /// Converged once `||g(u)|| < tol_abs + tol_rel * ||u||`.
     ///
@@ -131,6 +132,7 @@ impl NewtonConvergence {
 /// separate code path.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub enum JacobianStrategy {
     /// Evaluate the Jacobian once, at the initial guess, and reuse it for
     /// every correction (modified Newton).

--- a/src/solver/methods/newton.rs
+++ b/src/solver/methods/newton.rs
@@ -48,12 +48,14 @@
 //! ## Wiring status
 //!
 //! [`solve`] is called from
-//! [`super::implicit::theta_method_step_newton`] (DD-044, #111), itself
-//! used by
+//! [`super::implicit::theta_method_step_newton`] (DD-044, #111) and
+//! [`super::bdf2::bdf2_step_newton`] (DD-044, #112) — used respectively by
 //! [`BackwardEulerSolver`](super::backward_euler::BackwardEulerSolver)/
-//! [`CrankNicolsonSolver`](super::crank_nicolson::CrankNicolsonSolver).
-//! [`super::bdf2::bdf2_step`] does not yet route through this module —
-//! that wiring is #112.
+//! [`CrankNicolsonSolver`](super::crank_nicolson::CrankNicolsonSolver) and
+//! [`BDF2Solver`](super::bdf2::BDF2Solver). [`super::bdf2`]'s
+//! startup/bootstrap step is the one exception, unconditionally using
+//! [`super::implicit::theta_method_step`]'s non-configurable path — see
+//! that module's docs.
 
 use nalgebra::{DMatrix, DVector};
 
@@ -70,24 +72,19 @@ use crate::solver::linear::LinearSolver;
 /// `max_iterations = 1` with an exactly affine `f` succeeds immediately —
 /// the single correction is already exact up to floating-point rounding).
 ///
-/// Default: [`ResidualOnly`](Self::ResidualOnly) with `tol_abs = 1e-5`,
+/// Default: [`ResidualOnly`](Self::ResidualOnly) with `tol_abs = 1e-8`,
 /// `tol_rel = 1e-6` — starting points, not fixed constants; tune via the
 /// solver builders once this lands (#111/#112).
 ///
-/// `tol_abs`'s default is calibrated against
-/// [`finite_difference_jacobian`](super::implicit::finite_difference_jacobian)'s
-/// fixed step size, not chosen for near-machine-precision: on affine
-/// problems with large coefficients (e.g. `λ = 1e4` in the stiff-decay
-/// regression tests), computing `(f(u+ε) − f(u)) / ε` suffers
-/// catastrophic cancellation whose absolute error scales roughly as
-/// `λ · ε_machine / ε` — empirically up to ~1e-6 for the stiffest cases
-/// this crate currently tests. A single Newton correction on such a
-/// problem is still mathematically exact; the residual floor above
-/// reflects finite-difference precision, not nonlinearity. `1e-5` leaves
-/// comfortable margin over that floor while still catching genuine
-/// nonlinear non-convergence (which typically leaves residuals many
-/// orders of magnitude larger — see
-/// [`super::implicit`]'s and this module's own tests).
+/// Note: this default is *not* what
+/// [`theta_method_step`](super::implicit::theta_method_step) or the
+/// implicit solvers' own zero-config constructors use internally — those
+/// need a looser, explicitly named tolerance to guarantee the pre-DD-044
+/// single-correction contract on very stiff affine problems (see
+/// [`super::implicit`]'s module docs for why). This `Default` impl is a
+/// general starting point for callers configuring the loop themselves,
+/// not a guarantee that it tolerates every finite-difference precision
+/// floor.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum NewtonConvergence {
@@ -108,7 +105,7 @@ pub enum NewtonConvergence {
 impl Default for NewtonConvergence {
     fn default() -> Self {
         NewtonConvergence::ResidualOnly {
-            tol_abs: 1e-5,
+            tol_abs: 1e-8,
             tol_rel: 1e-6,
         }
     }
@@ -421,7 +418,7 @@ mod tests {
             u_scalar -= g / dg;
         }
         for v in u_next.iter() {
-            assert!((v - u_scalar).abs() < 1e-4, "got {v}, expected {u_scalar}");
+            assert!((v - u_scalar).abs() < 1e-5, "got {v}, expected {u_scalar}");
         }
     }
 

--- a/src/solver/methods/newton.rs
+++ b/src/solver/methods/newton.rs
@@ -45,13 +45,15 @@
 //! module: composing the two is [`super::implicit`]'s concern (chantier
 //! 2), not this one's.
 //!
-//! ## Scope of this increment (issue #110)
+//! ## Wiring status
 //!
-//! This module is the shared core only — it is not yet called from
-//! [`super::implicit::theta_method_step`] or [`super::bdf2::bdf2_step`].
-//! That wiring, and the `with_newton_convergence`/`with_jacobian_strategy`/
-//! `with_max_newton_iterations` builders on the three implicit solvers,
-//! land in the follow-up issues (#111, #112).
+//! [`solve`] is called from
+//! [`super::implicit::theta_method_step_newton`] (DD-044, #111), itself
+//! used by
+//! [`BackwardEulerSolver`](super::backward_euler::BackwardEulerSolver)/
+//! [`CrankNicolsonSolver`](super::crank_nicolson::CrankNicolsonSolver).
+//! [`super::bdf2::bdf2_step`] does not yet route through this module —
+//! that wiring is #112.
 
 use nalgebra::{DMatrix, DVector};
 
@@ -68,9 +70,24 @@ use crate::solver::linear::LinearSolver;
 /// `max_iterations = 1` with an exactly affine `f` succeeds immediately —
 /// the single correction is already exact up to floating-point rounding).
 ///
-/// Default: [`ResidualOnly`](Self::ResidualOnly) with `tol_abs = 1e-8`,
+/// Default: [`ResidualOnly`](Self::ResidualOnly) with `tol_abs = 1e-5`,
 /// `tol_rel = 1e-6` — starting points, not fixed constants; tune via the
 /// solver builders once this lands (#111/#112).
+///
+/// `tol_abs`'s default is calibrated against
+/// [`finite_difference_jacobian`](super::implicit::finite_difference_jacobian)'s
+/// fixed step size, not chosen for near-machine-precision: on affine
+/// problems with large coefficients (e.g. `λ = 1e4` in the stiff-decay
+/// regression tests), computing `(f(u+ε) − f(u)) / ε` suffers
+/// catastrophic cancellation whose absolute error scales roughly as
+/// `λ · ε_machine / ε` — empirically up to ~1e-6 for the stiffest cases
+/// this crate currently tests. A single Newton correction on such a
+/// problem is still mathematically exact; the residual floor above
+/// reflects finite-difference precision, not nonlinearity. `1e-5` leaves
+/// comfortable margin over that floor while still catching genuine
+/// nonlinear non-convergence (which typically leaves residuals many
+/// orders of magnitude larger — see
+/// [`super::implicit`]'s and this module's own tests).
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum NewtonConvergence {
@@ -91,7 +108,7 @@ pub enum NewtonConvergence {
 impl Default for NewtonConvergence {
     fn default() -> Self {
         NewtonConvergence::ResidualOnly {
-            tol_abs: 1e-8,
+            tol_abs: 1e-5,
             tol_rel: 1e-6,
         }
     }
@@ -100,9 +117,6 @@ impl Default for NewtonConvergence {
 impl NewtonConvergence {
     /// Extracts the common `(tol_abs, tol_rel)` pair, regardless of
     /// variant.
-    // TODO(#111/#112): called from `solve` below, itself unwired until
-    // then — see that function's own TODO.
-    #[allow(dead_code)]
     fn tolerances(&self) -> (f64, f64) {
         match *self {
             NewtonConvergence::ResidualOnly { tol_abs, tol_rel }
@@ -148,10 +162,6 @@ pub enum JacobianStrategy {
 /// `f_u` is `f(u)`, already evaluated by the caller (it is also needed
 /// to decide, e.g., whether to refresh the Jacobian — evaluating it here
 /// again would be redundant).
-// TODO(#111/#112): wire in once BackwardEulerSolver/CrankNicolsonSolver/
-// BDF2Solver route theta_method_step/bdf2_step through the generic loop —
-// currently only exercised by this module's own unit tests.
-#[allow(dead_code)]
 pub(crate) fn residual(
     u: &DVector<f64>,
     u_star: &DVector<f64>,
@@ -171,10 +181,9 @@ pub(crate) fn residual(
 /// [`finite_difference_jacobian`](super::implicit::finite_difference_jacobian),
 /// unchanged) rather than computed here, so this function stays
 /// dense/sparse-agnostic in principle; only the dense path
-/// (`&dyn LinearSolver`) is wired at this increment (#110) — banded/sparse
-/// composition is verified, not redecided, in #111.
-// TODO(#111/#112): wire in alongside `residual` above.
-#[allow(dead_code)]
+/// (`&dyn LinearSolver`) is wired at this increment (#110/#111) —
+/// banded/sparse composition remains a known gap, see
+/// [`super::implicit`]'s module docs.
 pub(crate) fn linear_correction(
     jacobian: &DMatrix<f64>,
     alpha: f64,
@@ -195,10 +204,6 @@ pub(crate) fn linear_correction(
 /// into one struct so the loop's own argument list stays manageable
 /// alongside the residual-shape parameters (`u_star`/`alpha`/`coeff`)
 /// and the two evaluation closures.
-// TODO(#111/#112): constructed by BackwardEulerSolver/CrankNicolsonSolver/
-// BDF2Solver once they gain `with_newton_convergence`/`with_jacobian_strategy`/
-// `with_max_newton_iterations` builders.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct NewtonParams {
     pub convergence: NewtonConvergence,
@@ -247,10 +252,6 @@ pub(crate) struct NewtonParams {
 /// Returns [`OxiflowError::NewtonNotConverged`] if `max_iterations` is
 /// exhausted without satisfying `params.convergence`. Propagates any
 /// error from `f_eval`, `jac_eval`, or the linear solve unchanged.
-// TODO(#111/#112): called from BackwardEulerSolver/CrankNicolsonSolver/
-// BDF2Solver's step() once wired — currently only exercised by this
-// module's own unit tests (see the `tests` module below).
-#[allow(dead_code)]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn solve(
     u0: DVector<f64>,
@@ -420,7 +421,7 @@ mod tests {
             u_scalar -= g / dg;
         }
         for v in u_next.iter() {
-            assert!((v - u_scalar).abs() < 1e-5, "got {v}, expected {u_scalar}");
+            assert!((v - u_scalar).abs() < 1e-4, "got {v}, expected {u_scalar}");
         }
     }
 

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -245,9 +245,25 @@ pub trait Solver: Send + Sync {
         config: &SolverConfiguration,
     ) -> Result<SimulationResult, OxiflowError>;
 
-    /// Called automatically right before a [`OxiflowError::SolverDivergence`]
-    /// is returned, with a [`SimulationSnapshot`] capturing the physical
-    /// state at the point of divergence (DD-025 Option B, issue #71).
+    /// Called automatically right before a divergence-class error is
+    /// returned, with a [`SimulationSnapshot`] capturing the state at the
+    /// point of failure (DD-025 Option B, issue #71). Two distinct
+    /// failure modes are routed through this hook:
+    ///
+    /// - [`OxiflowError::SolverDivergence`] — a non-finite value appeared
+    ///   in the field itself (checked after every step by
+    ///   [`methods`]'s internal finiteness check).
+    /// - [`OxiflowError::NewtonNotConverged`] — the iterated Newton
+    ///   solver ([`methods::newton`]) exhausted its iteration budget
+    ///   without satisfying its convergence criterion (DD-044, v0.7.0).
+    ///   This is a failure of the *nonlinear correction* to converge, not
+    ///   necessarily a non-finite state — the last iterate may still be
+    ///   finite, just not accepted as converged.
+    ///
+    /// Both cases reuse the same [`SimulationSnapshot`] checkpoint
+    /// infrastructure; implementations that override this hook to
+    /// persist or log should not assume the snapshot's `error` field
+    /// always describes a non-finite value.
     ///
     /// Default implementation is a no-op — override to persist (e.g. via
     /// [`snapshot::write_snapshot`]) or log. There is no `checkpoint()`

--- a/src/solver/spec.rs
+++ b/src/solver/spec.rs
@@ -21,18 +21,19 @@
 //!
 //! ## Scope of this first increment
 //!
-//! [`IntegratorSpec::BackwardEuler`] and [`IntegratorSpec::CrankNicolson`]
-//! (#115), covering the DD-043 (#50) sparse dispatch path — this whole
-//! module is gated behind the `sparse` feature: without it, a config DTO
-//! for these integrators adds nothing over the existing
-//! [`super::IntegratorKind`] labels, since the dense path takes no
-//! parameters. Remaining integrators (`RK4`, `BDF2` — #116, `DoPri45`) and
-//! the WHAT axis (`ModelConfig`/`MeshConfig`/`BoundaryConditionConfig`)
-//! are tracked as follow-up, not blocking this issue's closure (per
-//! #104's own stated scope). `newton_convergence`/`jacobian_strategy`/
-//! `max_iterations` (DD-044, #114/#115) extend both variants rather than
-//! waiting for `BDF2`'s variant to land (#116) — the Newton configuration
-//! is orthogonal to which integrator carries it.
+//! [`IntegratorSpec::BackwardEuler`], [`IntegratorSpec::CrankNicolson`]
+//! (#115), and [`IntegratorSpec::BDF2`] (#116, Newton fields only — see
+//! that variant's own docs for why it deliberately carries no sparse
+//! fields), covering the DD-043 (#50) sparse dispatch path where
+//! applicable — this whole module is gated behind the `sparse` feature:
+//! without it, a config DTO for these integrators adds nothing over the
+//! existing [`super::IntegratorKind`] labels, since the dense path takes
+//! no parameters. Remaining integrators (`RK4`, `DoPri45`) and the WHAT
+//! axis (`ModelConfig`/`MeshConfig`/`BoundaryConditionConfig`) are tracked
+//! as follow-up, not blocking this issue's closure (per #104's own stated
+//! scope). `newton_convergence`/`jacobian_strategy`/`max_iterations`
+//! (DD-044, #114/#115/#116) extend all three variants — the Newton
+//! configuration is orthogonal to which integrator carries it.
 //!
 //! The sparse backend itself is always [`FaerSparseSolver`] — a fixed,
 //! non-configurable choice: `Box<dyn SparseLinearSolver>` is a trait
@@ -41,6 +42,7 @@
 //! constraint).
 
 use super::methods::backward_euler::BackwardEulerSolver;
+use super::methods::bdf2::BDF2Solver;
 use super::methods::crank_nicolson::CrankNicolsonSolver;
 use super::methods::implicit::stiff_jacobian_convergence;
 use super::methods::newton::{JacobianStrategy, NewtonConvergence};
@@ -100,6 +102,24 @@ pub enum IntegratorSpec {
         /// See [`BackwardEuler::jacobian_bandwidth`](Self::BackwardEuler).
         #[cfg_attr(feature = "serde", serde(default))]
         jacobian_bandwidth: Option<usize>,
+        /// See [`BackwardEuler::newton_convergence`](Self::BackwardEuler).
+        #[cfg_attr(feature = "serde", serde(default = "default_newton_convergence"))]
+        newton_convergence: NewtonConvergence,
+        /// See [`BackwardEuler::jacobian_strategy`](Self::BackwardEuler).
+        #[cfg_attr(feature = "serde", serde(default))]
+        jacobian_strategy: JacobianStrategy,
+        /// See [`BackwardEuler::max_iterations`](Self::BackwardEuler).
+        #[cfg_attr(feature = "serde", serde(default = "default_max_newton_iterations"))]
+        max_iterations: usize,
+    },
+    /// BDF2 (implicit multi-step, 2nd order) — Newton configuration only
+    /// (DD-044, #116), deliberately **no** `sparse_threshold`/
+    /// `jacobian_bandwidth`: `BDF2Solver` has no sparse builders to map
+    /// (a DD-043 gap, not a DD-044 concern — see
+    /// [`BDF2Solver`](super::methods::bdf2::BDF2Solver)'s own docs).
+    /// Adding sparse-shaped fields with no backing implementation would
+    /// mislead a config author into thinking they take effect.
+    BDF2 {
         /// See [`BackwardEuler::newton_convergence`](Self::BackwardEuler).
         #[cfg_attr(feature = "serde", serde(default = "default_newton_convergence"))]
         newton_convergence: NewtonConvergence,
@@ -180,6 +200,16 @@ impl TryFrom<IntegratorSpec> for Box<dyn Solver> {
                 }
                 Ok(Box::new(solver))
             }
+            IntegratorSpec::BDF2 {
+                newton_convergence,
+                jacobian_strategy,
+                max_iterations,
+            } => Ok(Box::new(
+                BDF2Solver::new()
+                    .with_newton_convergence(newton_convergence)
+                    .with_jacobian_strategy(jacobian_strategy)
+                    .with_max_newton_iterations(max_iterations),
+            )),
         }
     }
 }
@@ -239,6 +269,7 @@ mod tests {
                 assert_eq!(max_iterations, default_max_newton_iterations());
             }
             IntegratorSpec::CrankNicolson { .. } => panic!("expected BackwardEuler variant"),
+            IntegratorSpec::BDF2 { .. } => panic!("expected BackwardEuler variant"),
         }
     }
 
@@ -257,6 +288,7 @@ mod tests {
                 assert_eq!(jacobian_bandwidth, Some(2));
             }
             IntegratorSpec::CrankNicolson { .. } => panic!("expected BackwardEuler variant"),
+            IntegratorSpec::BDF2 { .. } => panic!("expected BackwardEuler variant"),
         }
     }
 
@@ -285,6 +317,7 @@ mod tests {
                 assert_eq!(max_iterations, 1);
             }
             IntegratorSpec::CrankNicolson { .. } => panic!("expected BackwardEuler variant"),
+            IntegratorSpec::BDF2 { .. } => panic!("expected BackwardEuler variant"),
         }
     }
 
@@ -317,6 +350,7 @@ mod tests {
                 assert_eq!(max_iterations, 30);
             }
             IntegratorSpec::CrankNicolson { .. } => panic!("expected BackwardEuler variant"),
+            IntegratorSpec::BDF2 { .. } => panic!("expected BackwardEuler variant"),
         }
     }
 
@@ -389,6 +423,7 @@ mod tests {
             IntegratorSpec::BackwardEuler { .. } => {
                 panic!("expected CrankNicolson variant")
             }
+            IntegratorSpec::BDF2 { .. } => panic!("expected CrankNicolson variant"),
         }
     }
 
@@ -428,6 +463,70 @@ mod tests {
             IntegratorSpec::BackwardEuler { .. } => {
                 panic!("expected CrankNicolson variant")
             }
+            IntegratorSpec::BDF2 { .. } => panic!("expected CrankNicolson variant"),
+        }
+    }
+
+    // ── BDF2 (#116) — Newton fields only, no sparse ────────────────────────────
+
+    #[test]
+    fn bdf2_construction_succeeds() {
+        let spec = IntegratorSpec::BDF2 {
+            newton_convergence: NewtonConvergence::default(),
+            jacobian_strategy: JacobianStrategy::default(),
+            max_iterations: 1,
+        };
+        let solver: Box<dyn Solver> = spec.try_into().unwrap();
+        let _ = solver;
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn bdf2_deserialises_with_defaults() {
+        let json = r#"{ "BDF2": {} }"#;
+        let spec: IntegratorSpec = serde_json::from_str(json).unwrap();
+        match spec {
+            IntegratorSpec::BDF2 {
+                newton_convergence,
+                jacobian_strategy,
+                max_iterations,
+            } => {
+                assert_eq!(newton_convergence, default_newton_convergence());
+                assert_eq!(jacobian_strategy, JacobianStrategy::default());
+                assert_eq!(max_iterations, default_max_newton_iterations());
+            }
+            _ => panic!("expected BDF2 variant"),
+        }
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn bdf2_deserialises_explicit_fields() {
+        let json = r#"{
+            "BDF2": {
+                "newton_convergence": { "ResidualOnly": { "tol_abs": 1e-9, "tol_rel": 1e-7 } },
+                "jacobian_strategy": "FullNewton",
+                "max_iterations": 30
+            }
+        }"#;
+        let spec: IntegratorSpec = serde_json::from_str(json).unwrap();
+        match spec {
+            IntegratorSpec::BDF2 {
+                newton_convergence,
+                jacobian_strategy,
+                max_iterations,
+            } => {
+                assert_eq!(
+                    newton_convergence,
+                    NewtonConvergence::ResidualOnly {
+                        tol_abs: 1e-9,
+                        tol_rel: 1e-7,
+                    }
+                );
+                assert_eq!(jacobian_strategy, JacobianStrategy::FullNewton);
+                assert_eq!(max_iterations, 30);
+            }
+            _ => panic!("expected BDF2 variant"),
         }
     }
 }

--- a/src/solver/spec.rs
+++ b/src/solver/spec.rs
@@ -21,18 +21,18 @@
 //!
 //! ## Scope of this first increment
 //!
-//! Only [`IntegratorSpec::BackwardEuler`], covering the DD-043 (#50) sparse
-//! dispatch path — this whole module is gated behind the `sparse` feature:
-//! without it, a config DTO for `BackwardEuler` adds nothing over the
-//! existing [`super::IntegratorKind::BackwardEuler`] label, since the dense
-//! path takes no parameters. Remaining integrators (`RK4`, `CrankNicolson`,
-//! `BDF2`, `DoPri45`) and the WHAT axis (`ModelConfig`/`MeshConfig`/
-//! `BoundaryConditionConfig`) are tracked as follow-up, not blocking this
-//! issue's closure (per #104's own stated scope). `newton_convergence`/
-//! `jacobian_strategy`/`max_iterations` (DD-044, #114) extend this same
-//! variant rather than waiting for `CrankNicolson`/`BDF2` variants to land
-//! (#115/#116) — the Newton configuration is orthogonal to which
-//! integrator carries it.
+//! [`IntegratorSpec::BackwardEuler`] and [`IntegratorSpec::CrankNicolson`]
+//! (#115), covering the DD-043 (#50) sparse dispatch path — this whole
+//! module is gated behind the `sparse` feature: without it, a config DTO
+//! for these integrators adds nothing over the existing
+//! [`super::IntegratorKind`] labels, since the dense path takes no
+//! parameters. Remaining integrators (`RK4`, `BDF2` — #116, `DoPri45`) and
+//! the WHAT axis (`ModelConfig`/`MeshConfig`/`BoundaryConditionConfig`)
+//! are tracked as follow-up, not blocking this issue's closure (per
+//! #104's own stated scope). `newton_convergence`/`jacobian_strategy`/
+//! `max_iterations` (DD-044, #114/#115) extend both variants rather than
+//! waiting for `BDF2`'s variant to land (#116) — the Newton configuration
+//! is orthogonal to which integrator carries it.
 //!
 //! The sparse backend itself is always [`FaerSparseSolver`] — a fixed,
 //! non-configurable choice: `Box<dyn SparseLinearSolver>` is a trait
@@ -41,6 +41,7 @@
 //! constraint).
 
 use super::methods::backward_euler::BackwardEulerSolver;
+use super::methods::crank_nicolson::CrankNicolsonSolver;
 use super::methods::implicit::stiff_jacobian_convergence;
 use super::methods::newton::{JacobianStrategy, NewtonConvergence};
 use super::sparse::FaerSparseSolver;
@@ -86,6 +87,29 @@ pub enum IntegratorSpec {
         #[cfg_attr(feature = "serde", serde(default = "default_max_newton_iterations"))]
         max_iterations: usize,
     },
+    /// Crank-Nicolson (semi-implicit, 2nd order), symmetric to
+    /// [`BackwardEuler`](Self::BackwardEuler) in every field — sparse
+    /// dispatch (DD-043) and Newton configuration (DD-044, #115) both
+    /// apply identically. `theta = 0.5` is not exposed as a field —
+    /// implicit to the variant, consistent with `BackwardEuler`'s
+    /// `theta = 1.0` never being exposed either.
+    CrankNicolson {
+        /// See [`BackwardEuler::sparse_threshold`](Self::BackwardEuler).
+        #[cfg_attr(feature = "serde", serde(default = "default_sparse_threshold"))]
+        sparse_threshold: usize,
+        /// See [`BackwardEuler::jacobian_bandwidth`](Self::BackwardEuler).
+        #[cfg_attr(feature = "serde", serde(default))]
+        jacobian_bandwidth: Option<usize>,
+        /// See [`BackwardEuler::newton_convergence`](Self::BackwardEuler).
+        #[cfg_attr(feature = "serde", serde(default = "default_newton_convergence"))]
+        newton_convergence: NewtonConvergence,
+        /// See [`BackwardEuler::jacobian_strategy`](Self::BackwardEuler).
+        #[cfg_attr(feature = "serde", serde(default))]
+        jacobian_strategy: JacobianStrategy,
+        /// See [`BackwardEuler::max_iterations`](Self::BackwardEuler).
+        #[cfg_attr(feature = "serde", serde(default = "default_max_newton_iterations"))]
+        max_iterations: usize,
+    },
 }
 
 /// Default for `sparse_threshold` when omitted from a deserialised config.
@@ -126,6 +150,25 @@ impl TryFrom<IntegratorSpec> for Box<dyn Solver> {
                 max_iterations,
             } => {
                 let mut solver = BackwardEulerSolver::new()
+                    .with_sparse_threshold(sparse_threshold)
+                    .with_newton_convergence(newton_convergence)
+                    .with_jacobian_strategy(jacobian_strategy)
+                    .with_max_newton_iterations(max_iterations);
+                if let Some(bandwidth) = jacobian_bandwidth {
+                    solver = solver
+                        .with_jacobian_bandwidth(bandwidth)
+                        .with_sparse_solver(Box::new(FaerSparseSolver));
+                }
+                Ok(Box::new(solver))
+            }
+            IntegratorSpec::CrankNicolson {
+                sparse_threshold,
+                jacobian_bandwidth,
+                newton_convergence,
+                jacobian_strategy,
+                max_iterations,
+            } => {
+                let mut solver = CrankNicolsonSolver::new()
                     .with_sparse_threshold(sparse_threshold)
                     .with_newton_convergence(newton_convergence)
                     .with_jacobian_strategy(jacobian_strategy)
@@ -195,6 +238,7 @@ mod tests {
                 assert_eq!(jacobian_strategy, JacobianStrategy::default());
                 assert_eq!(max_iterations, default_max_newton_iterations());
             }
+            IntegratorSpec::CrankNicolson { .. } => panic!("expected BackwardEuler variant"),
         }
     }
 
@@ -212,6 +256,7 @@ mod tests {
                 assert_eq!(sparse_threshold, 42);
                 assert_eq!(jacobian_bandwidth, Some(2));
             }
+            IntegratorSpec::CrankNicolson { .. } => panic!("expected BackwardEuler variant"),
         }
     }
 
@@ -239,6 +284,7 @@ mod tests {
                 assert_eq!(jacobian_strategy, JacobianStrategy::ModifiedFrozen);
                 assert_eq!(max_iterations, 1);
             }
+            IntegratorSpec::CrankNicolson { .. } => panic!("expected BackwardEuler variant"),
         }
     }
 
@@ -270,6 +316,7 @@ mod tests {
                 assert_eq!(jacobian_strategy, JacobianStrategy::FullNewton);
                 assert_eq!(max_iterations, 30);
             }
+            IntegratorSpec::CrankNicolson { .. } => panic!("expected BackwardEuler variant"),
         }
     }
 
@@ -290,5 +337,97 @@ mod tests {
         };
         let solver: Box<dyn Solver> = spec.try_into().unwrap();
         let _ = solver;
+    }
+
+    // ── CrankNicolson (#115) — mirrors the BackwardEuler coverage above ────────
+
+    #[test]
+    fn crank_nicolson_dense_path_when_no_jacobian_bandwidth() {
+        let spec = IntegratorSpec::CrankNicolson {
+            sparse_threshold: 100,
+            jacobian_bandwidth: None,
+            newton_convergence: NewtonConvergence::default(),
+            jacobian_strategy: JacobianStrategy::default(),
+            max_iterations: 1,
+        };
+        let solver: Box<dyn Solver> = spec.try_into().unwrap();
+        let _ = solver;
+    }
+
+    #[test]
+    fn crank_nicolson_sparse_path_when_jacobian_bandwidth_given() {
+        let spec = IntegratorSpec::CrankNicolson {
+            sparse_threshold: 50,
+            jacobian_bandwidth: Some(3),
+            newton_convergence: NewtonConvergence::default(),
+            jacobian_strategy: JacobianStrategy::default(),
+            max_iterations: 1,
+        };
+        let solver: Box<dyn Solver> = spec.try_into().unwrap();
+        let _ = solver;
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn crank_nicolson_deserialises_with_defaults() {
+        let json = r#"{ "CrankNicolson": {} }"#;
+        let spec: IntegratorSpec = serde_json::from_str(json).unwrap();
+        match spec {
+            IntegratorSpec::CrankNicolson {
+                sparse_threshold,
+                jacobian_bandwidth,
+                newton_convergence,
+                jacobian_strategy,
+                max_iterations,
+            } => {
+                assert_eq!(sparse_threshold, default_sparse_threshold());
+                assert_eq!(jacobian_bandwidth, None);
+                assert_eq!(newton_convergence, default_newton_convergence());
+                assert_eq!(jacobian_strategy, JacobianStrategy::default());
+                assert_eq!(max_iterations, default_max_newton_iterations());
+            }
+            IntegratorSpec::BackwardEuler { .. } => {
+                panic!("expected CrankNicolson variant")
+            }
+        }
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn crank_nicolson_deserialises_explicit_fields() {
+        let json = r#"{
+            "CrankNicolson": {
+                "sparse_threshold": 42,
+                "jacobian_bandwidth": 2,
+                "newton_convergence": { "CombinedAnd": { "tol_abs": 1e-9, "tol_rel": 1e-7 } },
+                "jacobian_strategy": "FullNewton",
+                "max_iterations": 30
+            }
+        }"#;
+        let spec: IntegratorSpec = serde_json::from_str(json).unwrap();
+        match spec {
+            IntegratorSpec::CrankNicolson {
+                sparse_threshold,
+                jacobian_bandwidth,
+                newton_convergence,
+                jacobian_strategy,
+                max_iterations,
+            } => {
+                assert_eq!(sparse_threshold, 42);
+                assert_eq!(jacobian_bandwidth, Some(2));
+                assert_eq!(
+                    newton_convergence,
+                    NewtonConvergence::CombinedAnd {
+                        tol_abs: 1e-9,
+                        tol_rel: 1e-7,
+                    }
+                );
+                assert_eq!(jacobian_strategy, JacobianStrategy::FullNewton);
+                assert_eq!(max_iterations, 30);
+            }
+            IntegratorSpec::BackwardEuler { .. } => {
+                panic!("expected CrankNicolson variant")
+            }
+        }
     }
 }

--- a/src/solver/spec.rs
+++ b/src/solver/spec.rs
@@ -44,6 +44,7 @@
 use super::methods::backward_euler::BackwardEulerSolver;
 use super::methods::bdf2::BDF2Solver;
 use super::methods::crank_nicolson::CrankNicolsonSolver;
+#[cfg(feature = "serde")]
 use super::methods::implicit::stiff_jacobian_convergence;
 use super::methods::newton::{JacobianStrategy, NewtonConvergence};
 use super::sparse::FaerSparseSolver;

--- a/src/solver/spec.rs
+++ b/src/solver/spec.rs
@@ -28,7 +28,11 @@
 //! path takes no parameters. Remaining integrators (`RK4`, `CrankNicolson`,
 //! `BDF2`, `DoPri45`) and the WHAT axis (`ModelConfig`/`MeshConfig`/
 //! `BoundaryConditionConfig`) are tracked as follow-up, not blocking this
-//! issue's closure (per #104's own stated scope).
+//! issue's closure (per #104's own stated scope). `newton_convergence`/
+//! `jacobian_strategy`/`max_iterations` (DD-044, #114) extend this same
+//! variant rather than waiting for `CrankNicolson`/`BDF2` variants to land
+//! (#115/#116) — the Newton configuration is orthogonal to which
+//! integrator carries it.
 //!
 //! The sparse backend itself is always [`FaerSparseSolver`] — a fixed,
 //! non-configurable choice: `Box<dyn SparseLinearSolver>` is a trait
@@ -37,6 +41,8 @@
 //! constraint).
 
 use super::methods::backward_euler::BackwardEulerSolver;
+use super::methods::implicit::stiff_jacobian_convergence;
+use super::methods::newton::{JacobianStrategy, NewtonConvergence};
 use super::sparse::FaerSparseSolver;
 use super::Solver;
 use crate::context::error::OxiflowError;
@@ -62,6 +68,23 @@ pub enum IntegratorSpec {
         /// `None` keeps the dense path regardless of `sparse_threshold`.
         #[cfg_attr(feature = "serde", serde(default))]
         jacobian_bandwidth: Option<usize>,
+        /// Newton convergence criterion (DD-044, #114) — see
+        /// [`BackwardEulerSolver::with_newton_convergence`]. Defaults to
+        /// [`stiff_jacobian_convergence`], not [`NewtonConvergence::default`]
+        /// — matching `BackwardEulerSolver`'s own zero-config value (see
+        /// that function's docs for why they differ).
+        #[cfg_attr(feature = "serde", serde(default = "default_newton_convergence"))]
+        newton_convergence: NewtonConvergence,
+        /// Jacobian refresh strategy (DD-044, #114) — see
+        /// [`BackwardEulerSolver::with_jacobian_strategy`].
+        #[cfg_attr(feature = "serde", serde(default))]
+        jacobian_strategy: JacobianStrategy,
+        /// Newton iteration budget (DD-044, #114) — see
+        /// [`BackwardEulerSolver::with_max_newton_iterations`]. Defaults
+        /// to `1`, matching `BackwardEulerSolver`'s own zero-config value
+        /// (the pre-DD-044 single-correction contract).
+        #[cfg_attr(feature = "serde", serde(default = "default_max_newton_iterations"))]
+        max_iterations: usize,
     },
 }
 
@@ -76,6 +99,20 @@ fn default_sparse_threshold() -> usize {
     100
 }
 
+/// Default for `newton_convergence` when omitted — see the field's own
+/// docs for why this is [`stiff_jacobian_convergence`], not
+/// [`NewtonConvergence::default`].
+#[cfg(feature = "serde")]
+fn default_newton_convergence() -> NewtonConvergence {
+    stiff_jacobian_convergence()
+}
+
+/// Default for `max_iterations` when omitted — see the field's own docs.
+#[cfg(feature = "serde")]
+fn default_max_newton_iterations() -> usize {
+    1
+}
+
 impl TryFrom<IntegratorSpec> for Box<dyn Solver> {
     type Error = OxiflowError;
 
@@ -84,8 +121,15 @@ impl TryFrom<IntegratorSpec> for Box<dyn Solver> {
             IntegratorSpec::BackwardEuler {
                 sparse_threshold,
                 jacobian_bandwidth,
+                newton_convergence,
+                jacobian_strategy,
+                max_iterations,
             } => {
-                let mut solver = BackwardEulerSolver::new().with_sparse_threshold(sparse_threshold);
+                let mut solver = BackwardEulerSolver::new()
+                    .with_sparse_threshold(sparse_threshold)
+                    .with_newton_convergence(newton_convergence)
+                    .with_jacobian_strategy(jacobian_strategy)
+                    .with_max_newton_iterations(max_iterations);
                 if let Some(bandwidth) = jacobian_bandwidth {
                     solver = solver
                         .with_jacobian_bandwidth(bandwidth)
@@ -108,6 +152,9 @@ mod tests {
         let spec = IntegratorSpec::BackwardEuler {
             sparse_threshold: 100,
             jacobian_bandwidth: None,
+            newton_convergence: NewtonConvergence::default(),
+            jacobian_strategy: JacobianStrategy::default(),
+            max_iterations: 1,
         };
         let solver: Box<dyn Solver> = spec.try_into().unwrap();
         // Object-safety + successful construction is the assertion here —
@@ -121,6 +168,9 @@ mod tests {
         let spec = IntegratorSpec::BackwardEuler {
             sparse_threshold: 50,
             jacobian_bandwidth: Some(3),
+            newton_convergence: NewtonConvergence::default(),
+            jacobian_strategy: JacobianStrategy::default(),
+            max_iterations: 1,
         };
         let solver: Box<dyn Solver> = spec.try_into().unwrap();
         let _ = solver;
@@ -135,9 +185,15 @@ mod tests {
             IntegratorSpec::BackwardEuler {
                 sparse_threshold,
                 jacobian_bandwidth,
+                newton_convergence,
+                jacobian_strategy,
+                max_iterations,
             } => {
                 assert_eq!(sparse_threshold, default_sparse_threshold());
                 assert_eq!(jacobian_bandwidth, None);
+                assert_eq!(newton_convergence, default_newton_convergence());
+                assert_eq!(jacobian_strategy, JacobianStrategy::default());
+                assert_eq!(max_iterations, default_max_newton_iterations());
             }
         }
     }
@@ -151,10 +207,88 @@ mod tests {
             IntegratorSpec::BackwardEuler {
                 sparse_threshold,
                 jacobian_bandwidth,
+                ..
             } => {
                 assert_eq!(sparse_threshold, 42);
                 assert_eq!(jacobian_bandwidth, Some(2));
             }
         }
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialises_newton_fields_with_defaults() {
+        let json = r#"{ "BackwardEuler": {} }"#;
+        let spec: IntegratorSpec = serde_json::from_str(json).unwrap();
+        match spec {
+            IntegratorSpec::BackwardEuler {
+                newton_convergence,
+                jacobian_strategy,
+                max_iterations,
+                ..
+            } => {
+                // Matches `BackwardEulerSolver::default()`'s own values —
+                // not `NewtonConvergence::default()` (see the field's docs).
+                assert_eq!(
+                    newton_convergence,
+                    NewtonConvergence::ResidualOnly {
+                        tol_abs: 1e-5,
+                        tol_rel: 1e-6,
+                    }
+                );
+                assert_eq!(jacobian_strategy, JacobianStrategy::ModifiedFrozen);
+                assert_eq!(max_iterations, 1);
+            }
+        }
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialises_explicit_newton_fields() {
+        let json = r#"{
+            "BackwardEuler": {
+                "newton_convergence": { "CombinedOr": { "tol_abs": 1e-9, "tol_rel": 1e-7 } },
+                "jacobian_strategy": "FullNewton",
+                "max_iterations": 30
+            }
+        }"#;
+        let spec: IntegratorSpec = serde_json::from_str(json).unwrap();
+        match spec {
+            IntegratorSpec::BackwardEuler {
+                newton_convergence,
+                jacobian_strategy,
+                max_iterations,
+                ..
+            } => {
+                assert_eq!(
+                    newton_convergence,
+                    NewtonConvergence::CombinedOr {
+                        tol_abs: 1e-9,
+                        tol_rel: 1e-7,
+                    }
+                );
+                assert_eq!(jacobian_strategy, JacobianStrategy::FullNewton);
+                assert_eq!(max_iterations, 30);
+            }
+        }
+    }
+
+    #[test]
+    fn newton_fields_take_effect_through_try_from() {
+        // Object-safety + successful construction, mirroring
+        // `dense_path_when_no_jacobian_bandwidth` above -- `BackwardEulerSolver`'s
+        // Newton fields are private, not observable from outside the
+        // crate, so this only proves the builders are actually called
+        // (a typo'd builder name would fail to compile, not silently
+        // no-op).
+        let spec = IntegratorSpec::BackwardEuler {
+            sparse_threshold: 100,
+            jacobian_bandwidth: None,
+            newton_convergence: NewtonConvergence::default(),
+            jacobian_strategy: JacobianStrategy::FullNewton,
+            max_iterations: 25,
+        };
+        let solver: Box<dyn Solver> = spec.try_into().unwrap();
+        let _ = solver;
     }
 }


### PR DESCRIPTION
## Summary

Merges the validated `staging` branch into `main` for the v0.7.0 release — iterated Newton solver (#109) for  BackwardEulerSolver`/ `CrankNicolsonSolver`/`BDF2Solver`, extended `IntegratorSpec`, and #81 closed (RKN deferred, Option A recorded).

Straight merge of `staging`; no code beyond what the update→staging PR already introduced and validated.

## Linked issues

Same set as update→staging: closes #109–#116; refs #81.

## Type of change

- [x] Release merge

## Layer stack note

No change from update→staging.

## Tests

Full control chain and test suite (`cargo test`, `cargo test --features "sparse serde"`) validated on `staging` prior to this merge.

## Post-merge

Tag `v0.7.0` on `main`.