### PR TITLE
Release v0.8.0 — Computational Optimisation (GPU-readiness)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,9 @@ jobs:
         run: cargo clippy -- -D warnings
 
       # DD-043 (#50) — sparse linear algebra backend (faer). No system
-      # dependency needed, but requires rustc 1.84+ (faer 0.24's own MSRV,
-      # above this crate's own rust-version = "1.80") — @stable is expected
-      # to satisfy this; revisit if it ever regresses below 1.84.
+      # dependency needed. faer 0.24's own MSRV (1.84) now matches this
+      # crate's rust-version exactly (raised from 1.80 to 1.84 by DD-045,
+      # #127, for wgpu's sake) — no remaining tension to revisit here.
       - name: cargo clippy — feature sparse
         run: cargo clippy --features sparse -- -D warnings
 
@@ -69,6 +69,15 @@ jobs:
 
       - name: cargo clippy — feature hdf5
         run: cargo clippy --features hdf5 -- -D warnings
+
+      # DD-026 (#73) / DD-045 (#127) — no system dependency needed to
+      # compile: the vulkan/metal/dx12 wgpu backends only need a driver at
+      # runtime, not at build time. `gpu_context_acquires_adapter` is
+      # `#[ignore]`d (no GPU hardware on CI runners) — this step only
+      # guards against `wgpu`/`pollster`/`bytemuck` becoming unbuildable
+      # or the boundary-conversion code regressing.
+      - name: cargo clippy — feature gpu
+        run: cargo clippy --features gpu -- -D warnings
 
       # J5 (v0.7) — activate when consumed for real:
       # parallel/serde are already declared in Cargo.toml but not yet
@@ -114,6 +123,12 @@ jobs:
       - name: cargo test — feature hdf5
         run: cargo test --features hdf5
 
+      # DD-026 (#73) / DD-045 (#127) — see the clippy job for why no
+      # system dependency is needed. `gpu_context_acquires_adapter` stays
+      # `#[ignore]`d here (no GPU hardware on CI runners).
+      - name: cargo test — feature gpu
+        run: cargo test --features gpu
+
       # J5 (v0.7) — activate when consumed for real (see the clippy job).
       # - name: cargo test — feature parallel
       #   run: cargo test --features parallel
@@ -145,7 +160,7 @@ jobs:
           restore-keys: ${{ runner.os }}-doc-
 
       - name: cargo doc — build with KaTeX header
-        run: RUSTDOCFLAGS="--html-in-header docs/katex-header.html" cargo doc --no-deps
+        run: RUSTDOCFLAGS="--html-in-header docs/katex-header.html" cargo doc --no-deps --all-features
 
       - name: Add root redirect to oxiflow/index.html
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ oxiflow adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.8.0] - 2026-08-03
+
+### Added
+
+- `gpu` feature flag (`wgpu 26.0.1`, `pollster`, `bytemuck`, all optional) —
+  `solver::gpu::GpuContext::new()` acquires a GPU adapter/device/queue,
+  blocking via `pollster`; `to_gpu_bytes()` reinterprets `ContextValue`'s
+  contiguous `f64` payloads as raw bytes via `bytemuck::cast_slice`, without
+  requiring `ContextValue` itself to implement `bytemuck::Pod` (the enum
+  discriminant remains the blocker for that, deferred) (DD-026, DD-045,
+  #74)
+- `OxiflowError::GpuUnavailable` — returned when no compatible GPU adapter
+  or device is found; never a silent CPU fallback, the caller chooses its
+  own CPU solver (DD-045)
+- CI: `clippy --features gpu` and `test --features gpu` jobs added to
+  `ci.yml` (#122)
+
+### Changed
+
+- **MSRV raised `1.80` → `1.84`** — no stable `wgpu` release declares
+  compatibility with `1.80`; `1.84` is the lowest MSRV declared by `wgpu`
+  26.0.1, the version selected (DD-045)
+- `ContextValue`'s `GPU-READY` annotation (DD-026 INV-GPU-5) relocated onto
+  `ContextValue` itself (previously misapplied to `MultiDomainState`, which
+  can never be `bytemuck::Pod` — a `HashMap` has no fixed, Pod-compatible
+  layout); column-major layout (INV-GPU-4) documented directly on
+  `ContextValue::Matrix`/`ContextValue::VectorField` (#127)
+- `MultiDomainState` module docs corrected: requalified as an
+  indexed/orchestration container, out of INV-GPU-1's scope, rather than
+  claiming to satisfy it (#127)
+- Rustdoc intra-doc links and DD citation style normalised across the
+  crate; `cargo doc --no-deps --all-features` now emits **zero warnings**
+  (validated by a real run) (#122)
+
+### Known gaps
+
+- `derive(Pod, Zeroable)` on `ContextValue` remains blocked by its enum
+  discriminant — resolution deferred past this release, not part of the
+  `gpu` feature's initial scope (DD-045)
+- No real-GPU integration test runs in CI (no GPU hardware available);
+  the one that exists is `#[ignore]`d (#74)
+- `BDF2Solver` still has no sparse builders (`sparse_solver`,
+  `sparse_threshold`, `jacobian_bandwidth` absent) — a DD-043 gap,
+  unaddressed by this release, carried forward to v0.9.0
+- `OperatorSplittingSolver::solve` (IMEX) does not call
+  `self.on_divergence()` / build a `SimulationSnapshot` on divergence,
+  unlike every other solver in the crate — discovered this release,
+  carried forward to v0.9.0
+
 ## [0.7.0] - 2026-07-30
 
 ### Added

--- a/CONTRIBUER.md
+++ b/CONTRIBUER.md
@@ -51,6 +51,20 @@ Toute pull request doit satisfaire l'ensemble des points suivants avant d'être 
 - Utiliser `### Added`, `### Changed`, `### Fixed`, ou `### Breaking`.
 - Une ligne par changement logique.
 
+**Documentation (locale, pour contributeurs)**
+- La documentation publique déployée sur GitHub Pages (générée par le CI,
+  `cargo doc --no-deps --all-features`) ne couvre volontairement que la surface
+  d'API publique — les éléments internes `pub(crate)` (mécanique Newton, dispatch
+  bande/creux, etc.) sont abondamment référencés entre eux en rustdoc, mais ne
+  font pas partie de ce site public.
+- Pour parcourir localement le graphe complet des références croisées internes
+  (recommandé avant de relire une PR touchant `solver::methods` ou `operators`) :
+  ```
+  cargo doc --no-deps --all-features --document-private-items --open
+  ```
+- Cette commande n'est jamais exécutée en CI et son résultat n'est jamais publié —
+  usage local uniquement.
+
 ## Invariants de conception
 
 Toute contribution touchant `src/mesh/`, `src/coupling/`, `src/solver/spatial/`, ou

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,18 @@ Every pull request must satisfy all of the following before merging.
 - Use `### Added`, `### Changed`, `### Fixed`, or `### Breaking`.
 - One line per logical change.
 
+**Documentation (local, contributor-facing)**
+- The public docs published on GitHub Pages (built by CI, `cargo doc --no-deps
+  --all-features`) intentionally only cover the public API surface — internal
+  `pub(crate)` items (Newton loop internals, sparse/banded dispatch, etc.) are
+  cross-referenced extensively in rustdoc but are not part of that public site.
+- To browse the full internal cross-reference graph locally (recommended before
+  reviewing a PR that touches `solver::methods` or `operators`):
+  ```
+  cargo doc --no-deps --all-features --document-private-items --open
+  ```
+- This command is not run in CI and its output is never published — local use only.
+
 ## Design invariants
 
 Any contribution touching `src/mesh/`, `src/coupling/`, `src/solver/spatial/`, or any

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "oxiflow"
-version     = "0.7.0"
+version     = "0.8.0"
 edition     = "2021"
 rust-version = "1.84"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name        = "oxiflow"
 version     = "0.7.0"
 edition     = "2021"
-rust-version = "1.80"
+rust-version = "1.84"
 
 description = "Generic PDE solving engine for transport, reaction and diffusion phenomena (∂u/∂t + ∇·F = S)"
 license     = "Apache-2.0"
@@ -75,6 +75,22 @@ serde_json = { version = "1", optional = true }
 # MSRV que `serde_json` ci-dessus : `bincode 1.3` (API `serialize`/
 # `deserialize` classique), pas `2.x`/`3.x` (`rust-version = "1.85.0"`).
 bincode = { version = "1.3", optional = true }
+# feature `gpu`      — architecture GPU (DD-026/#73, DD-045/#127). `wgpu`
+# 26.0.1 : dernière version déclarant une MSRV compatible (`1.84`) — voir
+# DD-045 pour le détail de la tension MSRV (aucune version stable ne déclare
+# `1.80`, plancher relevé plutôt que de parier sur une MSRV non déclarée).
+# `default-features = false` : exclut `gles`/`webgpu` (cibles navigateur/
+# mobile, hors périmètre d'un crate de calcul scientifique natif) — seuls
+# les backends natifs desktop sont retenus (DD-045).
+wgpu = { version = "26.0.1", optional = true, default-features = false, features = ["vulkan", "metal", "dx12", "wgsl"] }
+# feature `gpu`      — exécution bloquante de `request_adapter`/`request_device`
+# (DD-045 : pas de runtime async, cohérent avec `Solver::solve()` déjà bloquant).
+pollster = { version = "1.0", optional = true }
+# feature `gpu`      — conversion des payloads `ContextValue` en octets
+# uploadables (`bytemuck::cast_slice` sur les tranches `DVector`/`DMatrix`,
+# DD-026 INV-GPU-5). Pas de `rust-version` déclarée en amont, aucune tension
+# MSRV constatée.
+bytemuck = { version = "1.25", optional = true }
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Features
@@ -103,6 +119,11 @@ vtk      = ["dep:vtkio"]
 # Solveur linéaire creux (faer) — DD-013 (issue #13) / DD-043 (issue #50,
 # v0.6.0). Trait frère de LinearSolver (solver::sparse), pas une extension.
 sparse   = ["dep:faer"]
+
+# Architecture GPU — DD-026 (#73) / DD-045 (#127). Toujours active dès que la
+# feature est activée, sans seuil runtime (divergence délibérée avec
+# `parallel`/DD-014 : la feature flag est déjà l'opt-in, voir DD-045).
+gpu      = ["dep:wgpu", "dep:pollster", "dep:bytemuck"]
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Dépendances de développement / Development dependencies

--- a/README.fr.md
+++ b/README.fr.md
@@ -67,7 +67,7 @@ object-safe précisément dans ce but.
 
 ```toml
 [dependencies]
-oxiflow = "0.7"
+oxiflow = "0.8"
 # oxiflow-chrom = "3.0"    # framework chromatographie (disponible dès v3.0)
 ```
 
@@ -161,15 +161,16 @@ assurent la compatibilité des frameworks tiers entre les versions du moteur :
 | J5 — Discrétisation                      | v0.5.0 | ✅ Publié   | DiscreteOperator (INV-2) · FD/FV · WENO3/5 · limiteurs de flux + sélection adaptative                              |
 | J6 — Algèbre creuse & persistance        | v0.6.0 | ✅ Publié   | solveur creux faer · SimulationSnapshot (checkpoint/on_divergence) · chargement HDF5 · export VTK · IntegratorSpec |
 | J7 — Intégration temporelle non linéaire | v0.7.0 | ✅ Publié   | Itération de Newton pour les intégrateurs implicites (DD-044) · `IntegratorSpec` étendu à BE/CN/BDF2                |
-| J8 — Optimisation des calculs            | v0.8.0 | ⏳ Planifié | Profilage · optimisation algorithmique/mémoire · GPU-readiness (DD-026)                                            |
+| J8 — Optimisation des calculs            | v0.8.0 | ✅ Publié   | GPU-readiness (DD-026, DD-045) · feature `gpu` (`wgpu`) · MSRV 1.84                                                 |
 | J9 — Parallélisme & Benchmarking         | v0.9.0 | ⏳ Planifié | Rayon · cache dirty-flag · benchmarks Criterion                                                                    |
 | J10 — Écosystème v1.0                    | v1.0.0 | ⏳ Planifié | 7 exemples · audit FEM · API stable                                                                                |
 | J20 — FEM                                | v2.0.0 | 🔭 Horizon | Maillages non structurés · ALE · INV-4 plugin-safe                                                                 |
 | J30 — Frameworks                         | v3.0.0 | 🔭 Horizon | oxiflow-chrom · oxiflow-geo · CLI `oxiflow run`                                                                    |
 
 Les sous-invariants INV-GPU-1 à INV-GPU-5 (DD-026) gouvernent la GPU-readiness des
-structures de données numériques dès v0.3.0 — pas de code GPU pour l'instant, mais tous
-les types sont conçus pour admettre un future feature `gpu` sans breaking change.
+structures de données numériques depuis v0.3.0 ; la feature `gpu` elle-même (sélection de
+backend, acquisition d'adaptateur, conversion à la frontière CPU↔GPU) est arrivée en
+v0.8.0 (DD-045), sans aucun breaking change sur les types conçus contre ces invariants.
 
 Voir [DEVELOPPEMENT.md](DEVELOPPEMENT.md) pour la spécification architecturale complète.
 
@@ -185,7 +186,7 @@ Voir [DEVELOPPEMENT.md](DEVELOPPEMENT.md) pour la spécification architecturale 
 | `vtk`      | Export VTK (`.vtu`) de `SimulationResult`                  | v0.6            |
 | `sparse`   | Solveur linéaire creux `faer` pour intégrateurs implicites | v0.6            |
 | `parallel` | Parallélisme Rayon pour les calculateurs indépendants      | v0.9 (planifié) |
-| `gpu`      | Accélération GPU via `wgpu` (Vulkan/Metal/DX12)            | v0.8 (planifié) |
+| `gpu`      | Accélération GPU via `wgpu` (Vulkan/Metal/DX12)            | v0.8            |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ plugin API — the engine exposes stable, object-safe extension points for exact
 
 ```toml
 [dependencies]
-oxiflow = "0.7"
+oxiflow = "0.8"
 # oxiflow-chrom = "3.0"    # chromatography framework (available from v3.0)
 ```
 
@@ -159,15 +159,16 @@ third-party frameworks remain compatible across engine versions:
 | J5 — Discretisation    | v0.5.0   | ✅ Published  | DiscreteOperator (INV-2) · FD/FV · WENO3/5 · flux limiters + adaptive selection |
 | J6 — Sparse Algebra & Persistence | v0.6.0 | ✅ Published | faer sparse solver · SimulationSnapshot (checkpoint/on_divergence) · HDF5 loading · VTK export · IntegratorSpec |
 | J7 — Nonlinear Time Integration | v0.7.0 | ✅ Published | Iterated Newton for implicit integrators (DD-044) · `IntegratorSpec` extended to BE/CN/BDF2 |
-| J8 — Computational Optimisation | v0.8.0 | ⏳ Planned | Profiling · algorithmic/memory optimisation · GPU-readiness (DD-026) |
+| J8 — Computational Optimisation | v0.8.0 | ✅ Published | GPU-readiness (DD-026, DD-045) · `gpu` feature (`wgpu`) · MSRV 1.84 |
 | J9 — Parallelism & Benchmarking | v0.9.0 | ⏳ Planned | Rayon · dirty-flag cache · Criterion benchmarks |
 | J10 — Ecosystem v1.0   | v1.0.0   | ⏳ Planned    | 7 examples · FEM audit · stable API             |
 | J20 — FEM              | v2.0.0   | 🔭 Horizon   | Unstructured meshes · ALE · INV-4 plugin-safe   |
 | J30 — Frameworks       | v3.0.0   | 🔭 Horizon   | oxiflow-chrom · oxiflow-geo · CLI `oxiflow run` |
 
-The INV-GPU-1 to INV-GPU-5 sub-invariants (DD-026) govern GPU-readiness of numerical
-data structures from v0.3.0 — no GPU code yet, but all types are designed to admit a
-future `gpu` feature without breaking API changes.
+The INV-GPU-1 to INV-GPU-5 sub-invariants (DD-026) have governed GPU-readiness of numerical
+data structures since v0.3.0; the `gpu` feature itself (backend selection, adapter
+acquisition, CPU↔GPU boundary conversion) landed in v0.8.0 (DD-045) with no breaking API
+changes to any type designed against those invariants.
 
 See [DEVELOPMENT.md](DEVELOPMENT.md) for the full architectural specification.
 
@@ -183,7 +184,7 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for the full architectural specification.
 | `vtk`       | VTK (`.vtu`) export of `SimulationResult`      | v0.6           |
 | `sparse`    | `faer` sparse linear solver for implicit integrators | v0.6     |
 | `parallel`  | Rayon parallelism for independent calculators  | v0.9 (planned) |
-| `gpu`       | GPU acceleration via `wgpu` (Vulkan/Metal/DX12) | v0.8 (planned) |
+| `gpu`       | GPU acceleration via `wgpu` (Vulkan/Metal/DX12)| v0.8           |
 
 ---
 

--- a/src/context/error.rs
+++ b/src/context/error.rs
@@ -125,6 +125,17 @@ pub enum OxiflowError {
         /// Norm of the residual at the last iterate.
         residual: f64,
     },
+
+    /// No compatible GPU adapter was found (DD-045, `gpu` feature).
+    ///
+    /// Returned by [`crate::solver::gpu::GpuContext::new`] — never a silent
+    /// CPU fallback (DD-045's explicit-error policy). The caller decides
+    /// which CPU solver to fall back to. Present unconditionally (not
+    /// `#[cfg(feature = "gpu")]`), consistent with `Persistence` above,
+    /// which is likewise feature-agnostic in the enum's shape even though
+    /// only produced under specific features.
+    #[error("no GPU adapter available (gpu feature enabled but no compatible device found)")]
+    GpuUnavailable,
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -37,9 +37,12 @@
 //!
 //! Field values are stored as [`ContextValue::ScalarField`] (`DVector<f64>`,
 //! column-major) or [`ContextValue::VectorField`] (`DMatrix<f64>`, column-major
-//! — nalgebra default). This satisfies DD-026 INV-GPU-1 and INV-GPU-4.
-//!
-// GPU-READY: bytemuck::Pod candidate (DD-026 INV-GPU-5) — pending v0.5.0 (DD-013)
+//! — nalgebra default). It is these stored *values* that satisfy DD-026
+//! INV-GPU-1/INV-GPU-4 (see [`ContextValue`]'s own rustdoc) — `MultiDomainState`
+//! itself is an indexed/orchestration container (`HashMap`), not a contiguous
+//! buffer, and is out of INV-GPU-1's scope for the same reason
+//! `Vec<Box<dyn PhysicalModel>>` is (DD-026): it holds numerical payloads
+//! without being one.
 
 use std::collections::HashMap;
 
@@ -84,7 +87,9 @@ use crate::solver::scenario::DomainId;
 pub struct MultiDomainState {
     /// Internal map: (domain, quantity) → field value.
     ///
-    /// Column-major memory layout for all field payloads (DD-026 INV-GPU-4).
+    /// The map itself is not contiguous memory; the [`ContextValue`] payloads
+    /// it stores are (DD-026 INV-GPU-1/INV-GPU-4 — see [`ContextValue`]'s
+    /// own rustdoc for the layout note and the `GPU-READY` annotation).
     states: HashMap<(DomainId, PhysicalQuantity), ContextValue>,
 }
 

--- a/src/context/value.rs
+++ b/src/context/value.rs
@@ -65,6 +65,11 @@ use crate::context::error::OxiflowError;
 /// assert_eq!(t.as_scalar().unwrap(), 1.5);
 /// assert!(!field.as_scalar_field().unwrap().is_empty());
 /// ```
+// GPU-READY: bytemuck::Pod candidate (DD-026 INV-GPU-5) — pending v0.8.0 (J8),
+// for the `Vector`/`Matrix`/`ScalarField`/`VectorField` variants specifically;
+// `Scalar`/`Boolean` are trivially Pod-compatible, the enum discriminant is
+// the actual blocker for a direct `derive(Pod)` and will need to be resolved
+// at upload-boundary design time (DD-045), not before.
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -87,6 +92,11 @@ pub enum ContextValue {
     /// $$D'_{ij} = J_{ik}\,D_{kl}\,J_{jl}^{\top}$$
     ///
     /// This variant stores components in the current reference frame only.
+    ///
+    /// Memory layout: `DMatrix<f64>` is **column-major** (nalgebra default,
+    /// Fortran order) — DD-026 INV-GPU-4. WGSL (the `wgpu` shader language)
+    /// is row-major; any transposition is resolved at the future GPU upload
+    /// boundary, never in this type.
     Matrix(DMatrix<f64>),
 
     // ── Nodal fields ──────────────────────────────────────────────────────────
@@ -97,7 +107,14 @@ pub enum ContextValue {
 
     /// One vector per mesh node, stored as `n_nodes × spatial_dim` matrix.
     ///
-    /// Row `i` holds the vector at node `i`.
+    /// Row `i` holds the vector at node `i`. Dimensions (`n_nodes`,
+    /// `spatial_dim`) are available via `DMatrix::nrows()`/`ncols()`
+    /// (DD-026 INV-GPU-2).
+    ///
+    /// Memory layout: `DMatrix<f64>` is **column-major** (nalgebra default,
+    /// Fortran order) — DD-026 INV-GPU-4. WGSL (the `wgpu` shader language)
+    /// is row-major; any transposition is resolved at the future GPU upload
+    /// boundary, never in this type.
     VectorField(DMatrix<f64>),
     // Reserved for J7 — requires DiscreteOperator (INV-2):
     // Tensor4(ndarray::Array4<f64>)  — rank-4 tensor C_ijkl

--- a/src/operators/fv.rs
+++ b/src/operators/fv.rs
@@ -30,7 +30,7 @@
 //! ## CFL check
 //!
 //! Both schemes check the explicit advective stability condition
-//! `|v|·dt/dx ≤ 1` via the shared [`crate::operators::check_cfl`] (the
+//! `|v|·dt/dx ≤ 1` via the shared `crate::operators::check_cfl` (the
 //! condition documented for Lax–Wendroff-type explicit advection schemes)
 //! inside `apply()`, using `ctx.time_step()` — failing explicitly via
 //! [`OxiflowError::PreconditionFailed`] rather than silently returning an
@@ -62,7 +62,7 @@ use crate::operators::{check_cfl, FluxBoundary, FluxDivergenceOperator};
 /// two neighboring cells, given their (cell-average) state values. The
 /// divergence at cell `i` is `(F_{i+1/2} − F_{i−1/2}) / dx`, with periodic
 /// wrap-around indexing (`FluxBoundary::Periodic`, see module documentation).
-fn periodic_divergence(
+pub(crate) fn periodic_divergence(
     u: &DVector<f64>,
     dx: f64,
     face_flux: impl Fn(f64, f64) -> f64,
@@ -96,7 +96,7 @@ fn periodic_divergence(
 /// documentation for why this mirrors `operators::fd`'s existing boundary
 /// posture. Requires at least 3 cells: 2 boundary cells plus 1 interior cell
 /// to borrow from.
-fn truncated_divergence(
+pub(crate) fn truncated_divergence(
     u: &DVector<f64>,
     dx: f64,
     face_flux: impl Fn(f64, f64) -> f64,

--- a/src/operators/limiters.rs
+++ b/src/operators/limiters.rs
@@ -69,7 +69,7 @@
 //!
 //! ## `FluxBoundary` and CFL
 //!
-//! Reuses [`crate::operators::FluxBoundary`], [`crate::operators::check_cfl`],
+//! Reuses [`crate::operators::FluxBoundary`], `crate::operators::check_cfl`,
 //! and the same wide-stencil boundary helpers `operators::weno` uses
 //! (`periodic_wide_divergence`, `truncated_wide_divergence`,
 //! `ghost_cell_wide_divergence`, relocated to `operators` — see their

--- a/src/operators/weno.rs
+++ b/src/operators/weno.rs
@@ -16,7 +16,7 @@
 //! formulas and ideal weights follow Jiang & Shu (1996); the nonlinear
 //! weighting formula itself uses WENO-Z (Borges, Carmona, Costa & Don,
 //! 2008) rather than the original Jiang-Shu weighting — see
-//! [`weno_combine2`] for why (critical-point accuracy).
+//! `weno_combine2` for why (critical-point accuracy).
 //!
 //! Like `operators::fv`: `F(u, ∇u) = v·u − D·∂u/∂x` (advection, Fick's law
 //! diffusion) — only the advective face value is WENO-reconstructed; the
@@ -58,7 +58,7 @@
 //! ## `FluxBoundary` and CFL
 //!
 //! Both reuse [`crate::operators::FluxBoundary`] and
-//! [`crate::operators::check_cfl`], shared with `operators::fv` — same
+//! `crate::operators::check_cfl`, shared with `operators::fv` — same
 //! boundary-treatment question, same advective stability condition. See
 //! their documentation for rationale.
 //!
@@ -107,7 +107,7 @@ const WENO_EPSILON: f64 = 1e-6;
 /// Exponent `p=1` on `τ/(ε+β_k)`, matching the original Borges et al. (2008)
 /// formulation (some later variants, e.g. "WENO-Z+", use `p=2` for a
 /// stronger correction — not adopted here, no concrete need for it yet).
-fn weno_combine2(q0: f64, q1: f64, beta0: f64, beta1: f64, d0: f64, d1: f64) -> f64 {
+pub(crate) fn weno_combine2(q0: f64, q1: f64, beta0: f64, beta1: f64, d0: f64, d1: f64) -> f64 {
     let tau = (beta0 - beta1).abs();
     let a0 = d0 * (1.0 + tau / (WENO_EPSILON + beta0));
     let a1 = d1 * (1.0 + tau / (WENO_EPSILON + beta1));
@@ -191,7 +191,7 @@ fn weno3_right(b: f64, c: f64, d: f64) -> f64 {
 /// `{a, b, c, d, e} = {u[i−2], u[i−1], u[i], u[i+1], u[i+2]}`
 /// (Jiang & Shu, 1996) — see the correction history above `weno3_left` for
 /// why these are cell-average coefficients, not a nodal reinterpretation.
-fn weno5_left(a: f64, b: f64, c: f64, d: f64, e: f64) -> f64 {
+pub(crate) fn weno5_left(a: f64, b: f64, c: f64, d: f64, e: f64) -> f64 {
     let q0 = (2.0 * a - 7.0 * b + 11.0 * c) / 6.0;
     let q1 = (-b + 5.0 * c + 2.0 * d) / 6.0;
     let q2 = (2.0 * c + 5.0 * d - e) / 6.0;

--- a/src/solver/gpu/mod.rs
+++ b/src/solver/gpu/mod.rs
@@ -1,0 +1,194 @@
+//! # Module `solver::gpu`
+//!
+//! GPU architecture layer (DD-026, issue #73; DD-045, issue #127).
+//!
+//! ## Scope
+//!
+//! This module owns exactly two things, both HOW-side (never surfacing into
+//! `PhysicalModel`/`Domain`/`Scenario`, per DD-045):
+//!
+//! 1. **Adapter/device acquisition** ([`GpuContext::new`]) — blocking, via
+//!    `pollster`, with an automatic `HighPerformance` adapter preference and
+//!    an explicit [`OxiflowError::GpuUnavailable`] on failure (never a silent
+//!    CPU fallback — the caller decides).
+//! 2. **CPU↔GPU boundary conversion** ([`to_gpu_bytes`]) — reinterprets the
+//!    contiguous `f64` payloads already inside [`ContextValue`] (DD-026
+//!    INV-GPU-1) as raw bytes via `bytemuck::cast_slice`, without requiring
+//!    `ContextValue` itself to implement `bytemuck::Pod` (its enum
+//!    discriminant never can). Only the numeric payload is cast, not the
+//!    enum wrapper.
+//!
+//! ## What this module does *not* do
+//!
+//! No compute shader (WGSL), no buffer upload/dispatch, no `wgpu::Device`
+//! usage beyond acquisition. Actual GPU-accelerated computation is future
+//! work, not part of #74/DD-045 — this module is the boundary layer those
+//! future kernels will sit behind.
+//!
+//! ## Dispatch model (DD-045)
+//!
+//! No configurable runtime threshold (contrast with `parallel`/DD-014): the
+//! `gpu` feature flag is itself the opt-in. Once compiled with `--features
+//! gpu`, [`GpuContext::new`] is always the path taken — there is no
+//! CPU/GPU switch left to flip at runtime by this module.
+
+use bytemuck::cast_slice;
+
+use crate::context::error::OxiflowError;
+use crate::context::value::ContextValue;
+
+// ── GpuContext ──────────────────────────────────────────────────────────────
+
+/// Acquired GPU adapter, device and queue — the entry point of the `gpu`
+/// feature.
+///
+/// Construction is blocking ([`GpuContext::new`]), consistent with
+/// `Solver::solve()` already being a single blocking call (DD-045): no
+/// async runtime is introduced anywhere else in the crate.
+pub struct GpuContext {
+    /// Kept for adapter introspection (name, backend, limits) — not read by
+    /// this skeleton yet, reserved for the future dispatch layer.
+    #[allow(dead_code)]
+    adapter: wgpu::Adapter,
+    /// Logical GPU device — will own future compute pipelines/shaders.
+    pub device: wgpu::Device,
+    /// Command queue — will submit future compute dispatches.
+    pub queue: wgpu::Queue,
+}
+
+impl GpuContext {
+    /// Acquires a GPU adapter and device, blocking (DD-045).
+    ///
+    /// Requests a `HighPerformance` adapter (compute workload, not
+    /// interactive rendering — no `compatible_surface`). Returns
+    /// [`OxiflowError::GpuUnavailable`] if no compatible adapter or device
+    /// is found — never a silent CPU fallback; the caller chooses its own
+    /// CPU solver in that case.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OxiflowError::GpuUnavailable`] if adapter or device
+    /// acquisition fails.
+    pub fn new() -> Result<Self, OxiflowError> {
+        // `wgpu 26.0.1` API: `InstanceDescriptor` still implements `Default`
+        // at this version (removed in a later release, v29+) — explicit
+        // backends restrict to the set decided in DD-045 (vulkan/metal/dx12,
+        // no gles/webgpu), matching the `features` selected in `Cargo.toml`.
+        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::VULKAN | wgpu::Backends::METAL | wgpu::Backends::DX12,
+            ..Default::default()
+        });
+
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            force_fallback_adapter: false,
+            compatible_surface: None,
+        }))
+        .map_err(|_| OxiflowError::GpuUnavailable)?;
+
+        let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("oxiflow-gpu-device"),
+            required_features: wgpu::Features::empty(),
+            required_limits: wgpu::Limits::default(),
+            memory_hints: wgpu::MemoryHints::default(),
+            trace: wgpu::Trace::Off,
+        }))
+        .map_err(|_| OxiflowError::GpuUnavailable)?;
+
+        Ok(Self {
+            adapter,
+            device,
+            queue,
+        })
+    }
+}
+
+// ── CPU↔GPU boundary conversion ──────────────────────────────────────────────
+
+/// Reinterprets a numeric [`ContextValue`] payload as raw bytes, ready for
+/// GPU buffer upload (DD-026 INV-GPU-5).
+///
+/// Only the contiguous `f64` payload is cast (`bytemuck::cast_slice`) — never
+/// `ContextValue` itself, whose enum discriminant is not `Pod`-compatible.
+/// `Boolean` is not a numeric payload and has no meaningful GPU-upload
+/// representation here; it returns [`OxiflowError::TypeMismatch`].
+///
+/// # Errors
+///
+/// Returns [`OxiflowError::TypeMismatch`] for [`ContextValue::Boolean`].
+///
+/// # Examples
+///
+/// ```rust
+/// # #[cfg(feature = "gpu")]
+/// # {
+/// use oxiflow::context::value::ContextValue;
+/// use oxiflow::solver::gpu::to_gpu_bytes;
+/// use nalgebra::DVector;
+///
+/// let field = ContextValue::ScalarField(DVector::from_vec(vec![1.0, 2.0, 3.0]));
+/// let bytes = to_gpu_bytes(&field).unwrap();
+/// assert_eq!(bytes.len(), 3 * std::mem::size_of::<f64>());
+/// # }
+/// ```
+pub fn to_gpu_bytes(value: &ContextValue) -> Result<&[u8], OxiflowError> {
+    match value {
+        ContextValue::Scalar(s) => Ok(bytemuck::bytes_of(s)),
+        ContextValue::Vector(v) | ContextValue::ScalarField(v) => Ok(cast_slice(v.as_slice())),
+        ContextValue::Matrix(m) | ContextValue::VectorField(m) => Ok(cast_slice(m.as_slice())),
+        ContextValue::Boolean(_) => Err(OxiflowError::TypeMismatch {
+            expected: "numeric ContextValue (Scalar/Vector/Matrix/ScalarField/VectorField)",
+            actual: "Boolean",
+        }),
+        // `#[non_exhaustive]` on ContextValue: reserved J7 variants
+        // (Tensor4/TensorField) are not yet defined in the enum itself, so
+        // this arm is unreachable today, not a gap.
+        #[allow(unreachable_patterns)]
+        _ => Err(OxiflowError::TypeMismatch {
+            expected: "numeric ContextValue (Scalar/Vector/Matrix/ScalarField/VectorField)",
+            actual: value.variant_name(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::{DMatrix, DVector};
+
+    #[test]
+    fn to_gpu_bytes_scalar_field() {
+        let field = ContextValue::ScalarField(DVector::from_vec(vec![1.0, 2.0, 3.0]));
+        let bytes = to_gpu_bytes(&field).unwrap();
+        assert_eq!(bytes.len(), 3 * std::mem::size_of::<f64>());
+    }
+
+    #[test]
+    fn to_gpu_bytes_vector_field() {
+        let field = ContextValue::VectorField(DMatrix::from_element(2, 3, 1.5));
+        let bytes = to_gpu_bytes(&field).unwrap();
+        assert_eq!(bytes.len(), 6 * std::mem::size_of::<f64>());
+    }
+
+    #[test]
+    fn to_gpu_bytes_scalar() {
+        let value = ContextValue::Scalar(42.0);
+        let bytes = to_gpu_bytes(&value).unwrap();
+        assert_eq!(bytes.len(), std::mem::size_of::<f64>());
+    }
+
+    #[test]
+    fn to_gpu_bytes_rejects_boolean() {
+        let value = ContextValue::Boolean(true);
+        let err = to_gpu_bytes(&value).unwrap_err();
+        assert!(matches!(err, OxiflowError::TypeMismatch { .. }));
+    }
+
+    /// No GPU hardware in CI (documented limitation, DD-045 consequences) —
+    /// `#[ignore]`, run manually on a machine with a real adapter.
+    #[test]
+    #[ignore = "requires real GPU hardware, not available in CI"]
+    fn gpu_context_acquires_adapter() {
+        GpuContext::new().unwrap();
+    }
+}

--- a/src/solver/methods/backward_euler.rs
+++ b/src/solver/methods/backward_euler.rs
@@ -7,7 +7,7 @@
 //! $$u^{n+1} = u^n + \Delta t \cdot f(u^{n+1}, t^{n+1})$$
 //!
 //! A thin wrapper around the shared generalised theta method
-//! ([`super::implicit::theta_method_step_newton`], θ=1, DD-044, #111) —
+//! (`theta_method_step_newton`, θ=1, DD-044, [#111](https://github.com/biface/oxiflow/issues/111)) —
 //! see that module's docs for the frozen-Jacobian default and the
 //! iterated Newton path configurable via [`BackwardEulerSolver`]'s
 //! builders.
@@ -58,15 +58,15 @@ use crate::solver::{SimulationResult, Solver, SolverConfiguration};
 /// ```
 pub struct BackwardEulerSolver {
     linear_solver: Box<dyn LinearSolver>,
-    /// Newton convergence criterion (DD-044, #111) — default
+    /// Newton convergence criterion (DD-044, [#111](https://github.com/biface/oxiflow/issues/111)) — default
     /// [`stiff_jacobian_convergence`] (deliberately looser than
     /// [`NewtonConvergence::default`] — see that function's docs for why
     /// zero-config construction needs it).
     newton_convergence: NewtonConvergence,
-    /// Jacobian refresh strategy (DD-044, #111) — default
+    /// Jacobian refresh strategy (DD-044, [#111](https://github.com/biface/oxiflow/issues/111)) — default
     /// [`JacobianStrategy::default`] (`ModifiedFrozen`).
     jacobian_strategy: JacobianStrategy,
-    /// Newton iteration budget (DD-044, #111). Default `1`: exactly the
+    /// Newton iteration budget (DD-044, [#111](https://github.com/biface/oxiflow/issues/111)). Default `1`: exactly the
     /// pre-DD-044 single frozen-Jacobian correction — see
     /// [`super::implicit`]'s module docs for why this reproduces the
     /// historical behaviour exactly, not approximately, on affine
@@ -122,19 +122,19 @@ impl BackwardEulerSolver {
         self
     }
 
-    /// Configures the Newton convergence criterion (DD-044, #111).
+    /// Configures the Newton convergence criterion (DD-044, [#111](https://github.com/biface/oxiflow/issues/111)).
     pub fn with_newton_convergence(mut self, newton_convergence: NewtonConvergence) -> Self {
         self.newton_convergence = newton_convergence;
         self
     }
 
-    /// Configures the Jacobian refresh strategy (DD-044, #111).
+    /// Configures the Jacobian refresh strategy (DD-044, [#111](https://github.com/biface/oxiflow/issues/111)).
     pub fn with_jacobian_strategy(mut self, jacobian_strategy: JacobianStrategy) -> Self {
         self.jacobian_strategy = jacobian_strategy;
         self
     }
 
-    /// Configures the Newton iteration budget (DD-044, #111) — see the
+    /// Configures the Newton iteration budget (DD-044, [#111](https://github.com/biface/oxiflow/issues/111)) — see the
     /// field's own docs for why the default (`1`) reproduces the
     /// pre-DD-044 behaviour exactly on affine problems.
     pub fn with_max_newton_iterations(mut self, max_newton_iterations: usize) -> Self {

--- a/src/solver/methods/bdf2.rs
+++ b/src/solver/methods/bdf2.rs
@@ -15,10 +15,10 @@
 //! rather than [`super::implicit`]: unlike `theta_method_step_newton`,
 //! which serves two solvers (Backward Euler, Crank-Nicolson), this
 //! formula has exactly one consumer. It still reuses
-//! [`super::implicit::finite_difference_jacobian`],
-//! [`super::evaluate_derivative`], and the shared [`super::newton`] loop
-//! (DD-044, #112) — the genuinely shared pieces. Unlike
-//! [`super::implicit::theta_method_step`] (kept as a separate,
+//! `super::implicit::finite_difference_jacobian`,
+//! `super::evaluate_derivative`, and the shared [`super::newton`] loop
+//! (DD-044, [#112](https://github.com/biface/oxiflow/issues/112)) — the genuinely shared pieces. Unlike
+//! `super::implicit::theta_method_step` (kept as a separate,
 //! non-configurable wrapper for BE/CN because *production* code — this
 //! module's own bootstrap step, below — calls it directly), BDF2 has no
 //! such production caller for the unconfigured form: `bdf2_step_newton`
@@ -31,7 +31,7 @@
 //!
 //! BDF2 needs `u^{n-1}`, which doesn't exist at the very first step. When
 //! `history` is empty, [`BDF2Solver::step`] falls back to a single
-//! Backward Euler step (θ=1, via [`super::implicit::theta_method_step`])
+//! Backward Euler step (θ=1, via `super::implicit::theta_method_step`)
 //! to produce `u^1` from `u^0` — the standard bootstrap for 2-step methods.
 //! From the second step onward, the real BDF2 update runs.
 //!
@@ -72,7 +72,7 @@ use crate::solver::{SimulationResult, Solver, SolverConfiguration};
 /// scope at J4a.
 pub struct BDF2Solver {
     linear_solver: Box<dyn LinearSolver>,
-    /// Newton convergence criterion (DD-044, #112) — default
+    /// Newton convergence criterion (DD-044, [#112](https://github.com/biface/oxiflow/issues/112)) — default
     /// [`stiff_jacobian_convergence`](super::implicit::stiff_jacobian_convergence)
     /// (deliberately looser than [`NewtonConvergence::default`] — see
     /// that function's docs for why zero-config construction needs it).
@@ -81,10 +81,10 @@ pub struct BDF2Solver {
     /// [`theta_method_step`](super::implicit::theta_method_step)
     /// unconditionally, per [module docs](self).
     newton_convergence: NewtonConvergence,
-    /// Jacobian refresh strategy (DD-044, #112) — default
+    /// Jacobian refresh strategy (DD-044, [#112](https://github.com/biface/oxiflow/issues/112)) — default
     /// [`JacobianStrategy::default`] (`ModifiedFrozen`).
     jacobian_strategy: JacobianStrategy,
-    /// Newton iteration budget (DD-044, #112). Default `1`: exactly the
+    /// Newton iteration budget (DD-044, [#112](https://github.com/biface/oxiflow/issues/112)). Default `1`: exactly the
     /// pre-DD-044 single frozen-Jacobian correction.
     max_newton_iterations: usize,
 }
@@ -112,7 +112,7 @@ impl BDF2Solver {
         self
     }
 
-    /// Configures the Newton convergence criterion (DD-044, #112) — only
+    /// Configures the Newton convergence criterion (DD-044, [#112](https://github.com/biface/oxiflow/issues/112)) — only
     /// affects the real BDF2 update, not the startup/bootstrap step (see
     /// [module docs](self)).
     pub fn with_newton_convergence(mut self, newton_convergence: NewtonConvergence) -> Self {
@@ -120,13 +120,13 @@ impl BDF2Solver {
         self
     }
 
-    /// Configures the Jacobian refresh strategy (DD-044, #112).
+    /// Configures the Jacobian refresh strategy (DD-044, [#112](https://github.com/biface/oxiflow/issues/112)).
     pub fn with_jacobian_strategy(mut self, jacobian_strategy: JacobianStrategy) -> Self {
         self.jacobian_strategy = jacobian_strategy;
         self
     }
 
-    /// Configures the Newton iteration budget (DD-044, #112) — see
+    /// Configures the Newton iteration budget (DD-044, [#112](https://github.com/biface/oxiflow/issues/112)) — see
     /// [`BackwardEulerSolver::with_max_newton_iterations`](super::backward_euler::BackwardEulerSolver::with_max_newton_iterations).
     pub fn with_max_newton_iterations(mut self, max_newton_iterations: usize) -> Self {
         self.max_newton_iterations = max_newton_iterations;
@@ -194,7 +194,7 @@ impl SteppableSolver for BDF2Solver {
 /// Same contract as the pre-DD-044 single-correction BDF2 step, routed
 /// through the generic iterated Newton loop ([`newton::solve`]) with
 /// caller-supplied convergence/Jacobian-strategy/iteration-budget
-/// configuration (DD-044, #112) — [`BDF2Solver`] calls this directly,
+/// configuration (DD-044, [#112](https://github.com/biface/oxiflow/issues/112)) — [`BDF2Solver`] calls this directly,
 /// passing its own configured fields. Passing `stiff_jacobian_convergence()`,
 /// [`JacobianStrategy::default`], and `max_iterations = 1` reproduces the
 /// pre-DD-044 behaviour exactly, matching
@@ -211,7 +211,7 @@ impl SteppableSolver for BDF2Solver {
 /// `f(u^n)` is evaluated once, at time `t`; every subsequent candidate
 /// `f`/Jacobian evaluation inside the Newton loop is at time `t + dt`.
 #[allow(clippy::too_many_arguments)]
-fn bdf2_step_newton(
+pub(crate) fn bdf2_step_newton(
     domain: &Domain,
     chain: &[&dyn ContextCalculator],
     state: &mut ContextValue,

--- a/src/solver/methods/crank_nicolson.rs
+++ b/src/solver/methods/crank_nicolson.rs
@@ -7,7 +7,7 @@
 //! $$u^{n+1} = u^n + \frac{\Delta t}{2}\left[f(u^n, t^n) + f(u^{n+1}, t^{n+1})\right]$$
 //!
 //! A thin wrapper around the shared generalised theta method
-//! ([`super::implicit::theta_method_step_newton`], θ=0.5, DD-044, #111)
+//! (`theta_method_step_newton`, θ=0.5, DD-044, [#111](https://github.com/biface/oxiflow/issues/111))
 //! — see that module's docs for the frozen-Jacobian default and the
 //! iterated Newton path configurable via [`CrankNicolsonSolver`]'s
 //! builders. Identical structure to
@@ -44,16 +44,16 @@ use crate::solver::{SimulationResult, Solver, SolverConfiguration};
 /// Crank-Nicolson solver — semi-implicit, 2nd order.
 pub struct CrankNicolsonSolver {
     linear_solver: Box<dyn LinearSolver>,
-    /// Newton convergence criterion (DD-044, #111) — default
+    /// Newton convergence criterion (DD-044, [#111](https://github.com/biface/oxiflow/issues/111)) — default
     /// [`stiff_jacobian_convergence`](super::implicit::stiff_jacobian_convergence)
     /// (deliberately looser than
     /// [`NewtonConvergence::default`] — see
     /// [`BackwardEulerSolver`](super::backward_euler::BackwardEulerSolver)'s
     /// field docs for the full rationale, identical here).
     newton_convergence: NewtonConvergence,
-    /// Jacobian refresh strategy (DD-044, #111).
+    /// Jacobian refresh strategy (DD-044, [#111](https://github.com/biface/oxiflow/issues/111)).
     jacobian_strategy: JacobianStrategy,
-    /// Newton iteration budget (DD-044, #111). Default `1` — the
+    /// Newton iteration budget (DD-044, [#111](https://github.com/biface/oxiflow/issues/111)). Default `1` — the
     /// pre-DD-044 single frozen-Jacobian correction.
     max_newton_iterations: usize,
     /// Sparse backend (DD-043) — see
@@ -96,19 +96,19 @@ impl CrankNicolsonSolver {
         self
     }
 
-    /// Configures the Newton convergence criterion (DD-044, #111).
+    /// Configures the Newton convergence criterion (DD-044, [#111](https://github.com/biface/oxiflow/issues/111)).
     pub fn with_newton_convergence(mut self, newton_convergence: NewtonConvergence) -> Self {
         self.newton_convergence = newton_convergence;
         self
     }
 
-    /// Configures the Jacobian refresh strategy (DD-044, #111).
+    /// Configures the Jacobian refresh strategy (DD-044, [#111](https://github.com/biface/oxiflow/issues/111)).
     pub fn with_jacobian_strategy(mut self, jacobian_strategy: JacobianStrategy) -> Self {
         self.jacobian_strategy = jacobian_strategy;
         self
     }
 
-    /// Configures the Newton iteration budget (DD-044, #111) — see
+    /// Configures the Newton iteration budget (DD-044, [#111](https://github.com/biface/oxiflow/issues/111)) — see
     /// [`BackwardEulerSolver::with_max_newton_iterations`](super::backward_euler::BackwardEulerSolver::with_max_newton_iterations).
     pub fn with_max_newton_iterations(mut self, max_newton_iterations: usize) -> Self {
         self.max_newton_iterations = max_newton_iterations;

--- a/src/solver/methods/dopri45.rs
+++ b/src/solver/methods/dopri45.rs
@@ -23,7 +23,7 @@
 //!
 //! ## Step-size control (DD-036)
 //!
-//! Delegates entirely to [`StepSizeController`](super::step_control::StepSizeController)
+//! Delegates entirely to [`StepSizeController`]
 //! for the accept/reject decision and the next `dt` — this file only
 //! supplies the error norm input (the RK4/5 difference) and the rejection
 //! retry loop. See [`super::step_control`] for the controller itself.

--- a/src/solver/methods/euler.rs
+++ b/src/solver/methods/euler.rs
@@ -10,7 +10,7 @@
 //!
 //! where $f = \text{compute\_physics}(u, \text{ctx})$ is the time derivative
 //! returned by the physical model, evaluated on `u` *after* boundary
-//! conditions have been enforced (see [`super::evaluate_derivative`]).
+//! conditions have been enforced (see `super::evaluate_derivative`).
 //!
 //! ## Scope at J4a
 //!

--- a/src/solver/methods/implicit.rs
+++ b/src/solver/methods/implicit.rs
@@ -1,12 +1,13 @@
 //! # Module `solver::methods::implicit`
 //!
-//! Shared machinery for implicit (theta-method) integrators — DD-033.
+//! Shared machinery for implicit (theta-method) integrators — DD-033
+//! ([#86](https://github.com/biface/oxiflow/issues/86)).
 //!
 //! [`BackwardEulerSolver`](super::backward_euler::BackwardEulerSolver) (θ=1)
 //! and [`CrankNicolsonSolver`](super::crank_nicolson::CrankNicolsonSolver)
-//! (θ=0.5) are thin wrappers around [`theta_method_step_newton`] (DD-044,
-//! #111), which itself relies on [`finite_difference_jacobian`] and the
-//! shared [`super::newton`] loop. [`theta_method_step`] keeps the
+//! (θ=0.5) are thin wrappers around `theta_method_step_newton` (DD-044,
+//! [#111](https://github.com/biface/oxiflow/issues/111)), which itself relies on `finite_difference_jacobian` and the
+//! shared [`super::newton`] loop. `theta_method_step` keeps the
 //! original, non-configurable entry point for direct callers — see below.
 //!
 //! ## Why a single shared function for two methods
@@ -21,44 +22,45 @@
 //! depend on θ at all. Only the system matrix does
 //! ($I - \theta \Delta t J_f$). One function, one parameter.
 //!
-//! ## v1 scope — frozen Jacobian, single correction (DD-033) by default
+//! ## v1 scope — frozen Jacobian, single correction (DD-033,
+//! [#86](https://github.com/biface/oxiflow/issues/86)) by default
 //!
-//! [`theta_method_step`] performs exactly **one** Newton-style correction,
+//! `theta_method_step` performs exactly **one** Newton-style correction,
 //! with the Jacobian frozen at $u^n$ — this is exact when `compute_physics`
 //! is affine in `u` and a first-order approximation otherwise, and stays
-//! the behaviour of [`theta_method_step`] itself (used directly by
+//! the behaviour of `theta_method_step` itself (used directly by
 //! callers that don't need more) and of
 //! [`BackwardEulerSolver`](super::backward_euler::BackwardEulerSolver)/
 //! [`CrankNicolsonSolver`](super::crank_nicolson::CrankNicolsonSolver)
 //! when left unconfigured.
 //!
-//! [`theta_method_step_newton`] (DD-044, #111) is the genuinely iterated
+//! `theta_method_step_newton` (DD-044, [#111](https://github.com/biface/oxiflow/issues/111)) is the genuinely iterated
 //! alternative DD-033 anticipated: it routes through the shared
 //! [`super::newton`] loop with caller-supplied convergence/Jacobian-
 //! strategy/iteration-budget configuration.
 //! `BackwardEulerSolver`/`CrankNicolsonSolver` call it directly (with
 //! `with_newton_convergence`/`with_jacobian_strategy`/
-//! `with_max_newton_iterations` builders); [`theta_method_step`] itself
+//! `with_max_newton_iterations` builders); `theta_method_step` itself
 //! stays at its original signature by delegating to it with
-//! `k_max = 1`/[`JacobianStrategy::ModifiedFrozen`](super::newton::JacobianStrategy::ModifiedFrozen)
+//! `k_max = 1`/[`JacobianStrategy::ModifiedFrozen`]
 //! baked in, reproducing its historical output exactly (see
 //! [`super::newton`]'s own docs for why no special-casing is needed for
 //! this to hold on affine problems).
 //!
 //! ## Known gap — sparse path not yet Newton-aware
 //!
-//! [`theta_method_step_adaptive`] (the sparse/banded dispatch, DD-043)
+//! `theta_method_step_adaptive` (the sparse/banded dispatch, DD-043)
 //! still performs a single frozen-Jacobian correction unconditionally —
 //! it is not wired through [`super::newton`] at this increment. Composing
-//! the two was verified, not implemented, per #111's stated scope:
+//! the two was verified, not implemented, per [#111](https://github.com/biface/oxiflow/issues/111)'s stated scope:
 //! configuring both a sparse backend *and* a non-default Newton budget on
 //! the same solver silently keeps the sparse path single-shot. Tracked as
 //! a follow-up, mirroring the existing BDF2/sparse gap.
 //!
 //! ## Boundary conditions × the perturbed Jacobian
 //!
-//! [`finite_difference_jacobian`] perturbs each component of the state and
-//! re-evaluates [`evaluate_derivative`], which re-applies boundary
+//! `finite_difference_jacobian` perturbs each component of the state and
+//! re-evaluates `evaluate_derivative`, which re-applies boundary
 //! conditions on every call. A Dirichlet-constrained node will have its
 //! perturbation overwritten before `compute_physics` sees it — physically
 //! correct (a BC-constrained node isn't a free unknown): the constrained
@@ -67,7 +69,7 @@
 //! unconstrained neighbours. Verified by
 //! `tests::dirichlet_constrained_column_is_exactly_zero_row_keeps_real_coupling`
 //! (#113) — previously documented as a known untested limitation (DD-033,
-//! v0.4.0).
+//! [#86](https://github.com/biface/oxiflow/issues/86), v0.4.0).
 
 use nalgebra::{DMatrix, DVector};
 

--- a/src/solver/methods/mod.rs
+++ b/src/solver/methods/mod.rs
@@ -23,11 +23,11 @@
 //! Every integrator — single-stage (Euler) or multi-stage (RK4 and beyond) —
 //! follows the same per-evaluation order documented in
 //! [`crate::solver`]: calculators, then boundary conditions, then
-//! `compute_physics`. [`evaluate_derivative`] implements this contract once
+//! `compute_physics`. `evaluate_derivative` implements this contract once
 //! so each solver doesn't reimplement it per stage.
 //!
 //! Implicit methods ([`backward_euler`], [`crank_nicolson`], [`bdf2`]) build
-//! on the same [`evaluate_derivative`] for their explicit-derivative
+//! on the same `evaluate_derivative` for their explicit-derivative
 //! evaluation, plus the shared machinery in [`implicit`] for the implicit
 //! part. [`newton`] provides the iterated Newton alternative DD-033
 //! anticipated (DD-044, v0.7.0), wired into [`backward_euler`]/
@@ -210,7 +210,7 @@ pub trait SteppableSolver: Solver {
     /// with `history_depth() == 0` ignore this parameter entirely.
     ///
     /// `state` may be mutated in-place by boundary condition application
-    /// (see [`evaluate_derivative`]); the returned value is the state at
+    /// (see `evaluate_derivative`); the returned value is the state at
     /// `t + dt`.
     fn step(
         &self,

--- a/src/solver/methods/newton.rs
+++ b/src/solver/methods/newton.rs
@@ -1,11 +1,12 @@
 //! # Module `solver::methods::newton`
 //!
 //! Iterated Newton solver — shared, integrator-agnostic core (DD-044,
-//! issue #109, activating DD-033's Option A).
+//! issue [#109](https://github.com/biface/oxiflow/issues/109), activating
+//! DD-033's ([#86](https://github.com/biface/oxiflow/issues/86)) Option A).
 //!
 //! ## Why this exists
 //!
-//! [`super::implicit::theta_method_step`] and [`super::bdf2::bdf2_step`]
+//! `super::implicit::theta_method_step` and `bdf2_step`
 //! (through v0.6.0) each performed exactly **one** Newton-style
 //! correction with a frozen Jacobian — exact when the underlying
 //! `compute_physics` is affine in `u`, a first-order approximation
@@ -30,15 +31,15 @@
 //!
 //! `u^{*}` folds in every term that doesn't depend on the unknown `u` —
 //! callers compute it once, outside the loop, from already-known past
-//! states. [`residual`] and [`linear_correction`] are the two building
-//! blocks operating on this shape; [`solve`] is the generic loop wiring
+//! states. `residual` and `linear_correction` are the two building
+//! blocks operating on this shape; `solve` is the generic loop wiring
 //! them together with a [`NewtonConvergence`] criterion and a
 //! [`JacobianStrategy`].
 //!
 //! ## Dense/sparse agnosticism
 //!
 //! This module knows nothing about `Domain`, `ContextCalculator`, or
-//! `faer` — [`solve`] is parameterised over caller-supplied closures for
+//! `faer` — `solve` is parameterised over caller-supplied closures for
 //! evaluating $f(u)$ and its Jacobian, and over `&dyn LinearSolver` for
 //! the correction step. The existing sparse/banded dispatch
 //! (DD-043, `theta_method_step_adaptive`) is therefore untouched by this
@@ -47,14 +48,14 @@
 //!
 //! ## Wiring status
 //!
-//! [`solve`] is called from
-//! [`super::implicit::theta_method_step_newton`] (DD-044, #111) and
-//! [`super::bdf2::bdf2_step_newton`] (DD-044, #112) — used respectively by
+//! `solve` is called from
+//! `super::implicit::theta_method_step_newton` (DD-044, [#111](https://github.com/biface/oxiflow/issues/111)) and
+//! `super::bdf2::bdf2_step_newton` (DD-044, [#112](https://github.com/biface/oxiflow/issues/112)) — used respectively by
 //! [`BackwardEulerSolver`](super::backward_euler::BackwardEulerSolver)/
 //! [`CrankNicolsonSolver`](super::crank_nicolson::CrankNicolsonSolver) and
 //! [`BDF2Solver`](super::bdf2::BDF2Solver). [`super::bdf2`]'s
 //! startup/bootstrap step is the one exception, unconditionally using
-//! [`super::implicit::theta_method_step`]'s non-configurable path — see
+//! `super::implicit::theta_method_step`'s non-configurable path — see
 //! that module's docs.
 
 use nalgebra::{DMatrix, DVector};
@@ -64,7 +65,7 @@ use crate::solver::linear::LinearSolver;
 
 // ── Configuration ────────────────────────────────────────────────────────────
 
-/// Convergence criterion for the iterated Newton loop ([`solve`]).
+/// Convergence criterion for the iterated Newton loop (`solve`).
 ///
 /// Every variant carries the same `tol_abs`/`tol_rel` pair: convergence
 /// is tested against `tol_abs + tol_rel * ||u||`, evaluated on the
@@ -77,7 +78,7 @@ use crate::solver::linear::LinearSolver;
 /// solver builders once this lands (#111/#112).
 ///
 /// Note: this default is *not* what
-/// [`theta_method_step`](super::implicit::theta_method_step) or the
+/// `theta_method_step` or the
 /// implicit solvers' own zero-config constructors use internally — those
 /// need a looser, explicitly named tolerance to guarantee the pre-DD-044
 /// single-correction contract on very stiff affine problems (see
@@ -124,7 +125,7 @@ impl NewtonConvergence {
     }
 }
 
-/// Jacobian refresh strategy for the iterated Newton loop ([`solve`]).
+/// Jacobian refresh strategy for the iterated Newton loop (`solve`).
 ///
 /// Default: [`ModifiedFrozen`](Self::ModifiedFrozen) — matches the
 /// pre-DD-044 behaviour (Jacobian evaluated once, at the initial guess,
@@ -140,7 +141,7 @@ pub enum JacobianStrategy {
     ModifiedFrozen,
     /// Re-evaluate the Jacobian at every iterate (full Newton) — most
     /// robust on strongly nonlinear problems, at the cost of one
-    /// [`finite_difference_jacobian`](super::implicit::finite_difference_jacobian)
+    /// `finite_difference_jacobian`
     /// (or its banded equivalent) per iteration.
     FullNewton,
     /// Reuse the frozen Jacobian while convergence is proceeding

--- a/src/solver/methods/rk4.rs
+++ b/src/solver/methods/rk4.rs
@@ -21,13 +21,13 @@
 //!
 //! where $f = \text{compute\_physics}(u, \text{ctx})$, evaluated on a state
 //! that has had boundary conditions enforced for *that* stage — see
-//! [`super::evaluate_derivative`].
+//! `super::evaluate_derivative`.
 //!
 //! ## Boundary conditions across stages
 //!
 //! Each of the four stages is a separate derivative evaluation, so each one
 //! gets its own boundary-condition application via
-//! [`super::apply_boundary_conditions`] — on `u` itself for stage 1, and on
+//! `super::apply_boundary_conditions` — on `u` itself for stage 1, and on
 //! the transient intermediate states (`u + scale * k_i`) for stages 2-4. A
 //! Dirichlet value enforced only once per outer step would otherwise drift
 //! across the intermediate evaluations.

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -24,6 +24,8 @@
 
 pub mod chain;
 pub mod config;
+#[cfg(feature = "gpu")]
+pub mod gpu;
 pub mod linear;
 pub mod methods;
 pub mod orchestrator;

--- a/src/solver/spec.rs
+++ b/src/solver/spec.rs
@@ -32,7 +32,7 @@
 //! axis (`ModelConfig`/`MeshConfig`/`BoundaryConditionConfig`) are tracked
 //! as follow-up, not blocking this issue's closure (per #104's own stated
 //! scope). `newton_convergence`/`jacobian_strategy`/`max_iterations`
-//! (DD-044, #114/#115/#116) extend all three variants — the Newton
+//! (DD-044, [#114](https://github.com/biface/oxiflow/issues/114)/[#115](https://github.com/biface/oxiflow/issues/115)/[#116](https://github.com/biface/oxiflow/issues/116)) extend all three variants — the Newton
 //! configuration is orthogonal to which integrator carries it.
 //!
 //! The sparse backend itself is always [`FaerSparseSolver`] — a fixed,
@@ -72,18 +72,18 @@ pub enum IntegratorSpec {
         /// `None` keeps the dense path regardless of `sparse_threshold`.
         #[cfg_attr(feature = "serde", serde(default))]
         jacobian_bandwidth: Option<usize>,
-        /// Newton convergence criterion (DD-044, #114) — see
+        /// Newton convergence criterion (DD-044, [#114](https://github.com/biface/oxiflow/issues/114)) — see
         /// [`BackwardEulerSolver::with_newton_convergence`]. Defaults to
-        /// [`stiff_jacobian_convergence`], not [`NewtonConvergence::default`]
+        /// `stiff_jacobian_convergence`, not [`NewtonConvergence::default`]
         /// — matching `BackwardEulerSolver`'s own zero-config value (see
         /// that function's docs for why they differ).
         #[cfg_attr(feature = "serde", serde(default = "default_newton_convergence"))]
         newton_convergence: NewtonConvergence,
-        /// Jacobian refresh strategy (DD-044, #114) — see
+        /// Jacobian refresh strategy (DD-044, [#114](https://github.com/biface/oxiflow/issues/114)) — see
         /// [`BackwardEulerSolver::with_jacobian_strategy`].
         #[cfg_attr(feature = "serde", serde(default))]
         jacobian_strategy: JacobianStrategy,
-        /// Newton iteration budget (DD-044, #114) — see
+        /// Newton iteration budget (DD-044, [#114](https://github.com/biface/oxiflow/issues/114)) — see
         /// [`BackwardEulerSolver::with_max_newton_iterations`]. Defaults
         /// to `1`, matching `BackwardEulerSolver`'s own zero-config value
         /// (the pre-DD-044 single-correction contract).
@@ -92,7 +92,7 @@ pub enum IntegratorSpec {
     },
     /// Crank-Nicolson (semi-implicit, 2nd order), symmetric to
     /// [`BackwardEuler`](Self::BackwardEuler) in every field — sparse
-    /// dispatch (DD-043) and Newton configuration (DD-044, #115) both
+    /// dispatch (DD-043) and Newton configuration (DD-044, [#115](https://github.com/biface/oxiflow/issues/115)) both
     /// apply identically. `theta = 0.5` is not exposed as a field —
     /// implicit to the variant, consistent with `BackwardEuler`'s
     /// `theta = 1.0` never being exposed either.
@@ -114,10 +114,10 @@ pub enum IntegratorSpec {
         max_iterations: usize,
     },
     /// BDF2 (implicit multi-step, 2nd order) — Newton configuration only
-    /// (DD-044, #116), deliberately **no** `sparse_threshold`/
+    /// (DD-044, [#116](https://github.com/biface/oxiflow/issues/116)), deliberately **no** `sparse_threshold`/
     /// `jacobian_bandwidth`: `BDF2Solver` has no sparse builders to map
     /// (a DD-043 gap, not a DD-044 concern — see
-    /// [`BDF2Solver`](super::methods::bdf2::BDF2Solver)'s own docs).
+    /// [`BDF2Solver`]'s own docs).
     /// Adding sparse-shaped fields with no backing implementation would
     /// mislead a config author into thinking they take effect.
     BDF2 {


### PR DESCRIPTION
Merges `staging` into `main` for the v0.8.0 tag.

DD-045 (GPU architecture) implemented; MSRV raised to 1.84; rustdoc fully clean (0 warnings, `--all-features`). See CHANGELOG.md [0.8.0] for the complete list.

No breaking API changes — `gpu` is additive and opt-in, `#[non_exhaustive]` absorbs the MSRV-driven dependency changes without SemVer impact (DD-016).